### PR TITLE
don't generate response bodies for errors

### DIFF
--- a/generator/gen.go
+++ b/generator/gen.go
@@ -264,7 +264,9 @@ func addResponseBodies(file *jen.File, endpoint model.Endpoint) {
 	}
 	sortedCodes := make([]int, 0, len(endpoint.Responses))
 	for code := range endpoint.Responses {
-		sortedCodes = append(sortedCodes, code)
+		if code < 300 {
+			sortedCodes = append(sortedCodes, code)
+		}
 	}
 	sort.Ints(sortedCodes)
 	for _, respCode := range sortedCodes {

--- a/octo-go.go
+++ b/octo-go.go
@@ -141,7 +141,17 @@ func Int64(i int64) *int64 {
 	return &i
 }
 
-//Int returns a pointer to i
-func Int(i int) *int {
-	return &i
+//ErrorResponse all 40x response bodies should unmarshal to this
+type ErrorResponse struct {
+	DocumentationUrl string               `json:"documentation_url,omitempty"`
+	Message          string               `json:"message,omitempty"`
+	Errors           []ErrorResponseError `json:"errors,omitempty"`
+}
+
+//ErrorResponseError an Error field in ErrorResponse
+type ErrorResponseError struct {
+	Code     string `json:"code,omitempty"`
+	Field    string `json:"field,omitempty"`
+	Message  string `json:"message,omitempty"`
+	Resource string `json:"resource,omitempty"`
 }

--- a/zz_orgs_gen.go
+++ b/zz_orgs_gen.go
@@ -340,16 +340,6 @@ func (r OrgsConvertMemberToOutsideCollaboratorReq) HTTPRequest(ctx context.Conte
 }
 
 /*
-OrgsConvertMemberToOutsideCollaboratorResponseBody403 is a response body for orgs/convert-member-to-outside-collaborator
-
-API documentation: https://developer.github.com/v3/orgs/outside_collaborators/#convert-member-to-outside-collaborator
-*/
-type OrgsConvertMemberToOutsideCollaboratorResponseBody403 struct {
-	DocumentationUrl string `json:"documentation_url,omitempty"`
-	Message          string `json:"message,omitempty"`
-}
-
-/*
 OrgsCreateHookReq builds requests for "orgs/create-hook"
 
 Create a hook.
@@ -2170,16 +2160,6 @@ func (r OrgsRemoveOutsideCollaboratorReq) header() http.Header {
 // HTTPRequest creates an http request
 func (r OrgsRemoveOutsideCollaboratorReq) HTTPRequest(ctx context.Context, opt ...RequestOption) (*http.Request, error) {
 	return httpRequest(ctx, r.urlPath(), r.method(), r.urlQuery(), r.header(), nil, opt)
-}
-
-/*
-OrgsRemoveOutsideCollaboratorResponseBody422 is a response body for orgs/remove-outside-collaborator
-
-API documentation: https://developer.github.com/v3/orgs/outside_collaborators/#remove-outside-collaborator
-*/
-type OrgsRemoveOutsideCollaboratorResponseBody422 struct {
-	DocumentationUrl string `json:"documentation_url,omitempty"`
-	Message          string `json:"message,omitempty"`
 }
 
 /*

--- a/zz_pulls_gen.go
+++ b/zz_pulls_gen.go
@@ -4025,26 +4025,6 @@ type PullsMergeResponseBody200 struct {
 }
 
 /*
-PullsMergeResponseBody405 is a response body for pulls/merge
-
-API documentation: https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button
-*/
-type PullsMergeResponseBody405 struct {
-	DocumentationUrl string `json:"documentation_url,omitempty"`
-	Message          string `json:"message,omitempty"`
-}
-
-/*
-PullsMergeResponseBody409 is a response body for pulls/merge
-
-API documentation: https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button
-*/
-type PullsMergeResponseBody409 struct {
-	DocumentationUrl string `json:"documentation_url,omitempty"`
-	Message          string `json:"message,omitempty"`
-}
-
-/*
 PullsSubmitReviewReq builds requests for "pulls/submit-review"
 
 Submit a pull request review.

--- a/zz_repos_gen.go
+++ b/zz_repos_gen.go
@@ -1346,15 +1346,6 @@ type ReposCreateDeploymentResponseBody202 struct {
 }
 
 /*
-ReposCreateDeploymentResponseBody409 is a response body for repos/create-deployment
-
-API documentation: https://developer.github.com/v3/repos/deployments/#create-a-deployment
-*/
-type ReposCreateDeploymentResponseBody409 struct {
-	Message string `json:"message,omitempty"`
-}
-
-/*
 ReposCreateDeploymentStatusReq builds requests for "repos/create-deployment-status"
 
 Create a deployment status.
@@ -3240,16 +3231,6 @@ func (r ReposDeleteReq) header() http.Header {
 // HTTPRequest creates an http request
 func (r ReposDeleteReq) HTTPRequest(ctx context.Context, opt ...RequestOption) (*http.Request, error) {
 	return httpRequest(ctx, r.urlPath(), r.method(), r.urlQuery(), r.header(), nil, opt)
-}
-
-/*
-ReposDeleteResponseBody403 is a response body for repos/delete
-
-API documentation: https://developer.github.com/v3/repos/#delete-a-repository
-*/
-type ReposDeleteResponseBody403 struct {
-	DocumentationUrl string `json:"documentation_url,omitempty"`
-	Message          string `json:"message,omitempty"`
 }
 
 /*
@@ -10837,24 +10818,6 @@ type ReposMergeResponseBody201 struct {
 	} `json:"parents,omitempty"`
 	Sha string `json:"sha,omitempty"`
 	Url string `json:"url,omitempty"`
-}
-
-/*
-ReposMergeResponseBody404 is a response body for repos/merge
-
-API documentation: https://developer.github.com/v3/repos/merging/#perform-a-merge
-*/
-type ReposMergeResponseBody404 struct {
-	Message string `json:"message,omitempty"`
-}
-
-/*
-ReposMergeResponseBody409 is a response body for repos/merge
-
-API documentation: https://developer.github.com/v3/repos/merging/#perform-a-merge
-*/
-type ReposMergeResponseBody409 struct {
-	Message string `json:"message,omitempty"`
 }
 
 /*

--- a/zz_teams_gen.go
+++ b/zz_teams_gen.go
@@ -50,20 +50,6 @@ func (r TeamsAddMemberLegacyReq) HTTPRequest(ctx context.Context, opt ...Request
 }
 
 /*
-TeamsAddMemberLegacyResponseBody422 is a response body for teams/add-member-legacy
-
-API documentation: https://developer.github.com/v3/teams/members/#add-team-member-legacy
-*/
-type TeamsAddMemberLegacyResponseBody422 struct {
-	Errors []struct {
-		Code     string `json:"code,omitempty"`
-		Field    string `json:"field,omitempty"`
-		Resource string `json:"resource,omitempty"`
-	} `json:"errors,omitempty"`
-	Message string `json:"message,omitempty"`
-}
-
-/*
 TeamsAddOrUpdateMembershipInOrgReq builds requests for "teams/add-or-update-membership-in-org"
 
 Add or update team membership.
@@ -132,20 +118,6 @@ type TeamsAddOrUpdateMembershipInOrgResponseBody200 struct {
 }
 
 /*
-TeamsAddOrUpdateMembershipInOrgResponseBody422 is a response body for teams/add-or-update-membership-in-org
-
-API documentation: https://developer.github.com/v3/teams/members/#add-or-update-team-membership
-*/
-type TeamsAddOrUpdateMembershipInOrgResponseBody422 struct {
-	Errors []struct {
-		Code     string `json:"code,omitempty"`
-		Field    string `json:"field,omitempty"`
-		Resource string `json:"resource,omitempty"`
-	} `json:"errors,omitempty"`
-	Message string `json:"message,omitempty"`
-}
-
-/*
 TeamsAddOrUpdateMembershipLegacyReq builds requests for "teams/add-or-update-membership-legacy"
 
 Add or update team membership (Legacy).
@@ -210,20 +182,6 @@ type TeamsAddOrUpdateMembershipLegacyResponseBody200 struct {
 	Role  string `json:"role,omitempty"`
 	State string `json:"state,omitempty"`
 	Url   string `json:"url,omitempty"`
-}
-
-/*
-TeamsAddOrUpdateMembershipLegacyResponseBody422 is a response body for teams/add-or-update-membership-legacy
-
-API documentation: https://developer.github.com/v3/teams/members/#add-or-update-team-membership-legacy
-*/
-type TeamsAddOrUpdateMembershipLegacyResponseBody422 struct {
-	Errors []struct {
-		Code     string `json:"code,omitempty"`
-		Field    string `json:"field,omitempty"`
-		Resource string `json:"resource,omitempty"`
-	} `json:"errors,omitempty"`
-	Message string `json:"message,omitempty"`
 }
 
 /*
@@ -297,16 +255,6 @@ type TeamsAddOrUpdateProjectInOrgReqBody struct {
 }
 
 /*
-TeamsAddOrUpdateProjectInOrgResponseBody403 is a response body for teams/add-or-update-project-in-org
-
-API documentation: https://developer.github.com/v3/teams/#add-or-update-team-project
-*/
-type TeamsAddOrUpdateProjectInOrgResponseBody403 struct {
-	DocumentationUrl string `json:"documentation_url,omitempty"`
-	Message          string `json:"message,omitempty"`
-}
-
-/*
 TeamsAddOrUpdateProjectLegacyReq builds requests for "teams/add-or-update-project-legacy"
 
 Add or update team project (Legacy).
@@ -373,16 +321,6 @@ type TeamsAddOrUpdateProjectLegacyReqBody struct {
 	   verbs](https://developer.github.com/v3/#http-verbs)."
 	*/
 	Permission *string `json:"permission,omitempty"`
-}
-
-/*
-TeamsAddOrUpdateProjectLegacyResponseBody403 is a response body for teams/add-or-update-project-legacy
-
-API documentation: https://developer.github.com/v3/teams/#add-or-update-team-project-legacy
-*/
-type TeamsAddOrUpdateProjectLegacyResponseBody403 struct {
-	DocumentationUrl string `json:"documentation_url,omitempty"`
-	Message          string `json:"message,omitempty"`
 }
 
 /*


### PR DESCRIPTION
I don't think separate messages for errors are going to be useful.  This adds `ErrorResponse` which should cover all errors.