### PR TITLE
remove err from NewClient's signature

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -58,20 +58,16 @@ type appInstallationAuthProvider struct {
 	tokenClient    *Client
 }
 
-func (a *appInstallationAuthProvider) getTokenClient() (*Client, error) {
+func (a *appInstallationAuthProvider) getTokenClient() *Client {
 	if a.tokenClient != nil {
-		return a.tokenClient, nil
+		return a.tokenClient
 	}
 	opts := append(a.requestOptions, RequestAuthProvider(&appAuthProvider{
 		appID:      a.appID,
 		privateKey: a.privateKey,
 	}))
-	var err error
-	a.tokenClient, err = NewClient(append(opts, RequestEnableRequirePreviews())...)
-	if err != nil {
-		return nil, err
-	}
-	return a.tokenClient, nil
+	a.tokenClient = NewClient(append(opts, RequestEnableRequirePreviews())...)
+	return a.tokenClient
 }
 
 // AuthorizationHeader implements AuthProvider
@@ -81,10 +77,7 @@ func (a *appInstallationAuthProvider) AuthorizationHeader(ctx context.Context) (
 	if time.Now().Before(a.tknExpiry.Add(-1 * time.Minute)) {
 		return a.tkn, nil
 	}
-	tokenClient, err := a.getTokenClient()
-	if err != nil {
-		return "", err
-	}
+	tokenClient := a.getTokenClient()
 	req := &AppsCreateInstallationTokenReq{
 		InstallationId: a.installationID,
 	}

--- a/examples/create_gist/create_gist.go
+++ b/examples/create_gist/create_gist.go
@@ -13,12 +13,9 @@ import (
 func main() {
 	ctx := context.Background()
 
-	client, err := octo.NewClient(
+	client := octo.NewClient(
 		octo.RequestPATAuth(os.Getenv("GITHUB_TOKEN")),
 	)
-	if err != nil {
-		log.Fatal(err)
-	}
 
 	createResp, err := client.GistsCreate(ctx, &octo.GistsCreateReq{
 		RequestBody: octo.GistsCreateReqBody{

--- a/examples/download_archive/download_archive.go
+++ b/examples/download_archive/download_archive.go
@@ -18,12 +18,9 @@ func main() {
 
 	ctx := context.Background()
 
-	client, err := octo.NewClient(
+	client := octo.NewClient(
 		octo.RequestPATAuth(os.Getenv("GITHUB_TOKEN")),
 	)
-	if err != nil {
-		log.Fatal(err)
-	}
 
 	resp, err := client.ReposGetArchiveLink(ctx, &octo.ReposGetArchiveLinkReq{
 		Owner:         "WillAbides",

--- a/examples/paging/paging.go
+++ b/examples/paging/paging.go
@@ -13,12 +13,9 @@ import (
 func main() {
 	ctx := context.Background()
 
-	client, err := octo.NewClient(
+	client := octo.NewClient(
 		octo.RequestPATAuth(os.Getenv("GITHUB_TOKEN")),
 	)
-	if err != nil {
-		log.Fatal(err)
-	}
 
 	req := &octo.IssuesListCommentsReq{
 		Owner:       "golang",

--- a/examples/simple/simple.go
+++ b/examples/simple/simple.go
@@ -12,12 +12,9 @@ import (
 func main() {
 	ctx := context.Background()
 
-	client, err := octo.NewClient(
+	client := octo.NewClient(
 		octo.RequestPATAuth(os.Getenv("GITHUB_TOKEN")),
 	)
-	if err != nil {
-		log.Fatal(err)
-	}
 
 	issue, err := client.IssuesGet(ctx, &octo.IssuesGetReq{
 		Owner:       "golang",

--- a/options.go
+++ b/options.go
@@ -11,13 +11,6 @@ import (
 // RequestOption is an option for building an http request
 type RequestOption func(opts *requestOpts) error
 
-func resetOptions(newOpts requestOpts) RequestOption {
-	return func(opts *requestOpts) error {
-		*opts = newOpts
-		return nil
-	}
-}
-
 // RequestBaseURL set the baseURL to use. Default is https://api.github.com
 func RequestBaseURL(baseURL url.URL) RequestOption {
 	return func(opts *requestOpts) error {

--- a/tests_test.go
+++ b/tests_test.go
@@ -72,9 +72,7 @@ func vcrClient(t *testing.T, cas string, opts ...octo.RequestOption) *octo.Clien
 		require.NoError(t, r.Stop())
 	})
 
-	cl, err := octo.NewClient(append(opts, octo.RequestHTTPClient(&http.Client{
+	return octo.NewClient(append(opts, octo.RequestHTTPClient(&http.Client{
 		Transport: r,
 	}))...)
-	require.NoError(t, err)
-	return cl
 }


### PR DESCRIPTION
There's no need to build the opts when creating the client, and removing that removes the need to return an error.