### PR TITLE
simplify response bodies

### DIFF
--- a/components/schemas_gen.go
+++ b/components/schemas_gen.go
@@ -146,7 +146,7 @@ type AuthenticationToken struct {
 	Permissions AuthenticationTokenPermissions `json:"permissions,omitempty"`
 
 	// The repositories this token has access to
-	Repositories []AuthenticationTokenRepositoriesItem `json:"repositories,omitempty"`
+	Repositories []Repository `json:"repositories,omitempty"`
 
 	// Describe whether all repositories have been selected or there's a selection involved
 	RepositorySelection string `json:"repository_selection,omitempty"`
@@ -157,278 +157,6 @@ type AuthenticationToken struct {
 }
 
 type AuthenticationTokenPermissions interface{}
-
-type AuthenticationTokenRepositoriesItem struct {
-
-	// Whether to allow merge commits for pull requests.
-	AllowMergeCommit bool `json:"allow_merge_commit,omitempty"`
-
-	// Whether to allow rebase merges for pull requests.
-	AllowRebaseMerge bool `json:"allow_rebase_merge,omitempty"`
-
-	// Whether to allow squash merges for pull requests.
-	AllowSquashMerge bool   `json:"allow_squash_merge,omitempty"`
-	ArchiveUrl       string `json:"archive_url"`
-
-	// Whether the repository is archived.
-	Archived         bool   `json:"archived"`
-	AssigneesUrl     string `json:"assignees_url"`
-	BlobsUrl         string `json:"blobs_url"`
-	BranchesUrl      string `json:"branches_url"`
-	CloneUrl         string `json:"clone_url"`
-	CollaboratorsUrl string `json:"collaborators_url"`
-	CommentsUrl      string `json:"comments_url"`
-	CommitsUrl       string `json:"commits_url"`
-	CompareUrl       string `json:"compare_url"`
-	ContentsUrl      string `json:"contents_url"`
-	ContributorsUrl  string `json:"contributors_url"`
-	CreatedAt        string `json:"created_at"`
-
-	// The default branch of the repository.
-	DefaultBranch string `json:"default_branch"`
-
-	// Whether to delete head branches when pull requests are merged
-	DeleteBranchOnMerge bool   `json:"delete_branch_on_merge,omitempty"`
-	DeploymentsUrl      string `json:"deployments_url"`
-	Description         string `json:"description"`
-
-	// Returns whether or not this repository disabled.
-	Disabled      bool   `json:"disabled"`
-	DownloadsUrl  string `json:"downloads_url"`
-	EventsUrl     string `json:"events_url"`
-	Fork          bool   `json:"fork"`
-	Forks         int64  `json:"forks"`
-	ForksCount    int64  `json:"forks_count"`
-	ForksUrl      string `json:"forks_url"`
-	FullName      string `json:"full_name"`
-	GitCommitsUrl string `json:"git_commits_url"`
-	GitRefsUrl    string `json:"git_refs_url"`
-	GitTagsUrl    string `json:"git_tags_url"`
-	GitUrl        string `json:"git_url"`
-
-	// Whether downloads are enabled.
-	HasDownloads bool `json:"has_downloads"`
-
-	// Whether issues are enabled.
-	HasIssues bool `json:"has_issues"`
-	HasPages  bool `json:"has_pages"`
-
-	// Whether projects are enabled.
-	HasProjects bool `json:"has_projects"`
-
-	// Whether the wiki is enabled.
-	HasWiki  bool   `json:"has_wiki"`
-	Homepage string `json:"homepage"`
-	HooksUrl string `json:"hooks_url"`
-	HtmlUrl  string `json:"html_url"`
-
-	// Unique identifier of the repository
-	Id int64 `json:"id"`
-
-	// Whether this repository acts as a template that can be used to generate new repositories.
-	IsTemplate      bool                                        `json:"is_template,omitempty"`
-	IssueCommentUrl string                                      `json:"issue_comment_url"`
-	IssueEventsUrl  string                                      `json:"issue_events_url"`
-	IssuesUrl       string                                      `json:"issues_url"`
-	KeysUrl         string                                      `json:"keys_url"`
-	LabelsUrl       string                                      `json:"labels_url"`
-	Language        string                                      `json:"language"`
-	LanguagesUrl    string                                      `json:"languages_url"`
-	License         *AuthenticationTokenRepositoriesItemLicense `json:"license"`
-	MasterBranch    string                                      `json:"master_branch,omitempty"`
-	MergesUrl       string                                      `json:"merges_url"`
-	MilestonesUrl   string                                      `json:"milestones_url"`
-	MirrorUrl       string                                      `json:"mirror_url"`
-
-	// The name of the repository.
-	Name             string                                         `json:"name"`
-	NetworkCount     int64                                          `json:"network_count,omitempty"`
-	NodeId           string                                         `json:"node_id"`
-	NotificationsUrl string                                         `json:"notifications_url"`
-	OpenIssues       int64                                          `json:"open_issues"`
-	OpenIssuesCount  int64                                          `json:"open_issues_count"`
-	Owner            *AuthenticationTokenRepositoriesItemOwner      `json:"owner"`
-	Permissions      AuthenticationTokenRepositoriesItemPermissions `json:"permissions,omitempty"`
-
-	// Whether the repository is private or public.
-	Private            bool                                                   `json:"private"`
-	PullsUrl           string                                                 `json:"pulls_url"`
-	PushedAt           string                                                 `json:"pushed_at"`
-	ReleasesUrl        string                                                 `json:"releases_url"`
-	Size               int64                                                  `json:"size"`
-	SshUrl             string                                                 `json:"ssh_url"`
-	StargazersCount    int64                                                  `json:"stargazers_count"`
-	StargazersUrl      string                                                 `json:"stargazers_url"`
-	StarredAt          string                                                 `json:"starred_at,omitempty"`
-	StatusesUrl        string                                                 `json:"statuses_url"`
-	SubscribersCount   int64                                                  `json:"subscribers_count,omitempty"`
-	SubscribersUrl     string                                                 `json:"subscribers_url"`
-	SubscriptionUrl    string                                                 `json:"subscription_url"`
-	SvnUrl             string                                                 `json:"svn_url"`
-	TagsUrl            string                                                 `json:"tags_url"`
-	TeamsUrl           string                                                 `json:"teams_url"`
-	TempCloneToken     string                                                 `json:"temp_clone_token,omitempty"`
-	TemplateRepository *AuthenticationTokenRepositoriesItemTemplateRepository `json:"template_repository,omitempty"`
-	Topics             []string                                               `json:"topics,omitempty"`
-	TreesUrl           string                                                 `json:"trees_url"`
-	UpdatedAt          string                                                 `json:"updated_at"`
-	Url                string                                                 `json:"url"`
-
-	// The repository visibility: public, private, or internal.
-	Visibility    string `json:"visibility,omitempty"`
-	Watchers      int64  `json:"watchers"`
-	WatchersCount int64  `json:"watchers_count"`
-}
-
-type AuthenticationTokenRepositoriesItemLicense struct {
-	HtmlUrl string `json:"html_url,omitempty"`
-	Key     string `json:"key,omitempty"`
-	Name    string `json:"name,omitempty"`
-	NodeId  string `json:"node_id,omitempty"`
-	SpdxId  string `json:"spdx_id,omitempty"`
-	Url     string `json:"url,omitempty"`
-}
-
-type AuthenticationTokenRepositoriesItemOwner struct {
-	AvatarUrl         string `json:"avatar_url,omitempty"`
-	EventsUrl         string `json:"events_url,omitempty"`
-	FollowersUrl      string `json:"followers_url,omitempty"`
-	FollowingUrl      string `json:"following_url,omitempty"`
-	GistsUrl          string `json:"gists_url,omitempty"`
-	GravatarId        string `json:"gravatar_id,omitempty"`
-	HtmlUrl           string `json:"html_url,omitempty"`
-	Id                int64  `json:"id,omitempty"`
-	Login             string `json:"login,omitempty"`
-	NodeId            string `json:"node_id,omitempty"`
-	OrganizationsUrl  string `json:"organizations_url,omitempty"`
-	ReceivedEventsUrl string `json:"received_events_url,omitempty"`
-	ReposUrl          string `json:"repos_url,omitempty"`
-	SiteAdmin         bool   `json:"site_admin,omitempty"`
-	StarredAt         string `json:"starred_at,omitempty"`
-	StarredUrl        string `json:"starred_url,omitempty"`
-	SubscriptionsUrl  string `json:"subscriptions_url,omitempty"`
-	Type              string `json:"type,omitempty"`
-	Url               string `json:"url,omitempty"`
-}
-
-type AuthenticationTokenRepositoriesItemPermissions struct {
-	Admin    bool `json:"admin"`
-	Maintain bool `json:"maintain,omitempty"`
-	Pull     bool `json:"pull"`
-	Push     bool `json:"push"`
-	Triage   bool `json:"triage,omitempty"`
-}
-
-type AuthenticationTokenRepositoriesItemTemplateRepository struct {
-	AllowMergeCommit    bool                                                             `json:"allow_merge_commit,omitempty"`
-	AllowRebaseMerge    bool                                                             `json:"allow_rebase_merge,omitempty"`
-	AllowSquashMerge    bool                                                             `json:"allow_squash_merge,omitempty"`
-	ArchiveUrl          string                                                           `json:"archive_url,omitempty"`
-	Archived            bool                                                             `json:"archived,omitempty"`
-	AssigneesUrl        string                                                           `json:"assignees_url,omitempty"`
-	BlobsUrl            string                                                           `json:"blobs_url,omitempty"`
-	BranchesUrl         string                                                           `json:"branches_url,omitempty"`
-	CloneUrl            string                                                           `json:"clone_url,omitempty"`
-	CollaboratorsUrl    string                                                           `json:"collaborators_url,omitempty"`
-	CommentsUrl         string                                                           `json:"comments_url,omitempty"`
-	CommitsUrl          string                                                           `json:"commits_url,omitempty"`
-	CompareUrl          string                                                           `json:"compare_url,omitempty"`
-	ContentsUrl         string                                                           `json:"contents_url,omitempty"`
-	ContributorsUrl     string                                                           `json:"contributors_url,omitempty"`
-	CreatedAt           string                                                           `json:"created_at,omitempty"`
-	DefaultBranch       string                                                           `json:"default_branch,omitempty"`
-	DeleteBranchOnMerge bool                                                             `json:"delete_branch_on_merge,omitempty"`
-	DeploymentsUrl      string                                                           `json:"deployments_url,omitempty"`
-	Description         string                                                           `json:"description,omitempty"`
-	Disabled            bool                                                             `json:"disabled,omitempty"`
-	DownloadsUrl        string                                                           `json:"downloads_url,omitempty"`
-	EventsUrl           string                                                           `json:"events_url,omitempty"`
-	Fork                bool                                                             `json:"fork,omitempty"`
-	ForksCount          int64                                                            `json:"forks_count,omitempty"`
-	ForksUrl            string                                                           `json:"forks_url,omitempty"`
-	FullName            string                                                           `json:"full_name,omitempty"`
-	GitCommitsUrl       string                                                           `json:"git_commits_url,omitempty"`
-	GitRefsUrl          string                                                           `json:"git_refs_url,omitempty"`
-	GitTagsUrl          string                                                           `json:"git_tags_url,omitempty"`
-	GitUrl              string                                                           `json:"git_url,omitempty"`
-	HasDownloads        bool                                                             `json:"has_downloads,omitempty"`
-	HasIssues           bool                                                             `json:"has_issues,omitempty"`
-	HasPages            bool                                                             `json:"has_pages,omitempty"`
-	HasProjects         bool                                                             `json:"has_projects,omitempty"`
-	HasWiki             bool                                                             `json:"has_wiki,omitempty"`
-	Homepage            string                                                           `json:"homepage,omitempty"`
-	HooksUrl            string                                                           `json:"hooks_url,omitempty"`
-	HtmlUrl             string                                                           `json:"html_url,omitempty"`
-	Id                  int64                                                            `json:"id,omitempty"`
-	IsTemplate          bool                                                             `json:"is_template,omitempty"`
-	IssueCommentUrl     string                                                           `json:"issue_comment_url,omitempty"`
-	IssueEventsUrl      string                                                           `json:"issue_events_url,omitempty"`
-	IssuesUrl           string                                                           `json:"issues_url,omitempty"`
-	KeysUrl             string                                                           `json:"keys_url,omitempty"`
-	LabelsUrl           string                                                           `json:"labels_url,omitempty"`
-	Language            string                                                           `json:"language,omitempty"`
-	LanguagesUrl        string                                                           `json:"languages_url,omitempty"`
-	MergesUrl           string                                                           `json:"merges_url,omitempty"`
-	MilestonesUrl       string                                                           `json:"milestones_url,omitempty"`
-	MirrorUrl           string                                                           `json:"mirror_url,omitempty"`
-	Name                string                                                           `json:"name,omitempty"`
-	NetworkCount        int64                                                            `json:"network_count,omitempty"`
-	NodeId              string                                                           `json:"node_id,omitempty"`
-	NotificationsUrl    string                                                           `json:"notifications_url,omitempty"`
-	OpenIssuesCount     int64                                                            `json:"open_issues_count,omitempty"`
-	Owner               AuthenticationTokenRepositoriesItemTemplateRepositoryOwner       `json:"owner,omitempty"`
-	Permissions         AuthenticationTokenRepositoriesItemTemplateRepositoryPermissions `json:"permissions,omitempty"`
-	Private             bool                                                             `json:"private,omitempty"`
-	PullsUrl            string                                                           `json:"pulls_url,omitempty"`
-	PushedAt            string                                                           `json:"pushed_at,omitempty"`
-	ReleasesUrl         string                                                           `json:"releases_url,omitempty"`
-	Size                int64                                                            `json:"size,omitempty"`
-	SshUrl              string                                                           `json:"ssh_url,omitempty"`
-	StargazersCount     int64                                                            `json:"stargazers_count,omitempty"`
-	StargazersUrl       string                                                           `json:"stargazers_url,omitempty"`
-	StatusesUrl         string                                                           `json:"statuses_url,omitempty"`
-	SubscribersCount    int64                                                            `json:"subscribers_count,omitempty"`
-	SubscribersUrl      string                                                           `json:"subscribers_url,omitempty"`
-	SubscriptionUrl     string                                                           `json:"subscription_url,omitempty"`
-	SvnUrl              string                                                           `json:"svn_url,omitempty"`
-	TagsUrl             string                                                           `json:"tags_url,omitempty"`
-	TeamsUrl            string                                                           `json:"teams_url,omitempty"`
-	TempCloneToken      string                                                           `json:"temp_clone_token,omitempty"`
-	TemplateRepository  string                                                           `json:"template_repository,omitempty"`
-	Topics              []string                                                         `json:"topics,omitempty"`
-	TreesUrl            string                                                           `json:"trees_url,omitempty"`
-	UpdatedAt           string                                                           `json:"updated_at,omitempty"`
-	Url                 string                                                           `json:"url,omitempty"`
-	Visibility          string                                                           `json:"visibility,omitempty"`
-	WatchersCount       int64                                                            `json:"watchers_count,omitempty"`
-}
-
-type AuthenticationTokenRepositoriesItemTemplateRepositoryOwner struct {
-	AvatarUrl         string `json:"avatar_url,omitempty"`
-	EventsUrl         string `json:"events_url,omitempty"`
-	FollowersUrl      string `json:"followers_url,omitempty"`
-	FollowingUrl      string `json:"following_url,omitempty"`
-	GistsUrl          string `json:"gists_url,omitempty"`
-	GravatarId        string `json:"gravatar_id,omitempty"`
-	HtmlUrl           string `json:"html_url,omitempty"`
-	Id                int64  `json:"id,omitempty"`
-	Login             string `json:"login,omitempty"`
-	NodeId            string `json:"node_id,omitempty"`
-	OrganizationsUrl  string `json:"organizations_url,omitempty"`
-	ReceivedEventsUrl string `json:"received_events_url,omitempty"`
-	ReposUrl          string `json:"repos_url,omitempty"`
-	SiteAdmin         bool   `json:"site_admin,omitempty"`
-	StarredUrl        string `json:"starred_url,omitempty"`
-	SubscriptionsUrl  string `json:"subscriptions_url,omitempty"`
-	Type              string `json:"type,omitempty"`
-	Url               string `json:"url,omitempty"`
-}
-
-type AuthenticationTokenRepositoriesItemTemplateRepositoryPermissions struct {
-	Admin bool `json:"admin,omitempty"`
-	Pull  bool `json:"pull,omitempty"`
-	Push  bool `json:"push,omitempty"`
-}
 
 type Authorization struct {
 	App          AuthorizationApp           `json:"app"`
@@ -843,11 +571,11 @@ type CheckSuite struct {
 	HeadCommit SimpleCommit `json:"head_commit"`
 
 	// The SHA of the head commit that is being checked.
-	HeadSha              string                       `json:"head_sha"`
-	Id                   int64                        `json:"id"`
-	LatestCheckRunsCount int64                        `json:"latest_check_runs_count"`
-	NodeId               string                       `json:"node_id"`
-	PullRequests         []CheckSuitePullRequestsItem `json:"pull_requests"`
+	HeadSha              string               `json:"head_sha"`
+	Id                   int64                `json:"id"`
+	LatestCheckRunsCount int64                `json:"latest_check_runs_count"`
+	NodeId               string               `json:"node_id"`
+	PullRequests         []PullRequestMinimal `json:"pull_requests"`
 
 	// Minimal Repository
 	Repository MinimalRepository `json:"repository"`
@@ -904,48 +632,10 @@ type CheckSuitePreferencePreferencesAutoTriggerChecksItem struct {
 	Setting bool  `json:"setting"`
 }
 
-type CheckSuitePullRequestsItem struct {
-	Base   CheckSuitePullRequestsItemBase `json:"base"`
-	Head   CheckSuitePullRequestsItemHead `json:"head"`
-	Id     int64                          `json:"id"`
-	Number int64                          `json:"number"`
-	Url    string                         `json:"url"`
-}
-
-type CheckSuitePullRequestsItemBase struct {
-	Ref  string                             `json:"ref"`
-	Repo CheckSuitePullRequestsItemBaseRepo `json:"repo"`
-	Sha  string                             `json:"sha"`
-}
-
-type CheckSuitePullRequestsItemBaseRepo struct {
-	Id   int64  `json:"id"`
-	Name string `json:"name"`
-	Url  string `json:"url"`
-}
-
-type CheckSuitePullRequestsItemHead struct {
-	Ref  string                             `json:"ref"`
-	Repo CheckSuitePullRequestsItemHeadRepo `json:"repo"`
-	Sha  string                             `json:"sha"`
-}
-
-type CheckSuitePullRequestsItemHeadRepo struct {
-	Id   int64  `json:"id"`
-	Name string `json:"name"`
-	Url  string `json:"url"`
-}
-
 type CloneTraffic struct {
-	Clones  []CloneTrafficClonesItem `json:"clones"`
-	Count   int64                    `json:"count"`
-	Uniques int64                    `json:"uniques"`
-}
-
-type CloneTrafficClonesItem struct {
-	Count     int64  `json:"count"`
-	Timestamp string `json:"timestamp"`
-	Uniques   int64  `json:"uniques"`
+	Clones  []Traffic `json:"clones"`
+	Count   int64     `json:"count"`
+	Uniques int64     `json:"uniques"`
 }
 
 type CodeFrequencyStat []int64
@@ -1074,40 +764,26 @@ type CombinedCommitStatus struct {
 	CommitUrl string `json:"commit_url"`
 
 	// Minimal Repository
-	Repository MinimalRepository                  `json:"repository"`
-	Sha        string                             `json:"sha"`
-	State      string                             `json:"state"`
-	Statuses   []CombinedCommitStatusStatusesItem `json:"statuses"`
-	TotalCount int64                              `json:"total_count"`
-	Url        string                             `json:"url"`
-}
-
-type CombinedCommitStatusStatusesItem struct {
-	AvatarUrl   string `json:"avatar_url"`
-	Context     string `json:"context"`
-	CreatedAt   string `json:"created_at"`
-	Description string `json:"description"`
-	Id          int64  `json:"id"`
-	NodeId      string `json:"node_id"`
-	Required    bool   `json:"required,omitempty"`
-	State       string `json:"state"`
-	TargetUrl   string `json:"target_url"`
-	UpdatedAt   string `json:"updated_at"`
-	Url         string `json:"url"`
+	Repository MinimalRepository    `json:"repository"`
+	Sha        string               `json:"sha"`
+	State      string               `json:"state"`
+	Statuses   []SimpleCommitStatus `json:"statuses"`
+	TotalCount int64                `json:"total_count"`
+	Url        string               `json:"url"`
 }
 
 type Commit struct {
-	Author      *CommitAuthor                            `json:"author"`
-	CommentsUrl string                                   `json:"comments_url"`
-	Commit      CommitCommit                             `json:"commit"`
-	Committer   *CommitCommitter                         `json:"committer"`
-	Files       []CommitComparisonCommitsItemFilesItem   `json:"files,omitempty"`
-	HtmlUrl     string                                   `json:"html_url"`
-	NodeId      string                                   `json:"node_id"`
-	Parents     []CommitComparisonCommitsItemParentsItem `json:"parents"`
-	Sha         string                                   `json:"sha"`
-	Stats       CommitStats                              `json:"stats,omitempty"`
-	Url         string                                   `json:"url"`
+	Author      *CommitAuthor       `json:"author"`
+	CommentsUrl string              `json:"comments_url"`
+	Commit      CommitCommit        `json:"commit"`
+	Committer   *CommitCommitter    `json:"committer"`
+	Files       []CommitFilesItem   `json:"files,omitempty"`
+	HtmlUrl     string              `json:"html_url"`
+	NodeId      string              `json:"node_id"`
+	Parents     []CommitParentsItem `json:"parents"`
+	Sha         string              `json:"sha"`
+	Stats       CommitStats         `json:"stats,omitempty"`
+	Url         string              `json:"url"`
 }
 
 type CommitActivity struct {
@@ -1230,12 +906,12 @@ type CommitComparison struct {
 	AheadBy int64 `json:"ahead_by"`
 
 	// Commit
-	BaseCommit Commit                        `json:"base_commit"`
-	BehindBy   int64                         `json:"behind_by"`
-	Commits    []CommitComparisonCommitsItem `json:"commits"`
-	DiffUrl    string                        `json:"diff_url"`
-	Files      []CommitComparisonFilesItem   `json:"files"`
-	HtmlUrl    string                        `json:"html_url"`
+	BaseCommit Commit      `json:"base_commit"`
+	BehindBy   int64       `json:"behind_by"`
+	Commits    []Commit    `json:"commits"`
+	DiffUrl    string      `json:"diff_url"`
+	Files      []DiffEntry `json:"files"`
+	HtmlUrl    string      `json:"html_url"`
 
 	// Commit
 	MergeBaseCommit Commit `json:"merge_base_commit"`
@@ -1244,54 +920,6 @@ type CommitComparison struct {
 	Status          string `json:"status"`
 	TotalCommits    int64  `json:"total_commits"`
 	Url             string `json:"url"`
-}
-
-type CommitComparisonCommitsItem struct {
-	Author      *CommitAuthor                            `json:"author"`
-	CommentsUrl string                                   `json:"comments_url"`
-	Commit      CommitCommit                             `json:"commit"`
-	Committer   *CommitCommitter                         `json:"committer"`
-	Files       []CommitComparisonCommitsItemFilesItem   `json:"files,omitempty"`
-	HtmlUrl     string                                   `json:"html_url"`
-	NodeId      string                                   `json:"node_id"`
-	Parents     []CommitComparisonCommitsItemParentsItem `json:"parents"`
-	Sha         string                                   `json:"sha"`
-	Stats       CommitStats                              `json:"stats,omitempty"`
-	Url         string                                   `json:"url"`
-}
-
-type CommitComparisonCommitsItemFilesItem struct {
-	Additions        int64  `json:"additions,omitempty"`
-	BlobUrl          string `json:"blob_url,omitempty"`
-	Changes          int64  `json:"changes,omitempty"`
-	ContentsUrl      string `json:"contents_url,omitempty"`
-	Deletions        int64  `json:"deletions,omitempty"`
-	Filename         string `json:"filename,omitempty"`
-	Patch            string `json:"patch,omitempty"`
-	PreviousFilename string `json:"previous_filename,omitempty"`
-	RawUrl           string `json:"raw_url,omitempty"`
-	Sha              string `json:"sha,omitempty"`
-	Status           string `json:"status,omitempty"`
-}
-
-type CommitComparisonCommitsItemParentsItem struct {
-	HtmlUrl string `json:"html_url,omitempty"`
-	Sha     string `json:"sha"`
-	Url     string `json:"url"`
-}
-
-type CommitComparisonFilesItem struct {
-	Additions        int64  `json:"additions"`
-	BlobUrl          string `json:"blob_url"`
-	Changes          int64  `json:"changes"`
-	ContentsUrl      string `json:"contents_url"`
-	Deletions        int64  `json:"deletions"`
-	Filename         string `json:"filename"`
-	Patch            string `json:"patch,omitempty"`
-	PreviousFilename string `json:"previous_filename,omitempty"`
-	RawUrl           string `json:"raw_url"`
-	Sha              string `json:"sha"`
-	Status           string `json:"status"`
 }
 
 type CommitFilesItem struct {
@@ -2028,8 +1656,8 @@ type FeedLinks struct {
 	CurrentUserActor LinkWithType `json:"current_user_actor,omitempty"`
 
 	// Hypermedia Link with Type
-	CurrentUserOrganization  LinkWithType                            `json:"current_user_organization,omitempty"`
-	CurrentUserOrganizations []FeedLinksCurrentUserOrganizationsItem `json:"current_user_organizations,omitempty"`
+	CurrentUserOrganization  LinkWithType   `json:"current_user_organization,omitempty"`
+	CurrentUserOrganizations []LinkWithType `json:"current_user_organizations,omitempty"`
 
 	// Hypermedia Link with Type
 	CurrentUserPublic LinkWithType `json:"current_user_public,omitempty"`
@@ -2042,11 +1670,6 @@ type FeedLinks struct {
 
 	// Hypermedia Link with Type
 	User LinkWithType `json:"user"`
-}
-
-type FeedLinksCurrentUserOrganizationsItem struct {
-	Href string `json:"href"`
-	Type string `json:"type"`
 }
 
 type FileCommit struct {
@@ -2346,53 +1969,53 @@ type FullRepositoryTemplateRepository struct {
 	Id int64 `json:"id,omitempty"`
 
 	// Whether this repository acts as a template that can be used to generate new repositories.
-	IsTemplate      bool                                        `json:"is_template,omitempty"`
-	IssueCommentUrl string                                      `json:"issue_comment_url,omitempty"`
-	IssueEventsUrl  string                                      `json:"issue_events_url,omitempty"`
-	IssuesUrl       string                                      `json:"issues_url,omitempty"`
-	KeysUrl         string                                      `json:"keys_url,omitempty"`
-	LabelsUrl       string                                      `json:"labels_url,omitempty"`
-	Language        string                                      `json:"language,omitempty"`
-	LanguagesUrl    string                                      `json:"languages_url,omitempty"`
-	License         *AuthenticationTokenRepositoriesItemLicense `json:"license,omitempty"`
-	MasterBranch    string                                      `json:"master_branch,omitempty"`
-	MergesUrl       string                                      `json:"merges_url,omitempty"`
-	MilestonesUrl   string                                      `json:"milestones_url,omitempty"`
-	MirrorUrl       string                                      `json:"mirror_url,omitempty"`
+	IsTemplate      bool               `json:"is_template,omitempty"`
+	IssueCommentUrl string             `json:"issue_comment_url,omitempty"`
+	IssueEventsUrl  string             `json:"issue_events_url,omitempty"`
+	IssuesUrl       string             `json:"issues_url,omitempty"`
+	KeysUrl         string             `json:"keys_url,omitempty"`
+	LabelsUrl       string             `json:"labels_url,omitempty"`
+	Language        string             `json:"language,omitempty"`
+	LanguagesUrl    string             `json:"languages_url,omitempty"`
+	License         *RepositoryLicense `json:"license,omitempty"`
+	MasterBranch    string             `json:"master_branch,omitempty"`
+	MergesUrl       string             `json:"merges_url,omitempty"`
+	MilestonesUrl   string             `json:"milestones_url,omitempty"`
+	MirrorUrl       string             `json:"mirror_url,omitempty"`
 
 	// The name of the repository.
-	Name             string                                         `json:"name,omitempty"`
-	NetworkCount     int64                                          `json:"network_count,omitempty"`
-	NodeId           string                                         `json:"node_id,omitempty"`
-	NotificationsUrl string                                         `json:"notifications_url,omitempty"`
-	OpenIssues       int64                                          `json:"open_issues,omitempty"`
-	OpenIssuesCount  int64                                          `json:"open_issues_count,omitempty"`
-	Owner            *AuthenticationTokenRepositoriesItemOwner      `json:"owner,omitempty"`
-	Permissions      AuthenticationTokenRepositoriesItemPermissions `json:"permissions,omitempty"`
+	Name             string                `json:"name,omitempty"`
+	NetworkCount     int64                 `json:"network_count,omitempty"`
+	NodeId           string                `json:"node_id,omitempty"`
+	NotificationsUrl string                `json:"notifications_url,omitempty"`
+	OpenIssues       int64                 `json:"open_issues,omitempty"`
+	OpenIssuesCount  int64                 `json:"open_issues_count,omitempty"`
+	Owner            *RepositoryOwner      `json:"owner,omitempty"`
+	Permissions      RepositoryPermissions `json:"permissions,omitempty"`
 
 	// Whether the repository is private or public.
-	Private            bool                                                   `json:"private,omitempty"`
-	PullsUrl           string                                                 `json:"pulls_url,omitempty"`
-	PushedAt           string                                                 `json:"pushed_at,omitempty"`
-	ReleasesUrl        string                                                 `json:"releases_url,omitempty"`
-	Size               int64                                                  `json:"size,omitempty"`
-	SshUrl             string                                                 `json:"ssh_url,omitempty"`
-	StargazersCount    int64                                                  `json:"stargazers_count,omitempty"`
-	StargazersUrl      string                                                 `json:"stargazers_url,omitempty"`
-	StarredAt          string                                                 `json:"starred_at,omitempty"`
-	StatusesUrl        string                                                 `json:"statuses_url,omitempty"`
-	SubscribersCount   int64                                                  `json:"subscribers_count,omitempty"`
-	SubscribersUrl     string                                                 `json:"subscribers_url,omitempty"`
-	SubscriptionUrl    string                                                 `json:"subscription_url,omitempty"`
-	SvnUrl             string                                                 `json:"svn_url,omitempty"`
-	TagsUrl            string                                                 `json:"tags_url,omitempty"`
-	TeamsUrl           string                                                 `json:"teams_url,omitempty"`
-	TempCloneToken     string                                                 `json:"temp_clone_token,omitempty"`
-	TemplateRepository *AuthenticationTokenRepositoriesItemTemplateRepository `json:"template_repository,omitempty"`
-	Topics             []string                                               `json:"topics,omitempty"`
-	TreesUrl           string                                                 `json:"trees_url,omitempty"`
-	UpdatedAt          string                                                 `json:"updated_at,omitempty"`
-	Url                string                                                 `json:"url,omitempty"`
+	Private            bool                          `json:"private,omitempty"`
+	PullsUrl           string                        `json:"pulls_url,omitempty"`
+	PushedAt           string                        `json:"pushed_at,omitempty"`
+	ReleasesUrl        string                        `json:"releases_url,omitempty"`
+	Size               int64                         `json:"size,omitempty"`
+	SshUrl             string                        `json:"ssh_url,omitempty"`
+	StargazersCount    int64                         `json:"stargazers_count,omitempty"`
+	StargazersUrl      string                        `json:"stargazers_url,omitempty"`
+	StarredAt          string                        `json:"starred_at,omitempty"`
+	StatusesUrl        string                        `json:"statuses_url,omitempty"`
+	SubscribersCount   int64                         `json:"subscribers_count,omitempty"`
+	SubscribersUrl     string                        `json:"subscribers_url,omitempty"`
+	SubscriptionUrl    string                        `json:"subscription_url,omitempty"`
+	SvnUrl             string                        `json:"svn_url,omitempty"`
+	TagsUrl            string                        `json:"tags_url,omitempty"`
+	TeamsUrl           string                        `json:"teams_url,omitempty"`
+	TempCloneToken     string                        `json:"temp_clone_token,omitempty"`
+	TemplateRepository *RepositoryTemplateRepository `json:"template_repository,omitempty"`
+	Topics             []string                      `json:"topics,omitempty"`
+	TreesUrl           string                        `json:"trees_url,omitempty"`
+	UpdatedAt          string                        `json:"updated_at,omitempty"`
+	Url                string                        `json:"url,omitempty"`
 
 	// The repository visibility: public, private, or internal.
 	Visibility    string `json:"visibility,omitempty"`
@@ -2981,12 +2604,12 @@ type InstallationSuspendedBy struct {
 }
 
 type InstallationToken struct {
-	ExpiresAt           string                              `json:"expires_at,omitempty"`
-	Permissions         InstallationTokenPermissions        `json:"permissions,omitempty"`
-	Repositories        []InstallationTokenRepositoriesItem `json:"repositories,omitempty"`
-	RepositorySelection string                              `json:"repository_selection,omitempty"`
-	SingleFile          string                              `json:"single_file,omitempty"`
-	Token               string                              `json:"token,omitempty"`
+	ExpiresAt           string                       `json:"expires_at,omitempty"`
+	Permissions         InstallationTokenPermissions `json:"permissions,omitempty"`
+	Repositories        []Repository                 `json:"repositories,omitempty"`
+	RepositorySelection string                       `json:"repository_selection,omitempty"`
+	SingleFile          string                       `json:"single_file,omitempty"`
+	Token               string                       `json:"token,omitempty"`
 }
 
 type InstallationTokenPermissions struct {
@@ -2994,128 +2617,6 @@ type InstallationTokenPermissions struct {
 	Issues     string `json:"issues,omitempty"`
 	Metadata   string `json:"metadata,omitempty"`
 	SingleFile string `json:"single_file,omitempty"`
-}
-
-type InstallationTokenRepositoriesItem struct {
-
-	// Whether to allow merge commits for pull requests.
-	AllowMergeCommit bool `json:"allow_merge_commit,omitempty"`
-
-	// Whether to allow rebase merges for pull requests.
-	AllowRebaseMerge bool `json:"allow_rebase_merge,omitempty"`
-
-	// Whether to allow squash merges for pull requests.
-	AllowSquashMerge bool   `json:"allow_squash_merge,omitempty"`
-	ArchiveUrl       string `json:"archive_url"`
-
-	// Whether the repository is archived.
-	Archived         bool   `json:"archived"`
-	AssigneesUrl     string `json:"assignees_url"`
-	BlobsUrl         string `json:"blobs_url"`
-	BranchesUrl      string `json:"branches_url"`
-	CloneUrl         string `json:"clone_url"`
-	CollaboratorsUrl string `json:"collaborators_url"`
-	CommentsUrl      string `json:"comments_url"`
-	CommitsUrl       string `json:"commits_url"`
-	CompareUrl       string `json:"compare_url"`
-	ContentsUrl      string `json:"contents_url"`
-	ContributorsUrl  string `json:"contributors_url"`
-	CreatedAt        string `json:"created_at"`
-
-	// The default branch of the repository.
-	DefaultBranch string `json:"default_branch"`
-
-	// Whether to delete head branches when pull requests are merged
-	DeleteBranchOnMerge bool   `json:"delete_branch_on_merge,omitempty"`
-	DeploymentsUrl      string `json:"deployments_url"`
-	Description         string `json:"description"`
-
-	// Returns whether or not this repository disabled.
-	Disabled      bool   `json:"disabled"`
-	DownloadsUrl  string `json:"downloads_url"`
-	EventsUrl     string `json:"events_url"`
-	Fork          bool   `json:"fork"`
-	Forks         int64  `json:"forks"`
-	ForksCount    int64  `json:"forks_count"`
-	ForksUrl      string `json:"forks_url"`
-	FullName      string `json:"full_name"`
-	GitCommitsUrl string `json:"git_commits_url"`
-	GitRefsUrl    string `json:"git_refs_url"`
-	GitTagsUrl    string `json:"git_tags_url"`
-	GitUrl        string `json:"git_url"`
-
-	// Whether downloads are enabled.
-	HasDownloads bool `json:"has_downloads"`
-
-	// Whether issues are enabled.
-	HasIssues bool `json:"has_issues"`
-	HasPages  bool `json:"has_pages"`
-
-	// Whether projects are enabled.
-	HasProjects bool `json:"has_projects"`
-
-	// Whether the wiki is enabled.
-	HasWiki  bool   `json:"has_wiki"`
-	Homepage string `json:"homepage"`
-	HooksUrl string `json:"hooks_url"`
-	HtmlUrl  string `json:"html_url"`
-
-	// Unique identifier of the repository
-	Id int64 `json:"id"`
-
-	// Whether this repository acts as a template that can be used to generate new repositories.
-	IsTemplate      bool                                        `json:"is_template,omitempty"`
-	IssueCommentUrl string                                      `json:"issue_comment_url"`
-	IssueEventsUrl  string                                      `json:"issue_events_url"`
-	IssuesUrl       string                                      `json:"issues_url"`
-	KeysUrl         string                                      `json:"keys_url"`
-	LabelsUrl       string                                      `json:"labels_url"`
-	Language        string                                      `json:"language"`
-	LanguagesUrl    string                                      `json:"languages_url"`
-	License         *AuthenticationTokenRepositoriesItemLicense `json:"license"`
-	MasterBranch    string                                      `json:"master_branch,omitempty"`
-	MergesUrl       string                                      `json:"merges_url"`
-	MilestonesUrl   string                                      `json:"milestones_url"`
-	MirrorUrl       string                                      `json:"mirror_url"`
-
-	// The name of the repository.
-	Name             string                                         `json:"name"`
-	NetworkCount     int64                                          `json:"network_count,omitempty"`
-	NodeId           string                                         `json:"node_id"`
-	NotificationsUrl string                                         `json:"notifications_url"`
-	OpenIssues       int64                                          `json:"open_issues"`
-	OpenIssuesCount  int64                                          `json:"open_issues_count"`
-	Owner            *AuthenticationTokenRepositoriesItemOwner      `json:"owner"`
-	Permissions      AuthenticationTokenRepositoriesItemPermissions `json:"permissions,omitempty"`
-
-	// Whether the repository is private or public.
-	Private            bool                                                   `json:"private"`
-	PullsUrl           string                                                 `json:"pulls_url"`
-	PushedAt           string                                                 `json:"pushed_at"`
-	ReleasesUrl        string                                                 `json:"releases_url"`
-	Size               int64                                                  `json:"size"`
-	SshUrl             string                                                 `json:"ssh_url"`
-	StargazersCount    int64                                                  `json:"stargazers_count"`
-	StargazersUrl      string                                                 `json:"stargazers_url"`
-	StarredAt          string                                                 `json:"starred_at,omitempty"`
-	StatusesUrl        string                                                 `json:"statuses_url"`
-	SubscribersCount   int64                                                  `json:"subscribers_count,omitempty"`
-	SubscribersUrl     string                                                 `json:"subscribers_url"`
-	SubscriptionUrl    string                                                 `json:"subscription_url"`
-	SvnUrl             string                                                 `json:"svn_url"`
-	TagsUrl            string                                                 `json:"tags_url"`
-	TeamsUrl           string                                                 `json:"teams_url"`
-	TempCloneToken     string                                                 `json:"temp_clone_token,omitempty"`
-	TemplateRepository *AuthenticationTokenRepositoriesItemTemplateRepository `json:"template_repository,omitempty"`
-	Topics             []string                                               `json:"topics,omitempty"`
-	TreesUrl           string                                                 `json:"trees_url"`
-	UpdatedAt          string                                                 `json:"updated_at"`
-	Url                string                                                 `json:"url"`
-
-	// The repository visibility: public, private, or internal.
-	Visibility    string `json:"visibility,omitempty"`
-	Watchers      int64  `json:"watchers"`
-	WatchersCount int64  `json:"watchers_count"`
 }
 
 type Integration struct {
@@ -3181,10 +2682,10 @@ type InteractionLimit struct {
 }
 
 type Issue struct {
-	ActiveLockReason  string               `json:"active_lock_reason,omitempty"`
-	Assignee          *IssueAssignee       `json:"assignee"`
-	Assignees         []IssueAssigneesItem `json:"assignees,omitempty"`
-	AuthorAssociation string               `json:"author_association"`
+	ActiveLockReason  string         `json:"active_lock_reason,omitempty"`
+	Assignee          *IssueAssignee `json:"assignee"`
+	Assignees         []SimpleUser   `json:"assignees,omitempty"`
+	AuthorAssociation string         `json:"author_association"`
 
 	// Contents of the issue
 	Body        string         `json:"body,omitempty"`
@@ -3254,28 +2755,6 @@ type IssueAssignee struct {
 	SubscriptionsUrl  string `json:"subscriptions_url,omitempty"`
 	Type              string `json:"type,omitempty"`
 	Url               string `json:"url,omitempty"`
-}
-
-type IssueAssigneesItem struct {
-	AvatarUrl         string `json:"avatar_url"`
-	EventsUrl         string `json:"events_url"`
-	FollowersUrl      string `json:"followers_url"`
-	FollowingUrl      string `json:"following_url"`
-	GistsUrl          string `json:"gists_url"`
-	GravatarId        string `json:"gravatar_id"`
-	HtmlUrl           string `json:"html_url"`
-	Id                int64  `json:"id"`
-	Login             string `json:"login"`
-	NodeId            string `json:"node_id"`
-	OrganizationsUrl  string `json:"organizations_url"`
-	ReceivedEventsUrl string `json:"received_events_url"`
-	ReposUrl          string `json:"repos_url"`
-	SiteAdmin         bool   `json:"site_admin"`
-	StarredAt         string `json:"starred_at,omitempty"`
-	StarredUrl        string `json:"starred_url"`
-	SubscriptionsUrl  string `json:"subscriptions_url"`
-	Type              string `json:"type"`
-	Url               string `json:"url"`
 }
 
 type IssueClosedBy struct {
@@ -3711,7 +3190,7 @@ type IssuePullRequest struct {
 type IssueSearchResultItem struct {
 	ActiveLockReason      string                                      `json:"active_lock_reason,omitempty"`
 	Assignee              *IssueSearchResultItemAssignee              `json:"assignee"`
-	Assignees             []IssueSearchResultItemAssigneesItem        `json:"assignees,omitempty"`
+	Assignees             []SimpleUser                                `json:"assignees,omitempty"`
 	AuthorAssociation     string                                      `json:"author_association"`
 	Body                  string                                      `json:"body,omitempty"`
 	BodyHtml              string                                      `json:"body_html,omitempty"`
@@ -3766,28 +3245,6 @@ type IssueSearchResultItemAssignee struct {
 	SubscriptionsUrl  string `json:"subscriptions_url,omitempty"`
 	Type              string `json:"type,omitempty"`
 	Url               string `json:"url,omitempty"`
-}
-
-type IssueSearchResultItemAssigneesItem struct {
-	AvatarUrl         string `json:"avatar_url"`
-	EventsUrl         string `json:"events_url"`
-	FollowersUrl      string `json:"followers_url"`
-	FollowingUrl      string `json:"following_url"`
-	GistsUrl          string `json:"gists_url"`
-	GravatarId        string `json:"gravatar_id"`
-	HtmlUrl           string `json:"html_url"`
-	Id                int64  `json:"id"`
-	Login             string `json:"login"`
-	NodeId            string `json:"node_id"`
-	OrganizationsUrl  string `json:"organizations_url"`
-	ReceivedEventsUrl string `json:"received_events_url"`
-	ReposUrl          string `json:"repos_url"`
-	SiteAdmin         bool   `json:"site_admin"`
-	StarredAt         string `json:"starred_at,omitempty"`
-	StarredUrl        string `json:"starred_url"`
-	SubscriptionsUrl  string `json:"subscriptions_url"`
-	Type              string `json:"type"`
-	Url               string `json:"url"`
 }
 
 type IssueSearchResultItemLabelsItem struct {
@@ -3890,7 +3347,7 @@ type IssueSearchResultItemUser struct {
 type IssueSimple struct {
 	ActiveLockReason      string                            `json:"active_lock_reason,omitempty"`
 	Assignee              *IssueSimpleAssignee              `json:"assignee"`
-	Assignees             []IssueSimpleAssigneesItem        `json:"assignees,omitempty"`
+	Assignees             []SimpleUser                      `json:"assignees,omitempty"`
 	AuthorAssociation     string                            `json:"author_association"`
 	Body                  string                            `json:"body,omitempty"`
 	BodyHtml              string                            `json:"body_html,omitempty"`
@@ -3942,28 +3399,6 @@ type IssueSimpleAssignee struct {
 	SubscriptionsUrl  string `json:"subscriptions_url,omitempty"`
 	Type              string `json:"type,omitempty"`
 	Url               string `json:"url,omitempty"`
-}
-
-type IssueSimpleAssigneesItem struct {
-	AvatarUrl         string `json:"avatar_url"`
-	EventsUrl         string `json:"events_url"`
-	FollowersUrl      string `json:"followers_url"`
-	FollowingUrl      string `json:"following_url"`
-	GistsUrl          string `json:"gists_url"`
-	GravatarId        string `json:"gravatar_id"`
-	HtmlUrl           string `json:"html_url"`
-	Id                int64  `json:"id"`
-	Login             string `json:"login"`
-	NodeId            string `json:"node_id"`
-	OrganizationsUrl  string `json:"organizations_url"`
-	ReceivedEventsUrl string `json:"received_events_url"`
-	ReposUrl          string `json:"repos_url"`
-	SiteAdmin         bool   `json:"site_admin"`
-	StarredAt         string `json:"starred_at,omitempty"`
-	StarredUrl        string `json:"starred_url"`
-	SubscriptionsUrl  string `json:"subscriptions_url"`
-	Type              string `json:"type"`
-	Url               string `json:"url"`
 }
 
 type IssueSimpleLabelsItem struct {
@@ -4310,19 +3745,19 @@ type MarketplacePurchaseMarketplacePurchase struct {
 }
 
 type Migration struct {
-	ArchiveUrl         string                      `json:"archive_url,omitempty"`
-	CreatedAt          string                      `json:"created_at"`
-	Exclude            []MigrationExcludeItem      `json:"exclude,omitempty"`
-	ExcludeAttachments bool                        `json:"exclude_attachments"`
-	Guid               string                      `json:"guid"`
-	Id                 int64                       `json:"id"`
-	LockRepositories   bool                        `json:"lock_repositories"`
-	NodeId             string                      `json:"node_id"`
-	Owner              *MigrationOwner             `json:"owner"`
-	Repositories       []MigrationRepositoriesItem `json:"repositories"`
-	State              string                      `json:"state"`
-	UpdatedAt          string                      `json:"updated_at"`
-	Url                string                      `json:"url"`
+	ArchiveUrl         string                 `json:"archive_url,omitempty"`
+	CreatedAt          string                 `json:"created_at"`
+	Exclude            []MigrationExcludeItem `json:"exclude,omitempty"`
+	ExcludeAttachments bool                   `json:"exclude_attachments"`
+	Guid               string                 `json:"guid"`
+	Id                 int64                  `json:"id"`
+	LockRepositories   bool                   `json:"lock_repositories"`
+	NodeId             string                 `json:"node_id"`
+	Owner              *MigrationOwner        `json:"owner"`
+	Repositories       []Repository           `json:"repositories"`
+	State              string                 `json:"state"`
+	UpdatedAt          string                 `json:"updated_at"`
+	Url                string                 `json:"url"`
 }
 
 type MigrationExcludeItem interface{}
@@ -4347,128 +3782,6 @@ type MigrationOwner struct {
 	SubscriptionsUrl  string `json:"subscriptions_url,omitempty"`
 	Type              string `json:"type,omitempty"`
 	Url               string `json:"url,omitempty"`
-}
-
-type MigrationRepositoriesItem struct {
-
-	// Whether to allow merge commits for pull requests.
-	AllowMergeCommit bool `json:"allow_merge_commit,omitempty"`
-
-	// Whether to allow rebase merges for pull requests.
-	AllowRebaseMerge bool `json:"allow_rebase_merge,omitempty"`
-
-	// Whether to allow squash merges for pull requests.
-	AllowSquashMerge bool   `json:"allow_squash_merge,omitempty"`
-	ArchiveUrl       string `json:"archive_url"`
-
-	// Whether the repository is archived.
-	Archived         bool   `json:"archived"`
-	AssigneesUrl     string `json:"assignees_url"`
-	BlobsUrl         string `json:"blobs_url"`
-	BranchesUrl      string `json:"branches_url"`
-	CloneUrl         string `json:"clone_url"`
-	CollaboratorsUrl string `json:"collaborators_url"`
-	CommentsUrl      string `json:"comments_url"`
-	CommitsUrl       string `json:"commits_url"`
-	CompareUrl       string `json:"compare_url"`
-	ContentsUrl      string `json:"contents_url"`
-	ContributorsUrl  string `json:"contributors_url"`
-	CreatedAt        string `json:"created_at"`
-
-	// The default branch of the repository.
-	DefaultBranch string `json:"default_branch"`
-
-	// Whether to delete head branches when pull requests are merged
-	DeleteBranchOnMerge bool   `json:"delete_branch_on_merge,omitempty"`
-	DeploymentsUrl      string `json:"deployments_url"`
-	Description         string `json:"description"`
-
-	// Returns whether or not this repository disabled.
-	Disabled      bool   `json:"disabled"`
-	DownloadsUrl  string `json:"downloads_url"`
-	EventsUrl     string `json:"events_url"`
-	Fork          bool   `json:"fork"`
-	Forks         int64  `json:"forks"`
-	ForksCount    int64  `json:"forks_count"`
-	ForksUrl      string `json:"forks_url"`
-	FullName      string `json:"full_name"`
-	GitCommitsUrl string `json:"git_commits_url"`
-	GitRefsUrl    string `json:"git_refs_url"`
-	GitTagsUrl    string `json:"git_tags_url"`
-	GitUrl        string `json:"git_url"`
-
-	// Whether downloads are enabled.
-	HasDownloads bool `json:"has_downloads"`
-
-	// Whether issues are enabled.
-	HasIssues bool `json:"has_issues"`
-	HasPages  bool `json:"has_pages"`
-
-	// Whether projects are enabled.
-	HasProjects bool `json:"has_projects"`
-
-	// Whether the wiki is enabled.
-	HasWiki  bool   `json:"has_wiki"`
-	Homepage string `json:"homepage"`
-	HooksUrl string `json:"hooks_url"`
-	HtmlUrl  string `json:"html_url"`
-
-	// Unique identifier of the repository
-	Id int64 `json:"id"`
-
-	// Whether this repository acts as a template that can be used to generate new repositories.
-	IsTemplate      bool                                        `json:"is_template,omitempty"`
-	IssueCommentUrl string                                      `json:"issue_comment_url"`
-	IssueEventsUrl  string                                      `json:"issue_events_url"`
-	IssuesUrl       string                                      `json:"issues_url"`
-	KeysUrl         string                                      `json:"keys_url"`
-	LabelsUrl       string                                      `json:"labels_url"`
-	Language        string                                      `json:"language"`
-	LanguagesUrl    string                                      `json:"languages_url"`
-	License         *AuthenticationTokenRepositoriesItemLicense `json:"license"`
-	MasterBranch    string                                      `json:"master_branch,omitempty"`
-	MergesUrl       string                                      `json:"merges_url"`
-	MilestonesUrl   string                                      `json:"milestones_url"`
-	MirrorUrl       string                                      `json:"mirror_url"`
-
-	// The name of the repository.
-	Name             string                                         `json:"name"`
-	NetworkCount     int64                                          `json:"network_count,omitempty"`
-	NodeId           string                                         `json:"node_id"`
-	NotificationsUrl string                                         `json:"notifications_url"`
-	OpenIssues       int64                                          `json:"open_issues"`
-	OpenIssuesCount  int64                                          `json:"open_issues_count"`
-	Owner            *AuthenticationTokenRepositoriesItemOwner      `json:"owner"`
-	Permissions      AuthenticationTokenRepositoriesItemPermissions `json:"permissions,omitempty"`
-
-	// Whether the repository is private or public.
-	Private            bool                                                   `json:"private"`
-	PullsUrl           string                                                 `json:"pulls_url"`
-	PushedAt           string                                                 `json:"pushed_at"`
-	ReleasesUrl        string                                                 `json:"releases_url"`
-	Size               int64                                                  `json:"size"`
-	SshUrl             string                                                 `json:"ssh_url"`
-	StargazersCount    int64                                                  `json:"stargazers_count"`
-	StargazersUrl      string                                                 `json:"stargazers_url"`
-	StarredAt          string                                                 `json:"starred_at,omitempty"`
-	StatusesUrl        string                                                 `json:"statuses_url"`
-	SubscribersCount   int64                                                  `json:"subscribers_count,omitempty"`
-	SubscribersUrl     string                                                 `json:"subscribers_url"`
-	SubscriptionUrl    string                                                 `json:"subscription_url"`
-	SvnUrl             string                                                 `json:"svn_url"`
-	TagsUrl            string                                                 `json:"tags_url"`
-	TeamsUrl           string                                                 `json:"teams_url"`
-	TempCloneToken     string                                                 `json:"temp_clone_token,omitempty"`
-	TemplateRepository *AuthenticationTokenRepositoriesItemTemplateRepository `json:"template_repository,omitempty"`
-	Topics             []string                                               `json:"topics,omitempty"`
-	TreesUrl           string                                                 `json:"trees_url"`
-	UpdatedAt          string                                                 `json:"updated_at"`
-	Url                string                                                 `json:"url"`
-
-	// The repository visibility: public, private, or internal.
-	Visibility    string `json:"visibility,omitempty"`
-	Watchers      int64  `json:"watchers"`
-	WatchersCount int64  `json:"watchers_count"`
 }
 
 type Milestone struct {
@@ -5161,50 +4474,13 @@ type ProtectedBranchPullRequestReview struct {
 type ProtectedBranchPullRequestReviewDismissalRestrictions struct {
 
 	// The list of teams with review dismissal access.
-	Teams    []ProtectedBranchPullRequestReviewDismissalRestrictionsTeamsItem `json:"teams,omitempty"`
-	TeamsUrl string                                                           `json:"teams_url,omitempty"`
-	Url      string                                                           `json:"url,omitempty"`
+	Teams    []Team `json:"teams,omitempty"`
+	TeamsUrl string `json:"teams_url,omitempty"`
+	Url      string `json:"url,omitempty"`
 
 	// The list of users with review dismissal access.
-	Users    []ProtectedBranchPullRequestReviewDismissalRestrictionsUsersItem `json:"users,omitempty"`
-	UsersUrl string                                                           `json:"users_url,omitempty"`
-}
-
-type ProtectedBranchPullRequestReviewDismissalRestrictionsTeamsItem struct {
-	Description     string                                                                         `json:"description"`
-	HtmlUrl         string                                                                         `json:"html_url"`
-	Id              int64                                                                          `json:"id"`
-	MembersUrl      string                                                                         `json:"members_url"`
-	Name            string                                                                         `json:"name"`
-	NodeId          string                                                                         `json:"node_id"`
-	Parent          *ProtectedBranchRequiredPullRequestReviewsDismissalRestrictionsTeamsItemParent `json:"parent,omitempty"`
-	Permission      string                                                                         `json:"permission"`
-	Privacy         string                                                                         `json:"privacy,omitempty"`
-	RepositoriesUrl string                                                                         `json:"repositories_url"`
-	Slug            string                                                                         `json:"slug"`
-	Url             string                                                                         `json:"url"`
-}
-
-type ProtectedBranchPullRequestReviewDismissalRestrictionsUsersItem struct {
-	AvatarUrl         string `json:"avatar_url"`
-	EventsUrl         string `json:"events_url"`
-	FollowersUrl      string `json:"followers_url"`
-	FollowingUrl      string `json:"following_url"`
-	GistsUrl          string `json:"gists_url"`
-	GravatarId        string `json:"gravatar_id"`
-	HtmlUrl           string `json:"html_url"`
-	Id                int64  `json:"id"`
-	Login             string `json:"login"`
-	NodeId            string `json:"node_id"`
-	OrganizationsUrl  string `json:"organizations_url"`
-	ReceivedEventsUrl string `json:"received_events_url"`
-	ReposUrl          string `json:"repos_url"`
-	SiteAdmin         bool   `json:"site_admin"`
-	StarredAt         string `json:"starred_at,omitempty"`
-	StarredUrl        string `json:"starred_url"`
-	SubscriptionsUrl  string `json:"subscriptions_url"`
-	Type              string `json:"type"`
-	Url               string `json:"url"`
+	Users    []SimpleUser `json:"users,omitempty"`
+	UsersUrl string       `json:"users_url,omitempty"`
 }
 
 type ProtectedBranchRequiredLinearHistory struct {
@@ -5220,77 +4496,11 @@ type ProtectedBranchRequiredPullRequestReviews struct {
 }
 
 type ProtectedBranchRequiredPullRequestReviewsDismissalRestrictions struct {
-	Teams    []ProtectedBranchRequiredPullRequestReviewsDismissalRestrictionsTeamsItem `json:"teams"`
-	TeamsUrl string                                                                    `json:"teams_url"`
-	Url      string                                                                    `json:"url"`
-	Users    []ProtectedBranchRequiredPullRequestReviewsDismissalRestrictionsUsersItem `json:"users"`
-	UsersUrl string                                                                    `json:"users_url"`
-}
-
-type ProtectedBranchRequiredPullRequestReviewsDismissalRestrictionsTeamsItem struct {
-	Description     string                                                                         `json:"description"`
-	HtmlUrl         string                                                                         `json:"html_url"`
-	Id              int64                                                                          `json:"id"`
-	MembersUrl      string                                                                         `json:"members_url"`
-	Name            string                                                                         `json:"name"`
-	NodeId          string                                                                         `json:"node_id"`
-	Parent          *ProtectedBranchRequiredPullRequestReviewsDismissalRestrictionsTeamsItemParent `json:"parent,omitempty"`
-	Permission      string                                                                         `json:"permission"`
-	Privacy         string                                                                         `json:"privacy,omitempty"`
-	RepositoriesUrl string                                                                         `json:"repositories_url"`
-	Slug            string                                                                         `json:"slug"`
-	Url             string                                                                         `json:"url"`
-}
-
-type ProtectedBranchRequiredPullRequestReviewsDismissalRestrictionsTeamsItemParent struct {
-
-	// Description of the team
-	Description string `json:"description,omitempty"`
-	HtmlUrl     string `json:"html_url,omitempty"`
-
-	// Unique identifier of the team
-	Id int64 `json:"id,omitempty"`
-
-	// Distinguished Name (DN) that team maps to within LDAP environment
-	LdapDn     string `json:"ldap_dn,omitempty"`
-	MembersUrl string `json:"members_url,omitempty"`
-
-	// Name of the team
-	Name   string `json:"name,omitempty"`
-	NodeId string `json:"node_id,omitempty"`
-
-	// Permission that the team will have for its repositories
-	Permission string `json:"permission,omitempty"`
-
-	// The level of privacy this team should have
-	Privacy         string `json:"privacy,omitempty"`
-	RepositoriesUrl string `json:"repositories_url,omitempty"`
-	Slug            string `json:"slug,omitempty"`
-
-	// URL for the team
-	Url string `json:"url,omitempty"`
-}
-
-type ProtectedBranchRequiredPullRequestReviewsDismissalRestrictionsUsersItem struct {
-	AvatarUrl         string `json:"avatar_url"`
-	EventsUrl         string `json:"events_url"`
-	FollowersUrl      string `json:"followers_url"`
-	FollowingUrl      string `json:"following_url"`
-	GistsUrl          string `json:"gists_url"`
-	GravatarId        string `json:"gravatar_id"`
-	HtmlUrl           string `json:"html_url"`
-	Id                int64  `json:"id"`
-	Login             string `json:"login"`
-	NodeId            string `json:"node_id"`
-	OrganizationsUrl  string `json:"organizations_url"`
-	ReceivedEventsUrl string `json:"received_events_url"`
-	ReposUrl          string `json:"repos_url"`
-	SiteAdmin         bool   `json:"site_admin"`
-	StarredAt         string `json:"starred_at,omitempty"`
-	StarredUrl        string `json:"starred_url"`
-	SubscriptionsUrl  string `json:"subscriptions_url"`
-	Type              string `json:"type"`
-	Url               string `json:"url"`
+	Teams    []Team       `json:"teams"`
+	TeamsUrl string       `json:"teams_url"`
+	Url      string       `json:"url"`
+	Users    []SimpleUser `json:"users"`
+	UsersUrl string       `json:"users_url"`
 }
 
 type ProtectedBranchRequiredSignatures struct {
@@ -5348,23 +4558,23 @@ type PublicUserPlan struct {
 }
 
 type PullRequest struct {
-	Links             PullRequestLinks           `json:"_links"`
-	ActiveLockReason  string                     `json:"active_lock_reason,omitempty"`
-	Additions         int64                      `json:"additions"`
-	Assignee          *PullRequestAssignee       `json:"assignee"`
-	Assignees         []PullRequestAssigneesItem `json:"assignees,omitempty"`
-	AuthorAssociation string                     `json:"author_association"`
-	Base              PullRequestBase            `json:"base"`
-	Body              string                     `json:"body"`
-	ChangedFiles      int64                      `json:"changed_files"`
-	ClosedAt          string                     `json:"closed_at"`
-	Comments          int64                      `json:"comments"`
-	CommentsUrl       string                     `json:"comments_url"`
-	Commits           int64                      `json:"commits"`
-	CommitsUrl        string                     `json:"commits_url"`
-	CreatedAt         string                     `json:"created_at"`
-	Deletions         int64                      `json:"deletions"`
-	DiffUrl           string                     `json:"diff_url"`
+	Links             PullRequestLinks     `json:"_links"`
+	ActiveLockReason  string               `json:"active_lock_reason,omitempty"`
+	Additions         int64                `json:"additions"`
+	Assignee          *PullRequestAssignee `json:"assignee"`
+	Assignees         []SimpleUser         `json:"assignees,omitempty"`
+	AuthorAssociation string               `json:"author_association"`
+	Base              PullRequestBase      `json:"base"`
+	Body              string               `json:"body"`
+	ChangedFiles      int64                `json:"changed_files"`
+	ClosedAt          string               `json:"closed_at"`
+	Comments          int64                `json:"comments"`
+	CommentsUrl       string               `json:"comments_url"`
+	Commits           int64                `json:"commits"`
+	CommitsUrl        string               `json:"commits_url"`
+	CreatedAt         string               `json:"created_at"`
+	Deletions         int64                `json:"deletions"`
+	DiffUrl           string               `json:"diff_url"`
 
 	// Indicates whether or not the pull request is a draft.
 	Draft    bool                    `json:"draft,omitempty"`
@@ -5387,14 +4597,14 @@ type PullRequest struct {
 	NodeId              string                `json:"node_id"`
 
 	// Number uniquely identifying the pull request within its repository.
-	Number             int64                               `json:"number"`
-	PatchUrl           string                              `json:"patch_url"`
-	Rebaseable         bool                                `json:"rebaseable,omitempty"`
-	RequestedReviewers []PullRequestRequestedReviewersItem `json:"requested_reviewers,omitempty"`
-	RequestedTeams     []PullRequestRequestedTeamsItem     `json:"requested_teams,omitempty"`
-	ReviewCommentUrl   string                              `json:"review_comment_url"`
-	ReviewComments     int64                               `json:"review_comments"`
-	ReviewCommentsUrl  string                              `json:"review_comments_url"`
+	Number             int64        `json:"number"`
+	PatchUrl           string       `json:"patch_url"`
+	Rebaseable         bool         `json:"rebaseable,omitempty"`
+	RequestedReviewers []SimpleUser `json:"requested_reviewers,omitempty"`
+	RequestedTeams     []TeamSimple `json:"requested_teams,omitempty"`
+	ReviewCommentUrl   string       `json:"review_comment_url"`
+	ReviewComments     int64        `json:"review_comments"`
+	ReviewCommentsUrl  string       `json:"review_comments_url"`
 
 	// State of this Pull Request. Either `open` or `closed`.
 	State       string `json:"state"`
@@ -5454,28 +4664,6 @@ type PullRequestAssignee struct {
 	SubscriptionsUrl  string `json:"subscriptions_url,omitempty"`
 	Type              string `json:"type,omitempty"`
 	Url               string `json:"url,omitempty"`
-}
-
-type PullRequestAssigneesItem struct {
-	AvatarUrl         string `json:"avatar_url"`
-	EventsUrl         string `json:"events_url"`
-	FollowersUrl      string `json:"followers_url"`
-	FollowingUrl      string `json:"following_url"`
-	GistsUrl          string `json:"gists_url"`
-	GravatarId        string `json:"gravatar_id"`
-	HtmlUrl           string `json:"html_url"`
-	Id                int64  `json:"id"`
-	Login             string `json:"login"`
-	NodeId            string `json:"node_id"`
-	OrganizationsUrl  string `json:"organizations_url"`
-	ReceivedEventsUrl string `json:"received_events_url"`
-	ReposUrl          string `json:"repos_url"`
-	SiteAdmin         bool   `json:"site_admin"`
-	StarredAt         string `json:"starred_at,omitempty"`
-	StarredUrl        string `json:"starred_url"`
-	SubscriptionsUrl  string `json:"subscriptions_url"`
-	Type              string `json:"type"`
-	Url               string `json:"url"`
 }
 
 type PullRequestBase struct {
@@ -5837,62 +5025,35 @@ type PullRequestMilestone struct {
 }
 
 type PullRequestMinimal struct {
-	Base   CheckSuitePullRequestsItemBase `json:"base"`
-	Head   CheckSuitePullRequestsItemHead `json:"head"`
-	Id     int64                          `json:"id"`
-	Number int64                          `json:"number"`
-	Url    string                         `json:"url"`
+	Base   PullRequestMinimalBase `json:"base"`
+	Head   PullRequestMinimalHead `json:"head"`
+	Id     int64                  `json:"id"`
+	Number int64                  `json:"number"`
+	Url    string                 `json:"url"`
 }
 
-type PullRequestRequestedReviewersItem struct {
-	AvatarUrl         string `json:"avatar_url"`
-	EventsUrl         string `json:"events_url"`
-	FollowersUrl      string `json:"followers_url"`
-	FollowingUrl      string `json:"following_url"`
-	GistsUrl          string `json:"gists_url"`
-	GravatarId        string `json:"gravatar_id"`
-	HtmlUrl           string `json:"html_url"`
-	Id                int64  `json:"id"`
-	Login             string `json:"login"`
-	NodeId            string `json:"node_id"`
-	OrganizationsUrl  string `json:"organizations_url"`
-	ReceivedEventsUrl string `json:"received_events_url"`
-	ReposUrl          string `json:"repos_url"`
-	SiteAdmin         bool   `json:"site_admin"`
-	StarredAt         string `json:"starred_at,omitempty"`
-	StarredUrl        string `json:"starred_url"`
-	SubscriptionsUrl  string `json:"subscriptions_url"`
-	Type              string `json:"type"`
-	Url               string `json:"url"`
+type PullRequestMinimalBase struct {
+	Ref  string                     `json:"ref"`
+	Repo PullRequestMinimalBaseRepo `json:"repo"`
+	Sha  string                     `json:"sha"`
 }
 
-type PullRequestRequestedTeamsItem struct {
+type PullRequestMinimalBaseRepo struct {
+	Id   int64  `json:"id"`
+	Name string `json:"name"`
+	Url  string `json:"url"`
+}
 
-	// Description of the team
-	Description string `json:"description"`
-	HtmlUrl     string `json:"html_url"`
+type PullRequestMinimalHead struct {
+	Ref  string                     `json:"ref"`
+	Repo PullRequestMinimalHeadRepo `json:"repo"`
+	Sha  string                     `json:"sha"`
+}
 
-	// Unique identifier of the team
-	Id int64 `json:"id"`
-
-	// Distinguished Name (DN) that team maps to within LDAP environment
-	LdapDn     string `json:"ldap_dn,omitempty"`
-	MembersUrl string `json:"members_url"`
-
-	// Name of the team
-	Name   string `json:"name"`
-	NodeId string `json:"node_id"`
-
-	// Permission that the team will have for its repositories
-	Permission string `json:"permission"`
-
-	// The level of privacy this team should have
-	Privacy         string `json:"privacy,omitempty"`
-	RepositoriesUrl string `json:"repositories_url"`
-	Slug            string `json:"slug"`
-
-	// URL for the team
-	Url string `json:"url"`
+type PullRequestMinimalHeadRepo struct {
+	Id   int64  `json:"id"`
+	Name string `json:"name"`
+	Url  string `json:"url"`
 }
 
 type PullRequestReview struct {
@@ -6087,43 +5248,43 @@ type PullRequestReviewUser struct {
 }
 
 type PullRequestSimple struct {
-	Links             PullRequestSimpleLinks           `json:"_links"`
-	ActiveLockReason  string                           `json:"active_lock_reason,omitempty"`
-	Assignee          *PullRequestSimpleAssignee       `json:"assignee"`
-	Assignees         []PullRequestSimpleAssigneesItem `json:"assignees,omitempty"`
-	AuthorAssociation string                           `json:"author_association"`
-	Base              PullRequestSimpleBase            `json:"base"`
-	Body              string                           `json:"body"`
-	ClosedAt          string                           `json:"closed_at"`
-	CommentsUrl       string                           `json:"comments_url"`
-	CommitsUrl        string                           `json:"commits_url"`
-	CreatedAt         string                           `json:"created_at"`
-	DiffUrl           string                           `json:"diff_url"`
+	Links             PullRequestSimpleLinks     `json:"_links"`
+	ActiveLockReason  string                     `json:"active_lock_reason,omitempty"`
+	Assignee          *PullRequestSimpleAssignee `json:"assignee"`
+	Assignees         []SimpleUser               `json:"assignees,omitempty"`
+	AuthorAssociation string                     `json:"author_association"`
+	Base              PullRequestSimpleBase      `json:"base"`
+	Body              string                     `json:"body"`
+	ClosedAt          string                     `json:"closed_at"`
+	CommentsUrl       string                     `json:"comments_url"`
+	CommitsUrl        string                     `json:"commits_url"`
+	CreatedAt         string                     `json:"created_at"`
+	DiffUrl           string                     `json:"diff_url"`
 
 	// Indicates whether or not the pull request is a draft.
-	Draft              bool                                      `json:"draft,omitempty"`
-	Head               PullRequestSimpleHead                     `json:"head"`
-	HtmlUrl            string                                    `json:"html_url"`
-	Id                 int64                                     `json:"id"`
-	IssueUrl           string                                    `json:"issue_url"`
-	Labels             []PullRequestSimpleLabelsItem             `json:"labels"`
-	Locked             bool                                      `json:"locked"`
-	MergeCommitSha     string                                    `json:"merge_commit_sha"`
-	MergedAt           string                                    `json:"merged_at"`
-	Milestone          *PullRequestSimpleMilestone               `json:"milestone"`
-	NodeId             string                                    `json:"node_id"`
-	Number             int64                                     `json:"number"`
-	PatchUrl           string                                    `json:"patch_url"`
-	RequestedReviewers []PullRequestSimpleRequestedReviewersItem `json:"requested_reviewers,omitempty"`
-	RequestedTeams     []PullRequestSimpleRequestedTeamsItem     `json:"requested_teams,omitempty"`
-	ReviewCommentUrl   string                                    `json:"review_comment_url"`
-	ReviewCommentsUrl  string                                    `json:"review_comments_url"`
-	State              string                                    `json:"state"`
-	StatusesUrl        string                                    `json:"statuses_url"`
-	Title              string                                    `json:"title"`
-	UpdatedAt          string                                    `json:"updated_at"`
-	Url                string                                    `json:"url"`
-	User               *PullRequestSimpleUser                    `json:"user"`
+	Draft              bool                          `json:"draft,omitempty"`
+	Head               PullRequestSimpleHead         `json:"head"`
+	HtmlUrl            string                        `json:"html_url"`
+	Id                 int64                         `json:"id"`
+	IssueUrl           string                        `json:"issue_url"`
+	Labels             []PullRequestSimpleLabelsItem `json:"labels"`
+	Locked             bool                          `json:"locked"`
+	MergeCommitSha     string                        `json:"merge_commit_sha"`
+	MergedAt           string                        `json:"merged_at"`
+	Milestone          *PullRequestSimpleMilestone   `json:"milestone"`
+	NodeId             string                        `json:"node_id"`
+	Number             int64                         `json:"number"`
+	PatchUrl           string                        `json:"patch_url"`
+	RequestedReviewers []SimpleUser                  `json:"requested_reviewers,omitempty"`
+	RequestedTeams     []TeamSimple                  `json:"requested_teams,omitempty"`
+	ReviewCommentUrl   string                        `json:"review_comment_url"`
+	ReviewCommentsUrl  string                        `json:"review_comments_url"`
+	State              string                        `json:"state"`
+	StatusesUrl        string                        `json:"statuses_url"`
+	Title              string                        `json:"title"`
+	UpdatedAt          string                        `json:"updated_at"`
+	Url                string                        `json:"url"`
+	User               *PullRequestSimpleUser        `json:"user"`
 }
 
 type PullRequestSimpleLinks struct {
@@ -6173,28 +5334,6 @@ type PullRequestSimpleAssignee struct {
 	SubscriptionsUrl  string `json:"subscriptions_url,omitempty"`
 	Type              string `json:"type,omitempty"`
 	Url               string `json:"url,omitempty"`
-}
-
-type PullRequestSimpleAssigneesItem struct {
-	AvatarUrl         string `json:"avatar_url"`
-	EventsUrl         string `json:"events_url"`
-	FollowersUrl      string `json:"followers_url"`
-	FollowingUrl      string `json:"following_url"`
-	GistsUrl          string `json:"gists_url"`
-	GravatarId        string `json:"gravatar_id"`
-	HtmlUrl           string `json:"html_url"`
-	Id                int64  `json:"id"`
-	Login             string `json:"login"`
-	NodeId            string `json:"node_id"`
-	OrganizationsUrl  string `json:"organizations_url"`
-	ReceivedEventsUrl string `json:"received_events_url"`
-	ReposUrl          string `json:"repos_url"`
-	SiteAdmin         bool   `json:"site_admin"`
-	StarredAt         string `json:"starred_at,omitempty"`
-	StarredUrl        string `json:"starred_url"`
-	SubscriptionsUrl  string `json:"subscriptions_url"`
-	Type              string `json:"type"`
-	Url               string `json:"url"`
 }
 
 type PullRequestSimpleBase struct {
@@ -6294,57 +5433,6 @@ type PullRequestSimpleMilestone struct {
 	Title     string `json:"title,omitempty"`
 	UpdatedAt string `json:"updated_at,omitempty"`
 	Url       string `json:"url,omitempty"`
-}
-
-type PullRequestSimpleRequestedReviewersItem struct {
-	AvatarUrl         string `json:"avatar_url"`
-	EventsUrl         string `json:"events_url"`
-	FollowersUrl      string `json:"followers_url"`
-	FollowingUrl      string `json:"following_url"`
-	GistsUrl          string `json:"gists_url"`
-	GravatarId        string `json:"gravatar_id"`
-	HtmlUrl           string `json:"html_url"`
-	Id                int64  `json:"id"`
-	Login             string `json:"login"`
-	NodeId            string `json:"node_id"`
-	OrganizationsUrl  string `json:"organizations_url"`
-	ReceivedEventsUrl string `json:"received_events_url"`
-	ReposUrl          string `json:"repos_url"`
-	SiteAdmin         bool   `json:"site_admin"`
-	StarredAt         string `json:"starred_at,omitempty"`
-	StarredUrl        string `json:"starred_url"`
-	SubscriptionsUrl  string `json:"subscriptions_url"`
-	Type              string `json:"type"`
-	Url               string `json:"url"`
-}
-
-type PullRequestSimpleRequestedTeamsItem struct {
-
-	// Description of the team
-	Description string `json:"description"`
-	HtmlUrl     string `json:"html_url"`
-
-	// Unique identifier of the team
-	Id int64 `json:"id"`
-
-	// Distinguished Name (DN) that team maps to within LDAP environment
-	LdapDn     string `json:"ldap_dn,omitempty"`
-	MembersUrl string `json:"members_url"`
-
-	// Name of the team
-	Name   string `json:"name"`
-	NodeId string `json:"node_id"`
-
-	// Permission that the team will have for its repositories
-	Permission string `json:"permission"`
-
-	// The level of privacy this team should have
-	Privacy         string `json:"privacy,omitempty"`
-	RepositoriesUrl string `json:"repositories_url"`
-	Slug            string `json:"slug"`
-
-	// URL for the team
-	Url string `json:"url"`
 }
 
 type PullRequestSimpleUser struct {
@@ -6462,8 +5550,8 @@ type ReferrerTraffic struct {
 }
 
 type Release struct {
-	Assets    []ReleaseAssetsItem `json:"assets"`
-	AssetsUrl string              `json:"assets_url"`
+	Assets    []ReleaseAsset `json:"assets"`
+	AssetsUrl string         `json:"assets_url"`
 
 	// Simple User
 	Author    *SimpleUser `json:"author"`
@@ -6508,33 +5596,13 @@ type ReleaseAsset struct {
 	Size   int64  `json:"size"`
 
 	// State of the release asset.
-	State     string                     `json:"state"`
-	UpdatedAt string                     `json:"updated_at"`
-	Uploader  *ReleaseAssetsItemUploader `json:"uploader"`
-	Url       string                     `json:"url"`
+	State     string                `json:"state"`
+	UpdatedAt string                `json:"updated_at"`
+	Uploader  *ReleaseAssetUploader `json:"uploader"`
+	Url       string                `json:"url"`
 }
 
-type ReleaseAssetsItem struct {
-	BrowserDownloadUrl string `json:"browser_download_url"`
-	ContentType        string `json:"content_type"`
-	CreatedAt          string `json:"created_at"`
-	DownloadCount      int64  `json:"download_count"`
-	Id                 int64  `json:"id"`
-	Label              string `json:"label"`
-
-	// The file name of the asset.
-	Name   string `json:"name"`
-	NodeId string `json:"node_id"`
-	Size   int64  `json:"size"`
-
-	// State of the release asset.
-	State     string                     `json:"state"`
-	UpdatedAt string                     `json:"updated_at"`
-	Uploader  *ReleaseAssetsItemUploader `json:"uploader"`
-	Url       string                     `json:"url"`
-}
-
-type ReleaseAssetsItemUploader struct {
+type ReleaseAssetUploader struct {
 	AvatarUrl         string `json:"avatar_url,omitempty"`
 	EventsUrl         string `json:"events_url,omitempty"`
 	FollowersUrl      string `json:"followers_url,omitempty"`
@@ -6749,53 +5817,53 @@ type Repository struct {
 	Id int64 `json:"id"`
 
 	// Whether this repository acts as a template that can be used to generate new repositories.
-	IsTemplate      bool                                        `json:"is_template,omitempty"`
-	IssueCommentUrl string                                      `json:"issue_comment_url"`
-	IssueEventsUrl  string                                      `json:"issue_events_url"`
-	IssuesUrl       string                                      `json:"issues_url"`
-	KeysUrl         string                                      `json:"keys_url"`
-	LabelsUrl       string                                      `json:"labels_url"`
-	Language        string                                      `json:"language"`
-	LanguagesUrl    string                                      `json:"languages_url"`
-	License         *AuthenticationTokenRepositoriesItemLicense `json:"license"`
-	MasterBranch    string                                      `json:"master_branch,omitempty"`
-	MergesUrl       string                                      `json:"merges_url"`
-	MilestonesUrl   string                                      `json:"milestones_url"`
-	MirrorUrl       string                                      `json:"mirror_url"`
+	IsTemplate      bool               `json:"is_template,omitempty"`
+	IssueCommentUrl string             `json:"issue_comment_url"`
+	IssueEventsUrl  string             `json:"issue_events_url"`
+	IssuesUrl       string             `json:"issues_url"`
+	KeysUrl         string             `json:"keys_url"`
+	LabelsUrl       string             `json:"labels_url"`
+	Language        string             `json:"language"`
+	LanguagesUrl    string             `json:"languages_url"`
+	License         *RepositoryLicense `json:"license"`
+	MasterBranch    string             `json:"master_branch,omitempty"`
+	MergesUrl       string             `json:"merges_url"`
+	MilestonesUrl   string             `json:"milestones_url"`
+	MirrorUrl       string             `json:"mirror_url"`
 
 	// The name of the repository.
-	Name             string                                         `json:"name"`
-	NetworkCount     int64                                          `json:"network_count,omitempty"`
-	NodeId           string                                         `json:"node_id"`
-	NotificationsUrl string                                         `json:"notifications_url"`
-	OpenIssues       int64                                          `json:"open_issues"`
-	OpenIssuesCount  int64                                          `json:"open_issues_count"`
-	Owner            *AuthenticationTokenRepositoriesItemOwner      `json:"owner"`
-	Permissions      AuthenticationTokenRepositoriesItemPermissions `json:"permissions,omitempty"`
+	Name             string                `json:"name"`
+	NetworkCount     int64                 `json:"network_count,omitempty"`
+	NodeId           string                `json:"node_id"`
+	NotificationsUrl string                `json:"notifications_url"`
+	OpenIssues       int64                 `json:"open_issues"`
+	OpenIssuesCount  int64                 `json:"open_issues_count"`
+	Owner            *RepositoryOwner      `json:"owner"`
+	Permissions      RepositoryPermissions `json:"permissions,omitempty"`
 
 	// Whether the repository is private or public.
-	Private            bool                                                   `json:"private"`
-	PullsUrl           string                                                 `json:"pulls_url"`
-	PushedAt           string                                                 `json:"pushed_at"`
-	ReleasesUrl        string                                                 `json:"releases_url"`
-	Size               int64                                                  `json:"size"`
-	SshUrl             string                                                 `json:"ssh_url"`
-	StargazersCount    int64                                                  `json:"stargazers_count"`
-	StargazersUrl      string                                                 `json:"stargazers_url"`
-	StarredAt          string                                                 `json:"starred_at,omitempty"`
-	StatusesUrl        string                                                 `json:"statuses_url"`
-	SubscribersCount   int64                                                  `json:"subscribers_count,omitempty"`
-	SubscribersUrl     string                                                 `json:"subscribers_url"`
-	SubscriptionUrl    string                                                 `json:"subscription_url"`
-	SvnUrl             string                                                 `json:"svn_url"`
-	TagsUrl            string                                                 `json:"tags_url"`
-	TeamsUrl           string                                                 `json:"teams_url"`
-	TempCloneToken     string                                                 `json:"temp_clone_token,omitempty"`
-	TemplateRepository *AuthenticationTokenRepositoriesItemTemplateRepository `json:"template_repository,omitempty"`
-	Topics             []string                                               `json:"topics,omitempty"`
-	TreesUrl           string                                                 `json:"trees_url"`
-	UpdatedAt          string                                                 `json:"updated_at"`
-	Url                string                                                 `json:"url"`
+	Private            bool                          `json:"private"`
+	PullsUrl           string                        `json:"pulls_url"`
+	PushedAt           string                        `json:"pushed_at"`
+	ReleasesUrl        string                        `json:"releases_url"`
+	Size               int64                         `json:"size"`
+	SshUrl             string                        `json:"ssh_url"`
+	StargazersCount    int64                         `json:"stargazers_count"`
+	StargazersUrl      string                        `json:"stargazers_url"`
+	StarredAt          string                        `json:"starred_at,omitempty"`
+	StatusesUrl        string                        `json:"statuses_url"`
+	SubscribersCount   int64                         `json:"subscribers_count,omitempty"`
+	SubscribersUrl     string                        `json:"subscribers_url"`
+	SubscriptionUrl    string                        `json:"subscription_url"`
+	SvnUrl             string                        `json:"svn_url"`
+	TagsUrl            string                        `json:"tags_url"`
+	TeamsUrl           string                        `json:"teams_url"`
+	TempCloneToken     string                        `json:"temp_clone_token,omitempty"`
+	TemplateRepository *RepositoryTemplateRepository `json:"template_repository,omitempty"`
+	Topics             []string                      `json:"topics,omitempty"`
+	TreesUrl           string                        `json:"trees_url"`
+	UpdatedAt          string                        `json:"updated_at"`
+	Url                string                        `json:"url"`
 
 	// The repository visibility: public, private, or internal.
 	Visibility    string `json:"visibility,omitempty"`
@@ -6894,6 +5962,45 @@ type RepositoryInvitationInviter struct {
 	Url               string `json:"url,omitempty"`
 }
 
+type RepositoryLicense struct {
+	HtmlUrl string `json:"html_url,omitempty"`
+	Key     string `json:"key,omitempty"`
+	Name    string `json:"name,omitempty"`
+	NodeId  string `json:"node_id,omitempty"`
+	SpdxId  string `json:"spdx_id,omitempty"`
+	Url     string `json:"url,omitempty"`
+}
+
+type RepositoryOwner struct {
+	AvatarUrl         string `json:"avatar_url,omitempty"`
+	EventsUrl         string `json:"events_url,omitempty"`
+	FollowersUrl      string `json:"followers_url,omitempty"`
+	FollowingUrl      string `json:"following_url,omitempty"`
+	GistsUrl          string `json:"gists_url,omitempty"`
+	GravatarId        string `json:"gravatar_id,omitempty"`
+	HtmlUrl           string `json:"html_url,omitempty"`
+	Id                int64  `json:"id,omitempty"`
+	Login             string `json:"login,omitempty"`
+	NodeId            string `json:"node_id,omitempty"`
+	OrganizationsUrl  string `json:"organizations_url,omitempty"`
+	ReceivedEventsUrl string `json:"received_events_url,omitempty"`
+	ReposUrl          string `json:"repos_url,omitempty"`
+	SiteAdmin         bool   `json:"site_admin,omitempty"`
+	StarredAt         string `json:"starred_at,omitempty"`
+	StarredUrl        string `json:"starred_url,omitempty"`
+	SubscriptionsUrl  string `json:"subscriptions_url,omitempty"`
+	Type              string `json:"type,omitempty"`
+	Url               string `json:"url,omitempty"`
+}
+
+type RepositoryPermissions struct {
+	Admin    bool `json:"admin"`
+	Maintain bool `json:"maintain,omitempty"`
+	Pull     bool `json:"pull"`
+	Push     bool `json:"push"`
+	Triage   bool `json:"triage,omitempty"`
+}
+
 type RepositorySubscription struct {
 	CreatedAt string `json:"created_at"`
 
@@ -6905,6 +6012,117 @@ type RepositorySubscription struct {
 	// Determines if notifications should be received from this repository.
 	Subscribed bool   `json:"subscribed"`
 	Url        string `json:"url"`
+}
+
+type RepositoryTemplateRepository struct {
+	AllowMergeCommit    bool                                    `json:"allow_merge_commit,omitempty"`
+	AllowRebaseMerge    bool                                    `json:"allow_rebase_merge,omitempty"`
+	AllowSquashMerge    bool                                    `json:"allow_squash_merge,omitempty"`
+	ArchiveUrl          string                                  `json:"archive_url,omitempty"`
+	Archived            bool                                    `json:"archived,omitempty"`
+	AssigneesUrl        string                                  `json:"assignees_url,omitempty"`
+	BlobsUrl            string                                  `json:"blobs_url,omitempty"`
+	BranchesUrl         string                                  `json:"branches_url,omitempty"`
+	CloneUrl            string                                  `json:"clone_url,omitempty"`
+	CollaboratorsUrl    string                                  `json:"collaborators_url,omitempty"`
+	CommentsUrl         string                                  `json:"comments_url,omitempty"`
+	CommitsUrl          string                                  `json:"commits_url,omitempty"`
+	CompareUrl          string                                  `json:"compare_url,omitempty"`
+	ContentsUrl         string                                  `json:"contents_url,omitempty"`
+	ContributorsUrl     string                                  `json:"contributors_url,omitempty"`
+	CreatedAt           string                                  `json:"created_at,omitempty"`
+	DefaultBranch       string                                  `json:"default_branch,omitempty"`
+	DeleteBranchOnMerge bool                                    `json:"delete_branch_on_merge,omitempty"`
+	DeploymentsUrl      string                                  `json:"deployments_url,omitempty"`
+	Description         string                                  `json:"description,omitempty"`
+	Disabled            bool                                    `json:"disabled,omitempty"`
+	DownloadsUrl        string                                  `json:"downloads_url,omitempty"`
+	EventsUrl           string                                  `json:"events_url,omitempty"`
+	Fork                bool                                    `json:"fork,omitempty"`
+	ForksCount          int64                                   `json:"forks_count,omitempty"`
+	ForksUrl            string                                  `json:"forks_url,omitempty"`
+	FullName            string                                  `json:"full_name,omitempty"`
+	GitCommitsUrl       string                                  `json:"git_commits_url,omitempty"`
+	GitRefsUrl          string                                  `json:"git_refs_url,omitempty"`
+	GitTagsUrl          string                                  `json:"git_tags_url,omitempty"`
+	GitUrl              string                                  `json:"git_url,omitempty"`
+	HasDownloads        bool                                    `json:"has_downloads,omitempty"`
+	HasIssues           bool                                    `json:"has_issues,omitempty"`
+	HasPages            bool                                    `json:"has_pages,omitempty"`
+	HasProjects         bool                                    `json:"has_projects,omitempty"`
+	HasWiki             bool                                    `json:"has_wiki,omitempty"`
+	Homepage            string                                  `json:"homepage,omitempty"`
+	HooksUrl            string                                  `json:"hooks_url,omitempty"`
+	HtmlUrl             string                                  `json:"html_url,omitempty"`
+	Id                  int64                                   `json:"id,omitempty"`
+	IsTemplate          bool                                    `json:"is_template,omitempty"`
+	IssueCommentUrl     string                                  `json:"issue_comment_url,omitempty"`
+	IssueEventsUrl      string                                  `json:"issue_events_url,omitempty"`
+	IssuesUrl           string                                  `json:"issues_url,omitempty"`
+	KeysUrl             string                                  `json:"keys_url,omitempty"`
+	LabelsUrl           string                                  `json:"labels_url,omitempty"`
+	Language            string                                  `json:"language,omitempty"`
+	LanguagesUrl        string                                  `json:"languages_url,omitempty"`
+	MergesUrl           string                                  `json:"merges_url,omitempty"`
+	MilestonesUrl       string                                  `json:"milestones_url,omitempty"`
+	MirrorUrl           string                                  `json:"mirror_url,omitempty"`
+	Name                string                                  `json:"name,omitempty"`
+	NetworkCount        int64                                   `json:"network_count,omitempty"`
+	NodeId              string                                  `json:"node_id,omitempty"`
+	NotificationsUrl    string                                  `json:"notifications_url,omitempty"`
+	OpenIssuesCount     int64                                   `json:"open_issues_count,omitempty"`
+	Owner               RepositoryTemplateRepositoryOwner       `json:"owner,omitempty"`
+	Permissions         RepositoryTemplateRepositoryPermissions `json:"permissions,omitempty"`
+	Private             bool                                    `json:"private,omitempty"`
+	PullsUrl            string                                  `json:"pulls_url,omitempty"`
+	PushedAt            string                                  `json:"pushed_at,omitempty"`
+	ReleasesUrl         string                                  `json:"releases_url,omitempty"`
+	Size                int64                                   `json:"size,omitempty"`
+	SshUrl              string                                  `json:"ssh_url,omitempty"`
+	StargazersCount     int64                                   `json:"stargazers_count,omitempty"`
+	StargazersUrl       string                                  `json:"stargazers_url,omitempty"`
+	StatusesUrl         string                                  `json:"statuses_url,omitempty"`
+	SubscribersCount    int64                                   `json:"subscribers_count,omitempty"`
+	SubscribersUrl      string                                  `json:"subscribers_url,omitempty"`
+	SubscriptionUrl     string                                  `json:"subscription_url,omitempty"`
+	SvnUrl              string                                  `json:"svn_url,omitempty"`
+	TagsUrl             string                                  `json:"tags_url,omitempty"`
+	TeamsUrl            string                                  `json:"teams_url,omitempty"`
+	TempCloneToken      string                                  `json:"temp_clone_token,omitempty"`
+	TemplateRepository  string                                  `json:"template_repository,omitempty"`
+	Topics              []string                                `json:"topics,omitempty"`
+	TreesUrl            string                                  `json:"trees_url,omitempty"`
+	UpdatedAt           string                                  `json:"updated_at,omitempty"`
+	Url                 string                                  `json:"url,omitempty"`
+	Visibility          string                                  `json:"visibility,omitempty"`
+	WatchersCount       int64                                   `json:"watchers_count,omitempty"`
+}
+
+type RepositoryTemplateRepositoryOwner struct {
+	AvatarUrl         string `json:"avatar_url,omitempty"`
+	EventsUrl         string `json:"events_url,omitempty"`
+	FollowersUrl      string `json:"followers_url,omitempty"`
+	FollowingUrl      string `json:"following_url,omitempty"`
+	GistsUrl          string `json:"gists_url,omitempty"`
+	GravatarId        string `json:"gravatar_id,omitempty"`
+	HtmlUrl           string `json:"html_url,omitempty"`
+	Id                int64  `json:"id,omitempty"`
+	Login             string `json:"login,omitempty"`
+	NodeId            string `json:"node_id,omitempty"`
+	OrganizationsUrl  string `json:"organizations_url,omitempty"`
+	ReceivedEventsUrl string `json:"received_events_url,omitempty"`
+	ReposUrl          string `json:"repos_url,omitempty"`
+	SiteAdmin         bool   `json:"site_admin,omitempty"`
+	StarredUrl        string `json:"starred_url,omitempty"`
+	SubscriptionsUrl  string `json:"subscriptions_url,omitempty"`
+	Type              string `json:"type,omitempty"`
+	Url               string `json:"url,omitempty"`
+}
+
+type RepositoryTemplateRepositoryPermissions struct {
+	Admin bool `json:"admin,omitempty"`
+	Pull  bool `json:"pull,omitempty"`
+	Push  bool `json:"push,omitempty"`
 }
 
 type ReviewComment struct {
@@ -7020,13 +6238,13 @@ type ScimUser struct {
 	Active bool `json:"active"`
 
 	// user emails
-	Emails []ScimUserListResourcesItemEmailsItem `json:"emails"`
+	Emails []ScimUserEmailsItem `json:"emails"`
 
 	// The ID of the User.
 	ExternalId string `json:"externalId"`
 
 	// associated groups
-	Groups []ScimUserListResourcesItemGroupsItem `json:"groups,omitempty"`
+	Groups []ScimUserGroupsItem `json:"groups,omitempty"`
 
 	// Unique identifier of an external identity
 	Id   string       `json:"id"`
@@ -7034,7 +6252,7 @@ type ScimUser struct {
 	Name ScimUserName `json:"name"`
 
 	// Set of operations to be performed
-	Operations []ScimUserListResourcesItemOperationsItem `json:"operations,omitempty"`
+	Operations []ScimUserOperationsItem `json:"operations,omitempty"`
 
 	// The ID of the organization.
 	OrganizationId int64 `json:"organization_id,omitempty"`
@@ -7057,61 +6275,13 @@ type ScimUserGroupsItem struct {
 }
 
 type ScimUserList struct {
-	Resources    []ScimUserListResourcesItem `json:"Resources"`
-	ItemsPerPage int64                       `json:"itemsPerPage"`
+	Resources    []ScimUser `json:"Resources"`
+	ItemsPerPage int64      `json:"itemsPerPage"`
 
 	// SCIM schema used.
 	Schemas      []string `json:"schemas"`
 	StartIndex   int64    `json:"startIndex"`
 	TotalResults int64    `json:"totalResults"`
-}
-
-type ScimUserListResourcesItem struct {
-
-	// The active status of the User.
-	Active bool `json:"active"`
-
-	// user emails
-	Emails []ScimUserListResourcesItemEmailsItem `json:"emails"`
-
-	// The ID of the User.
-	ExternalId string `json:"externalId"`
-
-	// associated groups
-	Groups []ScimUserListResourcesItemGroupsItem `json:"groups,omitempty"`
-
-	// Unique identifier of an external identity
-	Id   string       `json:"id"`
-	Meta ScimUserMeta `json:"meta"`
-	Name ScimUserName `json:"name"`
-
-	// Set of operations to be performed
-	Operations []ScimUserListResourcesItemOperationsItem `json:"operations,omitempty"`
-
-	// The ID of the organization.
-	OrganizationId int64 `json:"organization_id,omitempty"`
-
-	// SCIM schema used.
-	Schemas []string `json:"schemas"`
-
-	// Configured by the admin. Could be an email, login, or username
-	UserName string `json:"userName"`
-}
-
-type ScimUserListResourcesItemEmailsItem struct {
-	Primary bool   `json:"primary,omitempty"`
-	Value   string `json:"value"`
-}
-
-type ScimUserListResourcesItemGroupsItem struct {
-	Display string `json:"display,omitempty"`
-	Value   string `json:"value,omitempty"`
-}
-
-type ScimUserListResourcesItemOperationsItem struct {
-	Op    string                      `json:"op"`
-	Path  string                      `json:"path,omitempty"`
-	Value ScimUserOperationsItemValue `json:"value,omitempty"`
 }
 
 type ScimUserMeta struct {
@@ -7371,18 +6541,18 @@ type TagCommit struct {
 }
 
 type Team struct {
-	Description     string                                                                         `json:"description"`
-	HtmlUrl         string                                                                         `json:"html_url"`
-	Id              int64                                                                          `json:"id"`
-	MembersUrl      string                                                                         `json:"members_url"`
-	Name            string                                                                         `json:"name"`
-	NodeId          string                                                                         `json:"node_id"`
-	Parent          *ProtectedBranchRequiredPullRequestReviewsDismissalRestrictionsTeamsItemParent `json:"parent,omitempty"`
-	Permission      string                                                                         `json:"permission"`
-	Privacy         string                                                                         `json:"privacy,omitempty"`
-	RepositoriesUrl string                                                                         `json:"repositories_url"`
-	Slug            string                                                                         `json:"slug"`
-	Url             string                                                                         `json:"url"`
+	Description     string      `json:"description"`
+	HtmlUrl         string      `json:"html_url"`
+	Id              int64       `json:"id"`
+	MembersUrl      string      `json:"members_url"`
+	Name            string      `json:"name"`
+	NodeId          string      `json:"node_id"`
+	Parent          *TeamParent `json:"parent,omitempty"`
+	Permission      string      `json:"permission"`
+	Privacy         string      `json:"privacy,omitempty"`
+	RepositoriesUrl string      `json:"repositories_url"`
+	Slug            string      `json:"slug"`
+	Url             string      `json:"url"`
 }
 
 type TeamDiscussion struct {
@@ -7562,6 +6732,35 @@ type TeamMembership struct {
 	Role  string `json:"role"`
 	State string `json:"state"`
 	Url   string `json:"url"`
+}
+
+type TeamParent struct {
+
+	// Description of the team
+	Description string `json:"description,omitempty"`
+	HtmlUrl     string `json:"html_url,omitempty"`
+
+	// Unique identifier of the team
+	Id int64 `json:"id,omitempty"`
+
+	// Distinguished Name (DN) that team maps to within LDAP environment
+	LdapDn     string `json:"ldap_dn,omitempty"`
+	MembersUrl string `json:"members_url,omitempty"`
+
+	// Name of the team
+	Name   string `json:"name,omitempty"`
+	NodeId string `json:"node_id,omitempty"`
+
+	// Permission that the team will have for its repositories
+	Permission string `json:"permission,omitempty"`
+
+	// The level of privacy this team should have
+	Privacy         string `json:"privacy,omitempty"`
+	RepositoriesUrl string `json:"repositories_url,omitempty"`
+	Slug            string `json:"slug,omitempty"`
+
+	// URL for the team
+	Url string `json:"url,omitempty"`
 }
 
 type TeamProject struct {
@@ -8118,15 +7317,9 @@ type Verification struct {
 }
 
 type ViewTraffic struct {
-	Count   int64                  `json:"count"`
-	Uniques int64                  `json:"uniques"`
-	Views   []ViewTrafficViewsItem `json:"views"`
-}
-
-type ViewTrafficViewsItem struct {
-	Count     int64  `json:"count"`
-	Timestamp string `json:"timestamp"`
-	Uniques   int64  `json:"uniques"`
+	Count   int64     `json:"count"`
+	Uniques int64     `json:"uniques"`
+	Views   []Traffic `json:"views"`
 }
 
 type Workflow struct {
@@ -8176,9 +7369,9 @@ type WorkflowRun struct {
 	JobsUrl string `json:"jobs_url"`
 
 	// The URL to download the logs for the workflow run.
-	LogsUrl      string                        `json:"logs_url"`
-	NodeId       string                        `json:"node_id"`
-	PullRequests []WorkflowRunPullRequestsItem `json:"pull_requests"`
+	LogsUrl      string               `json:"logs_url"`
+	NodeId       string               `json:"node_id"`
+	PullRequests []PullRequestMinimal `json:"pull_requests"`
 
 	// Minimal Repository
 	Repository MinimalRepository `json:"repository"`
@@ -8199,14 +7392,6 @@ type WorkflowRun struct {
 
 	// The URL to the workflow.
 	WorkflowUrl string `json:"workflow_url"`
-}
-
-type WorkflowRunPullRequestsItem struct {
-	Base   CheckSuitePullRequestsItemBase `json:"base"`
-	Head   CheckSuitePullRequestsItemHead `json:"head"`
-	Id     int64                          `json:"id"`
-	Number int64                          `json:"number"`
-	Url    string                         `json:"url"`
 }
 
 type WorkflowRunUsage struct {

--- a/generator/gen.go
+++ b/generator/gen.go
@@ -45,7 +45,8 @@ func addRequestFunc(file *jen.File, endpoint *model.Endpoint) {
 			group.If(jen.Id("err != nil")).Block(jen.Id("return nil, err"))
 			group.Id("err").Op("=").Id("r.decodeBody(nil)")
 		case len(responseCodesWithBodies(endpoint)) > 0:
-			group.Id("resp").Dot("Data").Op("=").Id(respBodyStructName(endpoint)).Block()
+			bodyType := respBodyType(endpoint)
+			group.Id("resp").Dot("Data").Op("=").Qual(bodyType.pkg, bodyType.name).Block()
 			group.Id("err").Op("=").Id("r.decodeBody(&resp.Data)")
 		default:
 			group.Id("err").Op("=").Id("r.decodeBody(nil)")

--- a/generator/gen.go
+++ b/generator/gen.go
@@ -46,7 +46,11 @@ func addRequestFunc(file *jen.File, endpoint *model.Endpoint) {
 			group.Id("err").Op("=").Id("r.decodeBody(nil)")
 		case len(responseCodesWithBodies(endpoint)) > 0:
 			bodyType := respBodyType(endpoint)
-			group.Id("resp").Dot("Data").Op("=").Qual(bodyType.pkg, bodyType.name).Block()
+			group.Id("resp").Dot("Data").Op("=").Do(func(stmt *jen.Statement) {
+				if bodyType.slice {
+					stmt.Op("[]")
+				}
+			}).Qual(bodyType.pkg, bodyType.name).Block()
 			group.Id("err").Op("=").Id("r.decodeBody(&resp.Data)")
 		default:
 			group.Id("err").Op("=").Id("r.decodeBody(nil)")

--- a/generator/gen_test.go
+++ b/generator/gen_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/willabides/octo-go/generator/internal/model"
 )
 
 func TestAllEndpointAttributesHaveName(t *testing.T) {
@@ -31,4 +32,28 @@ func Test_run(t *testing.T) {
 	pkgName := "octo"
 	err = run(schemaPath, outputPath, pkgPath, pkgName)
 	require.NoError(t, err)
+}
+
+func Test_respBodyType(t *testing.T) {
+	endpoint := &model.Endpoint{
+		Name:    "blah-blah",
+		Concern: "puppies",
+		Responses: map[int]*model.Response{
+			200: {
+				Body: &model.ParamSchema{
+					Ref:  "",
+					Type: model.ParamTypeArray,
+					ItemSchema: &model.ParamSchema{
+						Ref: "#/components/schemas/foo-bar",
+					},
+				},
+			},
+		},
+	}
+	got := respBodyType(endpoint)
+	require.Equal(t, &qualifiedType{
+		pkg:   "github.com/willabides/octo-go/components",
+		name:  "FooBar",
+		slice: true,
+	}, got)
 }

--- a/generator/internal/model/openapi/openapi.go
+++ b/generator/internal/model/openapi/openapi.go
@@ -110,6 +110,9 @@ func prepareComponentSchemaObj(swagger *openapi3.Swagger, parentName string, sch
 			itemsRef := val.Items
 			itemsVal := itemsRef.Value
 			fullName := fmt.Sprintf("%s-%s-item", parentName, propName)
+			if strings.HasPrefix(itemsRef.Ref, "#/components/schemas/") {
+				fullName = strings.TrimPrefix(itemsRef.Ref, "#/components/schemas/")
+			}
 			wrongType := false
 			switch opSchemaType(itemsVal) {
 			case model.ParamTypeObject, model.ParamTypeOneOf:

--- a/generator/response.go
+++ b/generator/response.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/dave/jennifer/jen"
 	"github.com/google/go-cmp/cmp"
@@ -38,14 +39,36 @@ func addResponse(file *jen.File, endpoint *model.Endpoint) {
 	file.Type().Id(structName).StructFunc(func(group *jen.Group) {
 		group.Id("response")
 		group.Id("request").Op("*").Id(reqStructName(endpoint))
-		switch {
-		case endpointHasAttribute(endpoint, attrNoResponseBody):
-		case len(responseCodesWithBodies(endpoint)) > 0:
-			group.Id("Data").Id(respBodyStructName(endpoint))
-		case endpointHasAttribute(endpoint, attrBoolean):
+		if endpointHasAttribute(endpoint, attrNoResponseBody) {
+			return
+		}
+		bodyType := respBodyType(endpoint)
+		if bodyType != nil {
+			group.Id("Data").Qual(bodyType.pkg, bodyType.name)
+		}
+		if endpointHasAttribute(endpoint, attrBoolean) {
 			group.Id("Data").Bool()
 		}
 	})
+}
+
+func respBodyType(endpoint *model.Endpoint) *qualifiedType {
+	codeBodies := responseCodesWithBodies(endpoint)
+	if len(codeBodies) == 0 {
+		return nil
+	}
+	body := endpoint.Responses[codeBodies[0]].Body
+	if strings.HasPrefix(body.Ref, "#/components/schemas/") {
+		nm := strings.TrimPrefix(body.Ref, "#/components/schemas/")
+		return &qualifiedType{
+			pkg:  "github.com/willabides/octo-go/components",
+			name: toExportedName(nm),
+		}
+	}
+	return &qualifiedType{
+		pkg:  "github.com/willabides/octo-go",
+		name: toExportedName(fmt.Sprintf("%s-%s-response-body", endpoint.Concern, endpoint.Name)),
+	}
 }
 
 func responseCodesWithBodies(endpoint *model.Endpoint) []int {
@@ -75,6 +98,10 @@ func responseCodesWithBodies(endpoint *model.Endpoint) []int {
 
 func addResponseBody(file *jen.File, endpoint *model.Endpoint) {
 	if endpointHasAttribute(endpoint, attrNoResponseBody) {
+		return
+	}
+	bt := respBodyType(endpoint)
+	if bt != nil && bt.pkg == "github.com/willabides/octo-go/components" {
 		return
 	}
 	bodyCodes := responseCodesWithBodies(endpoint)

--- a/octotest/octotest_test.go
+++ b/octotest/octotest_test.go
@@ -31,15 +31,15 @@ func TestPaging(t *testing.T) {
 		Page:    octo.Int64(3),
 		PerPage: octo.Int64(2),
 	}
-	res1 := &octo.IssuesListForRepoResponseBody{
+	res1 := []*components.IssueSimple{
 		{Id: 1},
 		{Id: 2},
 	}
-	res2 := &octo.IssuesListForRepoResponseBody{
+	res2 := []*components.IssueSimple{
 		{Id: 3},
 		{Id: 4},
 	}
-	res3 := &octo.IssuesListForRepoResponseBody{
+	res3 := []*components.IssueSimple{
 		{Id: 5},
 		{Id: 6},
 	}

--- a/octotest/octotest_test.go
+++ b/octotest/octotest_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/willabides/octo-go"
+	"github.com/willabides/octo-go/components"
 )
 
 func TestPaging(t *testing.T) {
@@ -81,8 +82,8 @@ func TestDistinguishesBodies(t *testing.T) {
 			HeadSha: octo.String("deadbeef"),
 		},
 	}
-	respBody1 := octo.ChecksCreateResponseBody{Conclusion: "conclusion 1"}
-	respBody2 := octo.ChecksCreateResponseBody{Conclusion: "conclusion 2"}
+	respBody1 := components.CheckRun{Conclusion: "conclusion 1"}
+	respBody2 := components.CheckRun{Conclusion: "conclusion 2"}
 	ctx := context.Background()
 	server := New(octo.PreserveResponseBody())
 	t.Cleanup(server.Finish)

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -26,9 +26,8 @@ var unmarshalResponseBodyTests []unmarshalResponseBodyTest
 
 func TestUnmarshalResponseBody(t *testing.T) {
 	skippers := map[string]bool{
-		"octo.ActivityListStargazersForRepoResponseBody":               true,
-		"octo.ActivityListReposStarredByAuthenticatedUserResponseBody": true,
-		"octo.ActivityListReposStarredByUserResponseBody":              true,
+		"[]components.StarredRepository": true,
+		"[]components.Stargazer":         true,
 	}
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -26,9 +26,9 @@ var unmarshalResponseBodyTests []unmarshalResponseBodyTest
 
 func TestUnmarshalResponseBody(t *testing.T) {
 	skippers := map[string]bool{
-		"ActivityListStargazersForRepoResponseBody":               true,
-		"ActivityListReposStarredByAuthenticatedUserResponseBody": true,
-		"ActivityListReposStarredByUserResponseBody":              true,
+		"octo.ActivityListStargazersForRepoResponseBody":               true,
+		"octo.ActivityListReposStarredByAuthenticatedUserResponseBody": true,
+		"octo.ActivityListReposStarredByUserResponseBody":              true,
 	}
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")

--- a/zz_actions_gen.go
+++ b/zz_actions_gen.go
@@ -584,7 +584,7 @@ func ActionsCreateRegistrationTokenForOrg(ctx context.Context, req *ActionsCreat
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActionsCreateRegistrationTokenForOrgResponseBody{}
+	resp.Data = components.AuthenticationToken{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -673,13 +673,6 @@ func (r *ActionsCreateRegistrationTokenForOrgReq) Rel(link RelName, resp *Action
 }
 
 /*
-ActionsCreateRegistrationTokenForOrgResponseBody is a response body for ActionsCreateRegistrationTokenForOrg
-
-https://developer.github.com/v3/actions/self-hosted-runners/#create-a-registration-token-for-an-organization
-*/
-type ActionsCreateRegistrationTokenForOrgResponseBody components.AuthenticationToken
-
-/*
 ActionsCreateRegistrationTokenForOrgResponse is a response for ActionsCreateRegistrationTokenForOrg
 
 https://developer.github.com/v3/actions/self-hosted-runners/#create-a-registration-token-for-an-organization
@@ -687,7 +680,7 @@ https://developer.github.com/v3/actions/self-hosted-runners/#create-a-registrati
 type ActionsCreateRegistrationTokenForOrgResponse struct {
 	response
 	request *ActionsCreateRegistrationTokenForOrgReq
-	Data    ActionsCreateRegistrationTokenForOrgResponseBody
+	Data    components.AuthenticationToken
 }
 
 /*
@@ -711,7 +704,7 @@ func ActionsCreateRegistrationTokenForRepo(ctx context.Context, req *ActionsCrea
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActionsCreateRegistrationTokenForRepoResponseBody{}
+	resp.Data = components.AuthenticationToken{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -801,13 +794,6 @@ func (r *ActionsCreateRegistrationTokenForRepoReq) Rel(link RelName, resp *Actio
 }
 
 /*
-ActionsCreateRegistrationTokenForRepoResponseBody is a response body for ActionsCreateRegistrationTokenForRepo
-
-https://developer.github.com/v3/actions/self-hosted-runners/#create-a-registration-token-for-a-repository
-*/
-type ActionsCreateRegistrationTokenForRepoResponseBody components.AuthenticationToken
-
-/*
 ActionsCreateRegistrationTokenForRepoResponse is a response for ActionsCreateRegistrationTokenForRepo
 
 https://developer.github.com/v3/actions/self-hosted-runners/#create-a-registration-token-for-a-repository
@@ -815,7 +801,7 @@ https://developer.github.com/v3/actions/self-hosted-runners/#create-a-registrati
 type ActionsCreateRegistrationTokenForRepoResponse struct {
 	response
 	request *ActionsCreateRegistrationTokenForRepoReq
-	Data    ActionsCreateRegistrationTokenForRepoResponseBody
+	Data    components.AuthenticationToken
 }
 
 /*
@@ -839,7 +825,7 @@ func ActionsCreateRemoveTokenForOrg(ctx context.Context, req *ActionsCreateRemov
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActionsCreateRemoveTokenForOrgResponseBody{}
+	resp.Data = components.AuthenticationToken{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -928,13 +914,6 @@ func (r *ActionsCreateRemoveTokenForOrgReq) Rel(link RelName, resp *ActionsCreat
 }
 
 /*
-ActionsCreateRemoveTokenForOrgResponseBody is a response body for ActionsCreateRemoveTokenForOrg
-
-https://developer.github.com/v3/actions/self-hosted-runners/#create-a-remove-token-for-an-organization
-*/
-type ActionsCreateRemoveTokenForOrgResponseBody components.AuthenticationToken
-
-/*
 ActionsCreateRemoveTokenForOrgResponse is a response for ActionsCreateRemoveTokenForOrg
 
 https://developer.github.com/v3/actions/self-hosted-runners/#create-a-remove-token-for-an-organization
@@ -942,7 +921,7 @@ https://developer.github.com/v3/actions/self-hosted-runners/#create-a-remove-tok
 type ActionsCreateRemoveTokenForOrgResponse struct {
 	response
 	request *ActionsCreateRemoveTokenForOrgReq
-	Data    ActionsCreateRemoveTokenForOrgResponseBody
+	Data    components.AuthenticationToken
 }
 
 /*
@@ -966,7 +945,7 @@ func ActionsCreateRemoveTokenForRepo(ctx context.Context, req *ActionsCreateRemo
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActionsCreateRemoveTokenForRepoResponseBody{}
+	resp.Data = components.AuthenticationToken{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1056,13 +1035,6 @@ func (r *ActionsCreateRemoveTokenForRepoReq) Rel(link RelName, resp *ActionsCrea
 }
 
 /*
-ActionsCreateRemoveTokenForRepoResponseBody is a response body for ActionsCreateRemoveTokenForRepo
-
-https://developer.github.com/v3/actions/self-hosted-runners/#create-a-remove-token-for-a-repository
-*/
-type ActionsCreateRemoveTokenForRepoResponseBody components.AuthenticationToken
-
-/*
 ActionsCreateRemoveTokenForRepoResponse is a response for ActionsCreateRemoveTokenForRepo
 
 https://developer.github.com/v3/actions/self-hosted-runners/#create-a-remove-token-for-a-repository
@@ -1070,7 +1042,7 @@ https://developer.github.com/v3/actions/self-hosted-runners/#create-a-remove-tok
 type ActionsCreateRemoveTokenForRepoResponse struct {
 	response
 	request *ActionsCreateRemoveTokenForRepoReq
-	Data    ActionsCreateRemoveTokenForRepoResponseBody
+	Data    components.AuthenticationToken
 }
 
 /*
@@ -2448,7 +2420,7 @@ func ActionsGetArtifact(ctx context.Context, req *ActionsGetArtifactReq, opt ...
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActionsGetArtifactResponseBody{}
+	resp.Data = components.Artifact{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2541,13 +2513,6 @@ func (r *ActionsGetArtifactReq) Rel(link RelName, resp *ActionsGetArtifactRespon
 }
 
 /*
-ActionsGetArtifactResponseBody is a response body for ActionsGetArtifact
-
-https://developer.github.com/v3/actions/artifacts/#get-an-artifact
-*/
-type ActionsGetArtifactResponseBody components.Artifact
-
-/*
 ActionsGetArtifactResponse is a response for ActionsGetArtifact
 
 https://developer.github.com/v3/actions/artifacts/#get-an-artifact
@@ -2555,7 +2520,7 @@ https://developer.github.com/v3/actions/artifacts/#get-an-artifact
 type ActionsGetArtifactResponse struct {
 	response
 	request *ActionsGetArtifactReq
-	Data    ActionsGetArtifactResponseBody
+	Data    components.Artifact
 }
 
 /*
@@ -2579,7 +2544,7 @@ func ActionsGetJobForWorkflowRun(ctx context.Context, req *ActionsGetJobForWorkf
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActionsGetJobForWorkflowRunResponseBody{}
+	resp.Data = components.Job{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2672,13 +2637,6 @@ func (r *ActionsGetJobForWorkflowRunReq) Rel(link RelName, resp *ActionsGetJobFo
 }
 
 /*
-ActionsGetJobForWorkflowRunResponseBody is a response body for ActionsGetJobForWorkflowRun
-
-https://developer.github.com/v3/actions/workflow-jobs/#get-a-job-for-a-workflow-run
-*/
-type ActionsGetJobForWorkflowRunResponseBody components.Job
-
-/*
 ActionsGetJobForWorkflowRunResponse is a response for ActionsGetJobForWorkflowRun
 
 https://developer.github.com/v3/actions/workflow-jobs/#get-a-job-for-a-workflow-run
@@ -2686,7 +2644,7 @@ https://developer.github.com/v3/actions/workflow-jobs/#get-a-job-for-a-workflow-
 type ActionsGetJobForWorkflowRunResponse struct {
 	response
 	request *ActionsGetJobForWorkflowRunReq
-	Data    ActionsGetJobForWorkflowRunResponseBody
+	Data    components.Job
 }
 
 /*
@@ -2710,7 +2668,7 @@ func ActionsGetOrgPublicKey(ctx context.Context, req *ActionsGetOrgPublicKeyReq,
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActionsGetOrgPublicKeyResponseBody{}
+	resp.Data = components.ActionsPublicKey{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2799,13 +2757,6 @@ func (r *ActionsGetOrgPublicKeyReq) Rel(link RelName, resp *ActionsGetOrgPublicK
 }
 
 /*
-ActionsGetOrgPublicKeyResponseBody is a response body for ActionsGetOrgPublicKey
-
-https://developer.github.com/v3/actions/secrets/#get-an-organization-public-key
-*/
-type ActionsGetOrgPublicKeyResponseBody components.ActionsPublicKey
-
-/*
 ActionsGetOrgPublicKeyResponse is a response for ActionsGetOrgPublicKey
 
 https://developer.github.com/v3/actions/secrets/#get-an-organization-public-key
@@ -2813,7 +2764,7 @@ https://developer.github.com/v3/actions/secrets/#get-an-organization-public-key
 type ActionsGetOrgPublicKeyResponse struct {
 	response
 	request *ActionsGetOrgPublicKeyReq
-	Data    ActionsGetOrgPublicKeyResponseBody
+	Data    components.ActionsPublicKey
 }
 
 /*
@@ -2837,7 +2788,7 @@ func ActionsGetOrgSecret(ctx context.Context, req *ActionsGetOrgSecretReq, opt .
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActionsGetOrgSecretResponseBody{}
+	resp.Data = components.OrganizationActionsSecret{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2929,13 +2880,6 @@ func (r *ActionsGetOrgSecretReq) Rel(link RelName, resp *ActionsGetOrgSecretResp
 }
 
 /*
-ActionsGetOrgSecretResponseBody is a response body for ActionsGetOrgSecret
-
-https://developer.github.com/v3/actions/secrets/#get-an-organization-secret
-*/
-type ActionsGetOrgSecretResponseBody components.OrganizationActionsSecret
-
-/*
 ActionsGetOrgSecretResponse is a response for ActionsGetOrgSecret
 
 https://developer.github.com/v3/actions/secrets/#get-an-organization-secret
@@ -2943,7 +2887,7 @@ https://developer.github.com/v3/actions/secrets/#get-an-organization-secret
 type ActionsGetOrgSecretResponse struct {
 	response
 	request *ActionsGetOrgSecretReq
-	Data    ActionsGetOrgSecretResponseBody
+	Data    components.OrganizationActionsSecret
 }
 
 /*
@@ -2967,7 +2911,7 @@ func ActionsGetRepoPublicKey(ctx context.Context, req *ActionsGetRepoPublicKeyRe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActionsGetRepoPublicKeyResponseBody{}
+	resp.Data = components.ActionsPublicKey{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3057,13 +3001,6 @@ func (r *ActionsGetRepoPublicKeyReq) Rel(link RelName, resp *ActionsGetRepoPubli
 }
 
 /*
-ActionsGetRepoPublicKeyResponseBody is a response body for ActionsGetRepoPublicKey
-
-https://developer.github.com/v3/actions/secrets/#get-a-repository-public-key
-*/
-type ActionsGetRepoPublicKeyResponseBody components.ActionsPublicKey
-
-/*
 ActionsGetRepoPublicKeyResponse is a response for ActionsGetRepoPublicKey
 
 https://developer.github.com/v3/actions/secrets/#get-a-repository-public-key
@@ -3071,7 +3008,7 @@ https://developer.github.com/v3/actions/secrets/#get-a-repository-public-key
 type ActionsGetRepoPublicKeyResponse struct {
 	response
 	request *ActionsGetRepoPublicKeyReq
-	Data    ActionsGetRepoPublicKeyResponseBody
+	Data    components.ActionsPublicKey
 }
 
 /*
@@ -3095,7 +3032,7 @@ func ActionsGetRepoSecret(ctx context.Context, req *ActionsGetRepoSecretReq, opt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActionsGetRepoSecretResponseBody{}
+	resp.Data = components.ActionsSecret{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3188,13 +3125,6 @@ func (r *ActionsGetRepoSecretReq) Rel(link RelName, resp *ActionsGetRepoSecretRe
 }
 
 /*
-ActionsGetRepoSecretResponseBody is a response body for ActionsGetRepoSecret
-
-https://developer.github.com/v3/actions/secrets/#get-a-repository-secret
-*/
-type ActionsGetRepoSecretResponseBody components.ActionsSecret
-
-/*
 ActionsGetRepoSecretResponse is a response for ActionsGetRepoSecret
 
 https://developer.github.com/v3/actions/secrets/#get-a-repository-secret
@@ -3202,7 +3132,7 @@ https://developer.github.com/v3/actions/secrets/#get-a-repository-secret
 type ActionsGetRepoSecretResponse struct {
 	response
 	request *ActionsGetRepoSecretReq
-	Data    ActionsGetRepoSecretResponseBody
+	Data    components.ActionsSecret
 }
 
 /*
@@ -3226,7 +3156,7 @@ func ActionsGetSelfHostedRunnerForOrg(ctx context.Context, req *ActionsGetSelfHo
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActionsGetSelfHostedRunnerForOrgResponseBody{}
+	resp.Data = components.Runner{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3318,13 +3248,6 @@ func (r *ActionsGetSelfHostedRunnerForOrgReq) Rel(link RelName, resp *ActionsGet
 }
 
 /*
-ActionsGetSelfHostedRunnerForOrgResponseBody is a response body for ActionsGetSelfHostedRunnerForOrg
-
-https://developer.github.com/v3/actions/self-hosted-runners/#get-a-self-hosted-runner-for-an-organization
-*/
-type ActionsGetSelfHostedRunnerForOrgResponseBody components.Runner
-
-/*
 ActionsGetSelfHostedRunnerForOrgResponse is a response for ActionsGetSelfHostedRunnerForOrg
 
 https://developer.github.com/v3/actions/self-hosted-runners/#get-a-self-hosted-runner-for-an-organization
@@ -3332,7 +3255,7 @@ https://developer.github.com/v3/actions/self-hosted-runners/#get-a-self-hosted-r
 type ActionsGetSelfHostedRunnerForOrgResponse struct {
 	response
 	request *ActionsGetSelfHostedRunnerForOrgReq
-	Data    ActionsGetSelfHostedRunnerForOrgResponseBody
+	Data    components.Runner
 }
 
 /*
@@ -3356,7 +3279,7 @@ func ActionsGetSelfHostedRunnerForRepo(ctx context.Context, req *ActionsGetSelfH
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActionsGetSelfHostedRunnerForRepoResponseBody{}
+	resp.Data = components.Runner{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3449,13 +3372,6 @@ func (r *ActionsGetSelfHostedRunnerForRepoReq) Rel(link RelName, resp *ActionsGe
 }
 
 /*
-ActionsGetSelfHostedRunnerForRepoResponseBody is a response body for ActionsGetSelfHostedRunnerForRepo
-
-https://developer.github.com/v3/actions/self-hosted-runners/#get-a-self-hosted-runner-for-a-repository
-*/
-type ActionsGetSelfHostedRunnerForRepoResponseBody components.Runner
-
-/*
 ActionsGetSelfHostedRunnerForRepoResponse is a response for ActionsGetSelfHostedRunnerForRepo
 
 https://developer.github.com/v3/actions/self-hosted-runners/#get-a-self-hosted-runner-for-a-repository
@@ -3463,7 +3379,7 @@ https://developer.github.com/v3/actions/self-hosted-runners/#get-a-self-hosted-r
 type ActionsGetSelfHostedRunnerForRepoResponse struct {
 	response
 	request *ActionsGetSelfHostedRunnerForRepoReq
-	Data    ActionsGetSelfHostedRunnerForRepoResponseBody
+	Data    components.Runner
 }
 
 /*
@@ -3487,7 +3403,7 @@ func ActionsGetWorkflow(ctx context.Context, req *ActionsGetWorkflowReq, opt ...
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActionsGetWorkflowResponseBody{}
+	resp.Data = components.Workflow{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3578,13 +3494,6 @@ func (r *ActionsGetWorkflowReq) Rel(link RelName, resp *ActionsGetWorkflowRespon
 }
 
 /*
-ActionsGetWorkflowResponseBody is a response body for ActionsGetWorkflow
-
-https://developer.github.com/v3/actions/workflows/#get-a-workflow
-*/
-type ActionsGetWorkflowResponseBody components.Workflow
-
-/*
 ActionsGetWorkflowResponse is a response for ActionsGetWorkflow
 
 https://developer.github.com/v3/actions/workflows/#get-a-workflow
@@ -3592,7 +3501,7 @@ https://developer.github.com/v3/actions/workflows/#get-a-workflow
 type ActionsGetWorkflowResponse struct {
 	response
 	request *ActionsGetWorkflowReq
-	Data    ActionsGetWorkflowResponseBody
+	Data    components.Workflow
 }
 
 /*
@@ -3616,7 +3525,7 @@ func ActionsGetWorkflowRun(ctx context.Context, req *ActionsGetWorkflowRunReq, o
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActionsGetWorkflowRunResponseBody{}
+	resp.Data = components.WorkflowRun{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3707,13 +3616,6 @@ func (r *ActionsGetWorkflowRunReq) Rel(link RelName, resp *ActionsGetWorkflowRun
 }
 
 /*
-ActionsGetWorkflowRunResponseBody is a response body for ActionsGetWorkflowRun
-
-https://developer.github.com/v3/actions/workflow-runs/#get-a-workflow-run
-*/
-type ActionsGetWorkflowRunResponseBody components.WorkflowRun
-
-/*
 ActionsGetWorkflowRunResponse is a response for ActionsGetWorkflowRun
 
 https://developer.github.com/v3/actions/workflow-runs/#get-a-workflow-run
@@ -3721,7 +3623,7 @@ https://developer.github.com/v3/actions/workflow-runs/#get-a-workflow-run
 type ActionsGetWorkflowRunResponse struct {
 	response
 	request *ActionsGetWorkflowRunReq
-	Data    ActionsGetWorkflowRunResponseBody
+	Data    components.WorkflowRun
 }
 
 /*
@@ -3745,7 +3647,7 @@ func ActionsGetWorkflowRunUsage(ctx context.Context, req *ActionsGetWorkflowRunU
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActionsGetWorkflowRunUsageResponseBody{}
+	resp.Data = components.WorkflowRunUsage{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3836,13 +3738,6 @@ func (r *ActionsGetWorkflowRunUsageReq) Rel(link RelName, resp *ActionsGetWorkfl
 }
 
 /*
-ActionsGetWorkflowRunUsageResponseBody is a response body for ActionsGetWorkflowRunUsage
-
-https://developer.github.com/v3/actions/workflow-runs/#get-workflow-run-usage
-*/
-type ActionsGetWorkflowRunUsageResponseBody components.WorkflowRunUsage
-
-/*
 ActionsGetWorkflowRunUsageResponse is a response for ActionsGetWorkflowRunUsage
 
 https://developer.github.com/v3/actions/workflow-runs/#get-workflow-run-usage
@@ -3850,7 +3745,7 @@ https://developer.github.com/v3/actions/workflow-runs/#get-workflow-run-usage
 type ActionsGetWorkflowRunUsageResponse struct {
 	response
 	request *ActionsGetWorkflowRunUsageReq
-	Data    ActionsGetWorkflowRunUsageResponseBody
+	Data    components.WorkflowRunUsage
 }
 
 /*
@@ -3874,7 +3769,7 @@ func ActionsGetWorkflowUsage(ctx context.Context, req *ActionsGetWorkflowUsageRe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActionsGetWorkflowUsageResponseBody{}
+	resp.Data = components.WorkflowUsage{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3965,13 +3860,6 @@ func (r *ActionsGetWorkflowUsageReq) Rel(link RelName, resp *ActionsGetWorkflowU
 }
 
 /*
-ActionsGetWorkflowUsageResponseBody is a response body for ActionsGetWorkflowUsage
-
-https://developer.github.com/v3/actions/workflows/#get-workflow-usage
-*/
-type ActionsGetWorkflowUsageResponseBody components.WorkflowUsage
-
-/*
 ActionsGetWorkflowUsageResponse is a response for ActionsGetWorkflowUsage
 
 https://developer.github.com/v3/actions/workflows/#get-workflow-usage
@@ -3979,7 +3867,7 @@ https://developer.github.com/v3/actions/workflows/#get-workflow-usage
 type ActionsGetWorkflowUsageResponse struct {
 	response
 	request *ActionsGetWorkflowUsageReq
-	Data    ActionsGetWorkflowUsageResponseBody
+	Data    components.WorkflowUsage
 }
 
 /*

--- a/zz_actions_gen.go
+++ b/zz_actions_gen.go
@@ -4617,7 +4617,7 @@ func ActionsListRunnerApplicationsForOrg(ctx context.Context, req *ActionsListRu
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActionsListRunnerApplicationsForOrgResponseBody{}
+	resp.Data = []components.RunnerApplication{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -4706,13 +4706,6 @@ func (r *ActionsListRunnerApplicationsForOrgReq) Rel(link RelName, resp *Actions
 }
 
 /*
-ActionsListRunnerApplicationsForOrgResponseBody is a response body for ActionsListRunnerApplicationsForOrg
-
-https://developer.github.com/v3/actions/self-hosted-runners/#list-runner-applications-for-an-organization
-*/
-type ActionsListRunnerApplicationsForOrgResponseBody []components.RunnerApplication
-
-/*
 ActionsListRunnerApplicationsForOrgResponse is a response for ActionsListRunnerApplicationsForOrg
 
 https://developer.github.com/v3/actions/self-hosted-runners/#list-runner-applications-for-an-organization
@@ -4720,7 +4713,7 @@ https://developer.github.com/v3/actions/self-hosted-runners/#list-runner-applica
 type ActionsListRunnerApplicationsForOrgResponse struct {
 	response
 	request *ActionsListRunnerApplicationsForOrgReq
-	Data    ActionsListRunnerApplicationsForOrgResponseBody
+	Data    []components.RunnerApplication
 }
 
 /*
@@ -4744,7 +4737,7 @@ func ActionsListRunnerApplicationsForRepo(ctx context.Context, req *ActionsListR
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActionsListRunnerApplicationsForRepoResponseBody{}
+	resp.Data = []components.RunnerApplication{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -4834,13 +4827,6 @@ func (r *ActionsListRunnerApplicationsForRepoReq) Rel(link RelName, resp *Action
 }
 
 /*
-ActionsListRunnerApplicationsForRepoResponseBody is a response body for ActionsListRunnerApplicationsForRepo
-
-https://developer.github.com/v3/actions/self-hosted-runners/#list-runner-applications-for-a-repository
-*/
-type ActionsListRunnerApplicationsForRepoResponseBody []components.RunnerApplication
-
-/*
 ActionsListRunnerApplicationsForRepoResponse is a response for ActionsListRunnerApplicationsForRepo
 
 https://developer.github.com/v3/actions/self-hosted-runners/#list-runner-applications-for-a-repository
@@ -4848,7 +4834,7 @@ https://developer.github.com/v3/actions/self-hosted-runners/#list-runner-applica
 type ActionsListRunnerApplicationsForRepoResponse struct {
 	response
 	request *ActionsListRunnerApplicationsForRepoReq
-	Data    ActionsListRunnerApplicationsForRepoResponseBody
+	Data    []components.RunnerApplication
 }
 
 /*

--- a/zz_activity_gen.go
+++ b/zz_activity_gen.go
@@ -390,7 +390,7 @@ func ActivityGetFeeds(ctx context.Context, req *ActivityGetFeedsReq, opt ...Requ
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActivityGetFeedsResponseBody{}
+	resp.Data = components.Feed{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -478,13 +478,6 @@ func (r *ActivityGetFeedsReq) Rel(link RelName, resp *ActivityGetFeedsResponse) 
 }
 
 /*
-ActivityGetFeedsResponseBody is a response body for ActivityGetFeeds
-
-https://developer.github.com/v3/activity/feeds/#get-feeds
-*/
-type ActivityGetFeedsResponseBody components.Feed
-
-/*
 ActivityGetFeedsResponse is a response for ActivityGetFeeds
 
 https://developer.github.com/v3/activity/feeds/#get-feeds
@@ -492,7 +485,7 @@ https://developer.github.com/v3/activity/feeds/#get-feeds
 type ActivityGetFeedsResponse struct {
 	response
 	request *ActivityGetFeedsReq
-	Data    ActivityGetFeedsResponseBody
+	Data    components.Feed
 }
 
 /*
@@ -516,7 +509,7 @@ func ActivityGetRepoSubscription(ctx context.Context, req *ActivityGetRepoSubscr
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActivityGetRepoSubscriptionResponseBody{}
+	resp.Data = components.RepositorySubscription{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -606,13 +599,6 @@ func (r *ActivityGetRepoSubscriptionReq) Rel(link RelName, resp *ActivityGetRepo
 }
 
 /*
-ActivityGetRepoSubscriptionResponseBody is a response body for ActivityGetRepoSubscription
-
-https://developer.github.com/v3/activity/watching/#get-a-repository-subscription
-*/
-type ActivityGetRepoSubscriptionResponseBody components.RepositorySubscription
-
-/*
 ActivityGetRepoSubscriptionResponse is a response for ActivityGetRepoSubscription
 
 https://developer.github.com/v3/activity/watching/#get-a-repository-subscription
@@ -620,7 +606,7 @@ https://developer.github.com/v3/activity/watching/#get-a-repository-subscription
 type ActivityGetRepoSubscriptionResponse struct {
 	response
 	request *ActivityGetRepoSubscriptionReq
-	Data    ActivityGetRepoSubscriptionResponseBody
+	Data    components.RepositorySubscription
 }
 
 /*
@@ -644,7 +630,7 @@ func ActivityGetThread(ctx context.Context, req *ActivityGetThreadReq, opt ...Re
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActivityGetThreadResponseBody{}
+	resp.Data = components.Thread{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -735,13 +721,6 @@ func (r *ActivityGetThreadReq) Rel(link RelName, resp *ActivityGetThreadResponse
 }
 
 /*
-ActivityGetThreadResponseBody is a response body for ActivityGetThread
-
-https://developer.github.com/v3/activity/notifications/#get-a-thread
-*/
-type ActivityGetThreadResponseBody components.Thread
-
-/*
 ActivityGetThreadResponse is a response for ActivityGetThread
 
 https://developer.github.com/v3/activity/notifications/#get-a-thread
@@ -749,7 +728,7 @@ https://developer.github.com/v3/activity/notifications/#get-a-thread
 type ActivityGetThreadResponse struct {
 	response
 	request *ActivityGetThreadReq
-	Data    ActivityGetThreadResponseBody
+	Data    components.Thread
 }
 
 /*
@@ -773,7 +752,7 @@ func ActivityGetThreadSubscriptionForAuthenticatedUser(ctx context.Context, req 
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActivityGetThreadSubscriptionForAuthenticatedUserResponseBody{}
+	resp.Data = components.ThreadSubscription{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -864,13 +843,6 @@ func (r *ActivityGetThreadSubscriptionForAuthenticatedUserReq) Rel(link RelName,
 }
 
 /*
-ActivityGetThreadSubscriptionForAuthenticatedUserResponseBody is a response body for ActivityGetThreadSubscriptionForAuthenticatedUser
-
-https://developer.github.com/v3/activity/notifications/#get-a-thread-subscription-for-the-authenticated-user
-*/
-type ActivityGetThreadSubscriptionForAuthenticatedUserResponseBody components.ThreadSubscription
-
-/*
 ActivityGetThreadSubscriptionForAuthenticatedUserResponse is a response for ActivityGetThreadSubscriptionForAuthenticatedUser
 
 https://developer.github.com/v3/activity/notifications/#get-a-thread-subscription-for-the-authenticated-user
@@ -878,7 +850,7 @@ https://developer.github.com/v3/activity/notifications/#get-a-thread-subscriptio
 type ActivityGetThreadSubscriptionForAuthenticatedUserResponse struct {
 	response
 	request *ActivityGetThreadSubscriptionForAuthenticatedUserReq
-	Data    ActivityGetThreadSubscriptionForAuthenticatedUserResponseBody
+	Data    components.ThreadSubscription
 }
 
 /*
@@ -3770,7 +3742,7 @@ func ActivitySetRepoSubscription(ctx context.Context, req *ActivitySetRepoSubscr
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActivitySetRepoSubscriptionResponseBody{}
+	resp.Data = components.RepositorySubscription{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3878,13 +3850,6 @@ type ActivitySetRepoSubscriptionReqBody struct {
 }
 
 /*
-ActivitySetRepoSubscriptionResponseBody is a response body for ActivitySetRepoSubscription
-
-https://developer.github.com/v3/activity/watching/#set-a-repository-subscription
-*/
-type ActivitySetRepoSubscriptionResponseBody components.RepositorySubscription
-
-/*
 ActivitySetRepoSubscriptionResponse is a response for ActivitySetRepoSubscription
 
 https://developer.github.com/v3/activity/watching/#set-a-repository-subscription
@@ -3892,7 +3857,7 @@ https://developer.github.com/v3/activity/watching/#set-a-repository-subscription
 type ActivitySetRepoSubscriptionResponse struct {
 	response
 	request *ActivitySetRepoSubscriptionReq
-	Data    ActivitySetRepoSubscriptionResponseBody
+	Data    components.RepositorySubscription
 }
 
 /*
@@ -3916,7 +3881,7 @@ func ActivitySetThreadSubscription(ctx context.Context, req *ActivitySetThreadSu
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActivitySetThreadSubscriptionResponseBody{}
+	resp.Data = components.ThreadSubscription{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -4022,13 +3987,6 @@ type ActivitySetThreadSubscriptionReqBody struct {
 }
 
 /*
-ActivitySetThreadSubscriptionResponseBody is a response body for ActivitySetThreadSubscription
-
-https://developer.github.com/v3/activity/notifications/#set-a-thread-subscription
-*/
-type ActivitySetThreadSubscriptionResponseBody components.ThreadSubscription
-
-/*
 ActivitySetThreadSubscriptionResponse is a response for ActivitySetThreadSubscription
 
 https://developer.github.com/v3/activity/notifications/#set-a-thread-subscription
@@ -4036,7 +3994,7 @@ https://developer.github.com/v3/activity/notifications/#set-a-thread-subscriptio
 type ActivitySetThreadSubscriptionResponse struct {
 	response
 	request *ActivitySetThreadSubscriptionReq
-	Data    ActivitySetThreadSubscriptionResponseBody
+	Data    components.ThreadSubscription
 }
 
 /*

--- a/zz_activity_gen.go
+++ b/zz_activity_gen.go
@@ -874,7 +874,7 @@ func ActivityListEventsForAuthenticatedUser(ctx context.Context, req *ActivityLi
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActivityListEventsForAuthenticatedUserResponseBody{}
+	resp.Data = []components.Event{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -975,13 +975,6 @@ func (r *ActivityListEventsForAuthenticatedUserReq) Rel(link RelName, resp *Acti
 }
 
 /*
-ActivityListEventsForAuthenticatedUserResponseBody is a response body for ActivityListEventsForAuthenticatedUser
-
-https://developer.github.com/v3/activity/events/#list-events-for-the-authenticated-user
-*/
-type ActivityListEventsForAuthenticatedUserResponseBody []components.Event
-
-/*
 ActivityListEventsForAuthenticatedUserResponse is a response for ActivityListEventsForAuthenticatedUser
 
 https://developer.github.com/v3/activity/events/#list-events-for-the-authenticated-user
@@ -989,7 +982,7 @@ https://developer.github.com/v3/activity/events/#list-events-for-the-authenticat
 type ActivityListEventsForAuthenticatedUserResponse struct {
 	response
 	request *ActivityListEventsForAuthenticatedUserReq
-	Data    ActivityListEventsForAuthenticatedUserResponseBody
+	Data    []components.Event
 }
 
 /*
@@ -1013,7 +1006,7 @@ func ActivityListNotificationsForAuthenticatedUser(ctx context.Context, req *Act
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActivityListNotificationsForAuthenticatedUserResponseBody{}
+	resp.Data = []components.Thread{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1148,13 +1141,6 @@ func (r *ActivityListNotificationsForAuthenticatedUserReq) Rel(link RelName, res
 }
 
 /*
-ActivityListNotificationsForAuthenticatedUserResponseBody is a response body for ActivityListNotificationsForAuthenticatedUser
-
-https://developer.github.com/v3/activity/notifications/#list-notifications-for-the-authenticated-user
-*/
-type ActivityListNotificationsForAuthenticatedUserResponseBody []components.Thread
-
-/*
 ActivityListNotificationsForAuthenticatedUserResponse is a response for ActivityListNotificationsForAuthenticatedUser
 
 https://developer.github.com/v3/activity/notifications/#list-notifications-for-the-authenticated-user
@@ -1162,7 +1148,7 @@ https://developer.github.com/v3/activity/notifications/#list-notifications-for-t
 type ActivityListNotificationsForAuthenticatedUserResponse struct {
 	response
 	request *ActivityListNotificationsForAuthenticatedUserReq
-	Data    ActivityListNotificationsForAuthenticatedUserResponseBody
+	Data    []components.Thread
 }
 
 /*
@@ -1186,7 +1172,7 @@ func ActivityListOrgEventsForAuthenticatedUser(ctx context.Context, req *Activit
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActivityListOrgEventsForAuthenticatedUserResponseBody{}
+	resp.Data = []components.Event{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1288,13 +1274,6 @@ func (r *ActivityListOrgEventsForAuthenticatedUserReq) Rel(link RelName, resp *A
 }
 
 /*
-ActivityListOrgEventsForAuthenticatedUserResponseBody is a response body for ActivityListOrgEventsForAuthenticatedUser
-
-https://developer.github.com/v3/activity/events/#list-organization-events-for-the-authenticated-user
-*/
-type ActivityListOrgEventsForAuthenticatedUserResponseBody []components.Event
-
-/*
 ActivityListOrgEventsForAuthenticatedUserResponse is a response for ActivityListOrgEventsForAuthenticatedUser
 
 https://developer.github.com/v3/activity/events/#list-organization-events-for-the-authenticated-user
@@ -1302,7 +1281,7 @@ https://developer.github.com/v3/activity/events/#list-organization-events-for-th
 type ActivityListOrgEventsForAuthenticatedUserResponse struct {
 	response
 	request *ActivityListOrgEventsForAuthenticatedUserReq
-	Data    ActivityListOrgEventsForAuthenticatedUserResponseBody
+	Data    []components.Event
 }
 
 /*
@@ -1326,7 +1305,7 @@ func ActivityListPublicEvents(ctx context.Context, req *ActivityListPublicEvents
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActivityListPublicEventsResponseBody{}
+	resp.Data = []components.Event{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1426,13 +1405,6 @@ func (r *ActivityListPublicEventsReq) Rel(link RelName, resp *ActivityListPublic
 }
 
 /*
-ActivityListPublicEventsResponseBody is a response body for ActivityListPublicEvents
-
-https://developer.github.com/v3/activity/events/#list-public-events
-*/
-type ActivityListPublicEventsResponseBody []components.Event
-
-/*
 ActivityListPublicEventsResponse is a response for ActivityListPublicEvents
 
 https://developer.github.com/v3/activity/events/#list-public-events
@@ -1440,7 +1412,7 @@ https://developer.github.com/v3/activity/events/#list-public-events
 type ActivityListPublicEventsResponse struct {
 	response
 	request *ActivityListPublicEventsReq
-	Data    ActivityListPublicEventsResponseBody
+	Data    []components.Event
 }
 
 /*
@@ -1464,7 +1436,7 @@ func ActivityListPublicEventsForRepoNetwork(ctx context.Context, req *ActivityLi
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActivityListPublicEventsForRepoNetworkResponseBody{}
+	resp.Data = []components.Event{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1566,13 +1538,6 @@ func (r *ActivityListPublicEventsForRepoNetworkReq) Rel(link RelName, resp *Acti
 }
 
 /*
-ActivityListPublicEventsForRepoNetworkResponseBody is a response body for ActivityListPublicEventsForRepoNetwork
-
-https://developer.github.com/v3/activity/events/#list-public-events-for-a-network-of-repositories
-*/
-type ActivityListPublicEventsForRepoNetworkResponseBody []components.Event
-
-/*
 ActivityListPublicEventsForRepoNetworkResponse is a response for ActivityListPublicEventsForRepoNetwork
 
 https://developer.github.com/v3/activity/events/#list-public-events-for-a-network-of-repositories
@@ -1580,7 +1545,7 @@ https://developer.github.com/v3/activity/events/#list-public-events-for-a-networ
 type ActivityListPublicEventsForRepoNetworkResponse struct {
 	response
 	request *ActivityListPublicEventsForRepoNetworkReq
-	Data    ActivityListPublicEventsForRepoNetworkResponseBody
+	Data    []components.Event
 }
 
 /*
@@ -1604,7 +1569,7 @@ func ActivityListPublicEventsForUser(ctx context.Context, req *ActivityListPubli
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActivityListPublicEventsForUserResponseBody{}
+	resp.Data = []components.Event{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1705,13 +1670,6 @@ func (r *ActivityListPublicEventsForUserReq) Rel(link RelName, resp *ActivityLis
 }
 
 /*
-ActivityListPublicEventsForUserResponseBody is a response body for ActivityListPublicEventsForUser
-
-https://developer.github.com/v3/activity/events/#list-public-events-for-a-user
-*/
-type ActivityListPublicEventsForUserResponseBody []components.Event
-
-/*
 ActivityListPublicEventsForUserResponse is a response for ActivityListPublicEventsForUser
 
 https://developer.github.com/v3/activity/events/#list-public-events-for-a-user
@@ -1719,7 +1677,7 @@ https://developer.github.com/v3/activity/events/#list-public-events-for-a-user
 type ActivityListPublicEventsForUserResponse struct {
 	response
 	request *ActivityListPublicEventsForUserReq
-	Data    ActivityListPublicEventsForUserResponseBody
+	Data    []components.Event
 }
 
 /*
@@ -1743,7 +1701,7 @@ func ActivityListPublicOrgEvents(ctx context.Context, req *ActivityListPublicOrg
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActivityListPublicOrgEventsResponseBody{}
+	resp.Data = []components.Event{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1844,13 +1802,6 @@ func (r *ActivityListPublicOrgEventsReq) Rel(link RelName, resp *ActivityListPub
 }
 
 /*
-ActivityListPublicOrgEventsResponseBody is a response body for ActivityListPublicOrgEvents
-
-https://developer.github.com/v3/activity/events/#list-public-organization-events
-*/
-type ActivityListPublicOrgEventsResponseBody []components.Event
-
-/*
 ActivityListPublicOrgEventsResponse is a response for ActivityListPublicOrgEvents
 
 https://developer.github.com/v3/activity/events/#list-public-organization-events
@@ -1858,7 +1809,7 @@ https://developer.github.com/v3/activity/events/#list-public-organization-events
 type ActivityListPublicOrgEventsResponse struct {
 	response
 	request *ActivityListPublicOrgEventsReq
-	Data    ActivityListPublicOrgEventsResponseBody
+	Data    []components.Event
 }
 
 /*
@@ -1882,7 +1833,7 @@ func ActivityListReceivedEventsForUser(ctx context.Context, req *ActivityListRec
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActivityListReceivedEventsForUserResponseBody{}
+	resp.Data = []components.Event{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1983,13 +1934,6 @@ func (r *ActivityListReceivedEventsForUserReq) Rel(link RelName, resp *ActivityL
 }
 
 /*
-ActivityListReceivedEventsForUserResponseBody is a response body for ActivityListReceivedEventsForUser
-
-https://developer.github.com/v3/activity/events/#list-events-received-by-the-authenticated-user
-*/
-type ActivityListReceivedEventsForUserResponseBody []components.Event
-
-/*
 ActivityListReceivedEventsForUserResponse is a response for ActivityListReceivedEventsForUser
 
 https://developer.github.com/v3/activity/events/#list-events-received-by-the-authenticated-user
@@ -1997,7 +1941,7 @@ https://developer.github.com/v3/activity/events/#list-events-received-by-the-aut
 type ActivityListReceivedEventsForUserResponse struct {
 	response
 	request *ActivityListReceivedEventsForUserReq
-	Data    ActivityListReceivedEventsForUserResponseBody
+	Data    []components.Event
 }
 
 /*
@@ -2021,7 +1965,7 @@ func ActivityListReceivedPublicEventsForUser(ctx context.Context, req *ActivityL
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActivityListReceivedPublicEventsForUserResponseBody{}
+	resp.Data = []components.Event{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2122,13 +2066,6 @@ func (r *ActivityListReceivedPublicEventsForUserReq) Rel(link RelName, resp *Act
 }
 
 /*
-ActivityListReceivedPublicEventsForUserResponseBody is a response body for ActivityListReceivedPublicEventsForUser
-
-https://developer.github.com/v3/activity/events/#list-public-events-received-by-a-user
-*/
-type ActivityListReceivedPublicEventsForUserResponseBody []components.Event
-
-/*
 ActivityListReceivedPublicEventsForUserResponse is a response for ActivityListReceivedPublicEventsForUser
 
 https://developer.github.com/v3/activity/events/#list-public-events-received-by-a-user
@@ -2136,7 +2073,7 @@ https://developer.github.com/v3/activity/events/#list-public-events-received-by-
 type ActivityListReceivedPublicEventsForUserResponse struct {
 	response
 	request *ActivityListReceivedPublicEventsForUserReq
-	Data    ActivityListReceivedPublicEventsForUserResponseBody
+	Data    []components.Event
 }
 
 /*
@@ -2160,7 +2097,7 @@ func ActivityListRepoEvents(ctx context.Context, req *ActivityListRepoEventsReq,
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActivityListRepoEventsResponseBody{}
+	resp.Data = []components.Event{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2262,13 +2199,6 @@ func (r *ActivityListRepoEventsReq) Rel(link RelName, resp *ActivityListRepoEven
 }
 
 /*
-ActivityListRepoEventsResponseBody is a response body for ActivityListRepoEvents
-
-https://developer.github.com/v3/activity/events/#list-repository-events
-*/
-type ActivityListRepoEventsResponseBody []components.Event
-
-/*
 ActivityListRepoEventsResponse is a response for ActivityListRepoEvents
 
 https://developer.github.com/v3/activity/events/#list-repository-events
@@ -2276,7 +2206,7 @@ https://developer.github.com/v3/activity/events/#list-repository-events
 type ActivityListRepoEventsResponse struct {
 	response
 	request *ActivityListRepoEventsReq
-	Data    ActivityListRepoEventsResponseBody
+	Data    []components.Event
 }
 
 /*
@@ -2300,7 +2230,7 @@ func ActivityListRepoNotificationsForAuthenticatedUser(ctx context.Context, req 
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActivityListRepoNotificationsForAuthenticatedUserResponseBody{}
+	resp.Data = []components.Thread{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2437,13 +2367,6 @@ func (r *ActivityListRepoNotificationsForAuthenticatedUserReq) Rel(link RelName,
 }
 
 /*
-ActivityListRepoNotificationsForAuthenticatedUserResponseBody is a response body for ActivityListRepoNotificationsForAuthenticatedUser
-
-https://developer.github.com/v3/activity/notifications/#list-repository-notifications-for-the-authenticated-user
-*/
-type ActivityListRepoNotificationsForAuthenticatedUserResponseBody []components.Thread
-
-/*
 ActivityListRepoNotificationsForAuthenticatedUserResponse is a response for ActivityListRepoNotificationsForAuthenticatedUser
 
 https://developer.github.com/v3/activity/notifications/#list-repository-notifications-for-the-authenticated-user
@@ -2451,7 +2374,7 @@ https://developer.github.com/v3/activity/notifications/#list-repository-notifica
 type ActivityListRepoNotificationsForAuthenticatedUserResponse struct {
 	response
 	request *ActivityListRepoNotificationsForAuthenticatedUserReq
-	Data    ActivityListRepoNotificationsForAuthenticatedUserResponseBody
+	Data    []components.Thread
 }
 
 /*
@@ -2475,7 +2398,7 @@ func ActivityListReposStarredByAuthenticatedUser(ctx context.Context, req *Activ
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActivityListReposStarredByAuthenticatedUserResponseBody{}
+	resp.Data = []components.StarredRepository{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2590,13 +2513,6 @@ func (r *ActivityListReposStarredByAuthenticatedUserReq) Rel(link RelName, resp 
 }
 
 /*
-ActivityListReposStarredByAuthenticatedUserResponseBody is a response body for ActivityListReposStarredByAuthenticatedUser
-
-https://developer.github.com/v3/activity/starring/#list-repositories-starred-by-the-authenticated-user
-*/
-type ActivityListReposStarredByAuthenticatedUserResponseBody []components.StarredRepository
-
-/*
 ActivityListReposStarredByAuthenticatedUserResponse is a response for ActivityListReposStarredByAuthenticatedUser
 
 https://developer.github.com/v3/activity/starring/#list-repositories-starred-by-the-authenticated-user
@@ -2604,7 +2520,7 @@ https://developer.github.com/v3/activity/starring/#list-repositories-starred-by-
 type ActivityListReposStarredByAuthenticatedUserResponse struct {
 	response
 	request *ActivityListReposStarredByAuthenticatedUserReq
-	Data    ActivityListReposStarredByAuthenticatedUserResponseBody
+	Data    []components.StarredRepository
 }
 
 /*
@@ -2628,7 +2544,7 @@ func ActivityListReposStarredByUser(ctx context.Context, req *ActivityListReposS
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActivityListReposStarredByUserResponseBody{}
+	resp.Data = []components.StarredRepository{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2744,13 +2660,6 @@ func (r *ActivityListReposStarredByUserReq) Rel(link RelName, resp *ActivityList
 }
 
 /*
-ActivityListReposStarredByUserResponseBody is a response body for ActivityListReposStarredByUser
-
-https://developer.github.com/v3/activity/starring/#list-repositories-starred-by-a-user
-*/
-type ActivityListReposStarredByUserResponseBody []components.StarredRepository
-
-/*
 ActivityListReposStarredByUserResponse is a response for ActivityListReposStarredByUser
 
 https://developer.github.com/v3/activity/starring/#list-repositories-starred-by-a-user
@@ -2758,7 +2667,7 @@ https://developer.github.com/v3/activity/starring/#list-repositories-starred-by-
 type ActivityListReposStarredByUserResponse struct {
 	response
 	request *ActivityListReposStarredByUserReq
-	Data    ActivityListReposStarredByUserResponseBody
+	Data    []components.StarredRepository
 }
 
 /*
@@ -2782,7 +2691,7 @@ func ActivityListReposWatchedByUser(ctx context.Context, req *ActivityListReposW
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActivityListReposWatchedByUserResponseBody{}
+	resp.Data = []components.MinimalRepository{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2883,13 +2792,6 @@ func (r *ActivityListReposWatchedByUserReq) Rel(link RelName, resp *ActivityList
 }
 
 /*
-ActivityListReposWatchedByUserResponseBody is a response body for ActivityListReposWatchedByUser
-
-https://developer.github.com/v3/activity/watching/#list-repositories-watched-by-a-user
-*/
-type ActivityListReposWatchedByUserResponseBody []components.MinimalRepository
-
-/*
 ActivityListReposWatchedByUserResponse is a response for ActivityListReposWatchedByUser
 
 https://developer.github.com/v3/activity/watching/#list-repositories-watched-by-a-user
@@ -2897,7 +2799,7 @@ https://developer.github.com/v3/activity/watching/#list-repositories-watched-by-
 type ActivityListReposWatchedByUserResponse struct {
 	response
 	request *ActivityListReposWatchedByUserReq
-	Data    ActivityListReposWatchedByUserResponseBody
+	Data    []components.MinimalRepository
 }
 
 /*
@@ -2921,7 +2823,7 @@ func ActivityListStargazersForRepo(ctx context.Context, req *ActivityListStargaz
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActivityListStargazersForRepoResponseBody{}
+	resp.Data = []components.Stargazer{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3023,13 +2925,6 @@ func (r *ActivityListStargazersForRepoReq) Rel(link RelName, resp *ActivityListS
 }
 
 /*
-ActivityListStargazersForRepoResponseBody is a response body for ActivityListStargazersForRepo
-
-https://developer.github.com/v3/activity/starring/#list-stargazers
-*/
-type ActivityListStargazersForRepoResponseBody []components.Stargazer
-
-/*
 ActivityListStargazersForRepoResponse is a response for ActivityListStargazersForRepo
 
 https://developer.github.com/v3/activity/starring/#list-stargazers
@@ -3037,7 +2932,7 @@ https://developer.github.com/v3/activity/starring/#list-stargazers
 type ActivityListStargazersForRepoResponse struct {
 	response
 	request *ActivityListStargazersForRepoReq
-	Data    ActivityListStargazersForRepoResponseBody
+	Data    []components.Stargazer
 }
 
 /*
@@ -3061,7 +2956,7 @@ func ActivityListWatchedReposForAuthenticatedUser(ctx context.Context, req *Acti
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActivityListWatchedReposForAuthenticatedUserResponseBody{}
+	resp.Data = []components.MinimalRepository{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3161,13 +3056,6 @@ func (r *ActivityListWatchedReposForAuthenticatedUserReq) Rel(link RelName, resp
 }
 
 /*
-ActivityListWatchedReposForAuthenticatedUserResponseBody is a response body for ActivityListWatchedReposForAuthenticatedUser
-
-https://developer.github.com/v3/activity/watching/#list-repositories-watched-by-the-authenticated-user
-*/
-type ActivityListWatchedReposForAuthenticatedUserResponseBody []components.MinimalRepository
-
-/*
 ActivityListWatchedReposForAuthenticatedUserResponse is a response for ActivityListWatchedReposForAuthenticatedUser
 
 https://developer.github.com/v3/activity/watching/#list-repositories-watched-by-the-authenticated-user
@@ -3175,7 +3063,7 @@ https://developer.github.com/v3/activity/watching/#list-repositories-watched-by-
 type ActivityListWatchedReposForAuthenticatedUserResponse struct {
 	response
 	request *ActivityListWatchedReposForAuthenticatedUserReq
-	Data    ActivityListWatchedReposForAuthenticatedUserResponseBody
+	Data    []components.MinimalRepository
 }
 
 /*
@@ -3199,7 +3087,7 @@ func ActivityListWatchersForRepo(ctx context.Context, req *ActivityListWatchersF
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ActivityListWatchersForRepoResponseBody{}
+	resp.Data = []components.SimpleUser{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3301,13 +3189,6 @@ func (r *ActivityListWatchersForRepoReq) Rel(link RelName, resp *ActivityListWat
 }
 
 /*
-ActivityListWatchersForRepoResponseBody is a response body for ActivityListWatchersForRepo
-
-https://developer.github.com/v3/activity/watching/#list-watchers
-*/
-type ActivityListWatchersForRepoResponseBody []components.SimpleUser
-
-/*
 ActivityListWatchersForRepoResponse is a response for ActivityListWatchersForRepo
 
 https://developer.github.com/v3/activity/watching/#list-watchers
@@ -3315,7 +3196,7 @@ https://developer.github.com/v3/activity/watching/#list-watchers
 type ActivityListWatchersForRepoResponse struct {
 	response
 	request *ActivityListWatchersForRepoReq
-	Data    ActivityListWatchersForRepoResponseBody
+	Data    []components.SimpleUser
 }
 
 /*

--- a/zz_apps_gen.go
+++ b/zz_apps_gen.go
@@ -346,7 +346,7 @@ func AppsCheckToken(ctx context.Context, req *AppsCheckTokenReq, opt ...RequestO
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = AppsCheckTokenResponseBody{}
+	resp.Data = components.Authorization{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -450,13 +450,6 @@ type AppsCheckTokenReqBody struct {
 }
 
 /*
-AppsCheckTokenResponseBody is a response body for AppsCheckToken
-
-https://developer.github.com/v3/apps/oauth_applications/#check-a-token
-*/
-type AppsCheckTokenResponseBody components.Authorization
-
-/*
 AppsCheckTokenResponse is a response for AppsCheckToken
 
 https://developer.github.com/v3/apps/oauth_applications/#check-a-token
@@ -464,7 +457,7 @@ https://developer.github.com/v3/apps/oauth_applications/#check-a-token
 type AppsCheckTokenResponse struct {
 	response
 	request *AppsCheckTokenReq
-	Data    AppsCheckTokenResponseBody
+	Data    components.Authorization
 }
 
 /*
@@ -488,7 +481,7 @@ func AppsCreateContentAttachment(ctx context.Context, req *AppsCreateContentAtta
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = AppsCreateContentAttachmentResponseBody{}
+	resp.Data = components.ContentReferenceAttachment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -609,13 +602,6 @@ type AppsCreateContentAttachmentReqBody struct {
 }
 
 /*
-AppsCreateContentAttachmentResponseBody is a response body for AppsCreateContentAttachment
-
-https://developer.github.com/v3/apps/installations/#create-a-content-attachment
-*/
-type AppsCreateContentAttachmentResponseBody components.ContentReferenceAttachment
-
-/*
 AppsCreateContentAttachmentResponse is a response for AppsCreateContentAttachment
 
 https://developer.github.com/v3/apps/installations/#create-a-content-attachment
@@ -623,7 +609,7 @@ https://developer.github.com/v3/apps/installations/#create-a-content-attachment
 type AppsCreateContentAttachmentResponse struct {
 	response
 	request *AppsCreateContentAttachmentReq
-	Data    AppsCreateContentAttachmentResponseBody
+	Data    components.ContentReferenceAttachment
 }
 
 /*
@@ -826,7 +812,7 @@ func AppsCreateInstallationAccessToken(ctx context.Context, req *AppsCreateInsta
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = AppsCreateInstallationAccessTokenResponseBody{}
+	resp.Data = components.InstallationToken{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -951,13 +937,6 @@ type AppsCreateInstallationAccessTokenReqBody struct {
 }
 
 /*
-AppsCreateInstallationAccessTokenResponseBody is a response body for AppsCreateInstallationAccessToken
-
-https://developer.github.com/v3/apps/#create-an-installation-access-token-for-an-app
-*/
-type AppsCreateInstallationAccessTokenResponseBody components.InstallationToken
-
-/*
 AppsCreateInstallationAccessTokenResponse is a response for AppsCreateInstallationAccessToken
 
 https://developer.github.com/v3/apps/#create-an-installation-access-token-for-an-app
@@ -965,7 +944,7 @@ https://developer.github.com/v3/apps/#create-an-installation-access-token-for-an
 type AppsCreateInstallationAccessTokenResponse struct {
 	response
 	request *AppsCreateInstallationAccessTokenReq
-	Data    AppsCreateInstallationAccessTokenResponseBody
+	Data    components.InstallationToken
 }
 
 /*
@@ -1386,7 +1365,7 @@ func AppsGetAuthenticated(ctx context.Context, req *AppsGetAuthenticatedReq, opt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = AppsGetAuthenticatedResponseBody{}
+	resp.Data = components.Integration{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1486,13 +1465,6 @@ func (r *AppsGetAuthenticatedReq) Rel(link RelName, resp *AppsGetAuthenticatedRe
 }
 
 /*
-AppsGetAuthenticatedResponseBody is a response body for AppsGetAuthenticated
-
-https://developer.github.com/v3/apps/#get-the-authenticated-app
-*/
-type AppsGetAuthenticatedResponseBody components.Integration
-
-/*
 AppsGetAuthenticatedResponse is a response for AppsGetAuthenticated
 
 https://developer.github.com/v3/apps/#get-the-authenticated-app
@@ -1500,7 +1472,7 @@ https://developer.github.com/v3/apps/#get-the-authenticated-app
 type AppsGetAuthenticatedResponse struct {
 	response
 	request *AppsGetAuthenticatedReq
-	Data    AppsGetAuthenticatedResponseBody
+	Data    components.Integration
 }
 
 /*
@@ -1524,7 +1496,7 @@ func AppsGetBySlug(ctx context.Context, req *AppsGetBySlugReq, opt ...RequestOpt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = AppsGetBySlugResponseBody{}
+	resp.Data = components.Integration{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1627,13 +1599,6 @@ func (r *AppsGetBySlugReq) Rel(link RelName, resp *AppsGetBySlugResponse) bool {
 }
 
 /*
-AppsGetBySlugResponseBody is a response body for AppsGetBySlug
-
-https://developer.github.com/v3/apps/#get-an-app
-*/
-type AppsGetBySlugResponseBody components.Integration
-
-/*
 AppsGetBySlugResponse is a response for AppsGetBySlug
 
 https://developer.github.com/v3/apps/#get-an-app
@@ -1641,7 +1606,7 @@ https://developer.github.com/v3/apps/#get-an-app
 type AppsGetBySlugResponse struct {
 	response
 	request *AppsGetBySlugReq
-	Data    AppsGetBySlugResponseBody
+	Data    components.Integration
 }
 
 /*
@@ -1665,7 +1630,7 @@ func AppsGetInstallation(ctx context.Context, req *AppsGetInstallationReq, opt .
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = AppsGetInstallationResponseBody{}
+	resp.Data = components.Installation{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1768,13 +1733,6 @@ func (r *AppsGetInstallationReq) Rel(link RelName, resp *AppsGetInstallationResp
 }
 
 /*
-AppsGetInstallationResponseBody is a response body for AppsGetInstallation
-
-https://developer.github.com/v3/apps/#get-an-installation-for-the-authenticated-app
-*/
-type AppsGetInstallationResponseBody components.Installation
-
-/*
 AppsGetInstallationResponse is a response for AppsGetInstallation
 
 https://developer.github.com/v3/apps/#get-an-installation-for-the-authenticated-app
@@ -1782,7 +1740,7 @@ https://developer.github.com/v3/apps/#get-an-installation-for-the-authenticated-
 type AppsGetInstallationResponse struct {
 	response
 	request *AppsGetInstallationReq
-	Data    AppsGetInstallationResponseBody
+	Data    components.Installation
 }
 
 /*
@@ -1806,7 +1764,7 @@ func AppsGetOrgInstallation(ctx context.Context, req *AppsGetOrgInstallationReq,
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = AppsGetOrgInstallationResponseBody{}
+	resp.Data = components.Installation{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1907,13 +1865,6 @@ func (r *AppsGetOrgInstallationReq) Rel(link RelName, resp *AppsGetOrgInstallati
 }
 
 /*
-AppsGetOrgInstallationResponseBody is a response body for AppsGetOrgInstallation
-
-https://developer.github.com/v3/apps/#get-an-organization-installation-for-the-authenticated-app
-*/
-type AppsGetOrgInstallationResponseBody components.Installation
-
-/*
 AppsGetOrgInstallationResponse is a response for AppsGetOrgInstallation
 
 https://developer.github.com/v3/apps/#get-an-organization-installation-for-the-authenticated-app
@@ -1921,7 +1872,7 @@ https://developer.github.com/v3/apps/#get-an-organization-installation-for-the-a
 type AppsGetOrgInstallationResponse struct {
 	response
 	request *AppsGetOrgInstallationReq
-	Data    AppsGetOrgInstallationResponseBody
+	Data    components.Installation
 }
 
 /*
@@ -1945,7 +1896,7 @@ func AppsGetRepoInstallation(ctx context.Context, req *AppsGetRepoInstallationRe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = AppsGetRepoInstallationResponseBody{}
+	resp.Data = components.Installation{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2047,13 +1998,6 @@ func (r *AppsGetRepoInstallationReq) Rel(link RelName, resp *AppsGetRepoInstalla
 }
 
 /*
-AppsGetRepoInstallationResponseBody is a response body for AppsGetRepoInstallation
-
-https://developer.github.com/v3/apps/#get-a-repository-installation-for-the-authenticated-app
-*/
-type AppsGetRepoInstallationResponseBody components.Installation
-
-/*
 AppsGetRepoInstallationResponse is a response for AppsGetRepoInstallation
 
 https://developer.github.com/v3/apps/#get-a-repository-installation-for-the-authenticated-app
@@ -2061,7 +2005,7 @@ https://developer.github.com/v3/apps/#get-a-repository-installation-for-the-auth
 type AppsGetRepoInstallationResponse struct {
 	response
 	request *AppsGetRepoInstallationReq
-	Data    AppsGetRepoInstallationResponseBody
+	Data    components.Installation
 }
 
 /*
@@ -2085,7 +2029,7 @@ func AppsGetSubscriptionPlanForAccount(ctx context.Context, req *AppsGetSubscrip
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = AppsGetSubscriptionPlanForAccountResponseBody{}
+	resp.Data = components.MarketplacePurchase{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2176,13 +2120,6 @@ func (r *AppsGetSubscriptionPlanForAccountReq) Rel(link RelName, resp *AppsGetSu
 }
 
 /*
-AppsGetSubscriptionPlanForAccountResponseBody is a response body for AppsGetSubscriptionPlanForAccount
-
-https://developer.github.com/v3/apps/marketplace/#get-a-subscription-plan-for-an-account
-*/
-type AppsGetSubscriptionPlanForAccountResponseBody components.MarketplacePurchase
-
-/*
 AppsGetSubscriptionPlanForAccountResponse is a response for AppsGetSubscriptionPlanForAccount
 
 https://developer.github.com/v3/apps/marketplace/#get-a-subscription-plan-for-an-account
@@ -2190,7 +2127,7 @@ https://developer.github.com/v3/apps/marketplace/#get-a-subscription-plan-for-an
 type AppsGetSubscriptionPlanForAccountResponse struct {
 	response
 	request *AppsGetSubscriptionPlanForAccountReq
-	Data    AppsGetSubscriptionPlanForAccountResponseBody
+	Data    components.MarketplacePurchase
 }
 
 /*
@@ -2214,7 +2151,7 @@ func AppsGetSubscriptionPlanForAccountStubbed(ctx context.Context, req *AppsGetS
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = AppsGetSubscriptionPlanForAccountStubbedResponseBody{}
+	resp.Data = components.MarketplacePurchase{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2305,13 +2242,6 @@ func (r *AppsGetSubscriptionPlanForAccountStubbedReq) Rel(link RelName, resp *Ap
 }
 
 /*
-AppsGetSubscriptionPlanForAccountStubbedResponseBody is a response body for AppsGetSubscriptionPlanForAccountStubbed
-
-https://developer.github.com/v3/apps/marketplace/#get-a-subscription-plan-for-an-account-stubbed
-*/
-type AppsGetSubscriptionPlanForAccountStubbedResponseBody components.MarketplacePurchase
-
-/*
 AppsGetSubscriptionPlanForAccountStubbedResponse is a response for AppsGetSubscriptionPlanForAccountStubbed
 
 https://developer.github.com/v3/apps/marketplace/#get-a-subscription-plan-for-an-account-stubbed
@@ -2319,7 +2249,7 @@ https://developer.github.com/v3/apps/marketplace/#get-a-subscription-plan-for-an
 type AppsGetSubscriptionPlanForAccountStubbedResponse struct {
 	response
 	request *AppsGetSubscriptionPlanForAccountStubbedReq
-	Data    AppsGetSubscriptionPlanForAccountStubbedResponseBody
+	Data    components.MarketplacePurchase
 }
 
 /*
@@ -2343,7 +2273,7 @@ func AppsGetUserInstallation(ctx context.Context, req *AppsGetUserInstallationRe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = AppsGetUserInstallationResponseBody{}
+	resp.Data = components.Installation{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2444,13 +2374,6 @@ func (r *AppsGetUserInstallationReq) Rel(link RelName, resp *AppsGetUserInstalla
 }
 
 /*
-AppsGetUserInstallationResponseBody is a response body for AppsGetUserInstallation
-
-https://developer.github.com/v3/apps/#get-a-user-installation-for-the-authenticated-app
-*/
-type AppsGetUserInstallationResponseBody components.Installation
-
-/*
 AppsGetUserInstallationResponse is a response for AppsGetUserInstallation
 
 https://developer.github.com/v3/apps/#get-a-user-installation-for-the-authenticated-app
@@ -2458,7 +2381,7 @@ https://developer.github.com/v3/apps/#get-a-user-installation-for-the-authentica
 type AppsGetUserInstallationResponse struct {
 	response
 	request *AppsGetUserInstallationReq
-	Data    AppsGetUserInstallationResponseBody
+	Data    components.Installation
 }
 
 /*
@@ -4137,7 +4060,7 @@ func AppsResetAuthorization(ctx context.Context, req *AppsResetAuthorizationReq,
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = AppsResetAuthorizationResponseBody{}
+	resp.Data = components.Authorization{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -4227,13 +4150,6 @@ func (r *AppsResetAuthorizationReq) Rel(link RelName, resp *AppsResetAuthorizati
 }
 
 /*
-AppsResetAuthorizationResponseBody is a response body for AppsResetAuthorization
-
-https://developer.github.com/v3/apps/oauth_applications/#reset-an-authorization
-*/
-type AppsResetAuthorizationResponseBody components.Authorization
-
-/*
 AppsResetAuthorizationResponse is a response for AppsResetAuthorization
 
 https://developer.github.com/v3/apps/oauth_applications/#reset-an-authorization
@@ -4241,7 +4157,7 @@ https://developer.github.com/v3/apps/oauth_applications/#reset-an-authorization
 type AppsResetAuthorizationResponse struct {
 	response
 	request *AppsResetAuthorizationReq
-	Data    AppsResetAuthorizationResponseBody
+	Data    components.Authorization
 }
 
 /*
@@ -4265,7 +4181,7 @@ func AppsResetToken(ctx context.Context, req *AppsResetTokenReq, opt ...RequestO
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = AppsResetTokenResponseBody{}
+	resp.Data = components.Authorization{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -4369,13 +4285,6 @@ type AppsResetTokenReqBody struct {
 }
 
 /*
-AppsResetTokenResponseBody is a response body for AppsResetToken
-
-https://developer.github.com/v3/apps/oauth_applications/#reset-a-token
-*/
-type AppsResetTokenResponseBody components.Authorization
-
-/*
 AppsResetTokenResponse is a response for AppsResetToken
 
 https://developer.github.com/v3/apps/oauth_applications/#reset-a-token
@@ -4383,7 +4292,7 @@ https://developer.github.com/v3/apps/oauth_applications/#reset-a-token
 type AppsResetTokenResponse struct {
 	response
 	request *AppsResetTokenReq
-	Data    AppsResetTokenResponseBody
+	Data    components.Authorization
 }
 
 /*

--- a/zz_apps_gen.go
+++ b/zz_apps_gen.go
@@ -2405,7 +2405,7 @@ func AppsListAccountsForPlan(ctx context.Context, req *AppsListAccountsForPlanRe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = AppsListAccountsForPlanResponseBody{}
+	resp.Data = []components.MarketplacePurchase{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2526,13 +2526,6 @@ func (r *AppsListAccountsForPlanReq) Rel(link RelName, resp *AppsListAccountsFor
 }
 
 /*
-AppsListAccountsForPlanResponseBody is a response body for AppsListAccountsForPlan
-
-https://developer.github.com/v3/apps/marketplace/#list-accounts-for-a-plan
-*/
-type AppsListAccountsForPlanResponseBody []components.MarketplacePurchase
-
-/*
 AppsListAccountsForPlanResponse is a response for AppsListAccountsForPlan
 
 https://developer.github.com/v3/apps/marketplace/#list-accounts-for-a-plan
@@ -2540,7 +2533,7 @@ https://developer.github.com/v3/apps/marketplace/#list-accounts-for-a-plan
 type AppsListAccountsForPlanResponse struct {
 	response
 	request *AppsListAccountsForPlanReq
-	Data    AppsListAccountsForPlanResponseBody
+	Data    []components.MarketplacePurchase
 }
 
 /*
@@ -2564,7 +2557,7 @@ func AppsListAccountsForPlanStubbed(ctx context.Context, req *AppsListAccountsFo
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = AppsListAccountsForPlanStubbedResponseBody{}
+	resp.Data = []components.MarketplacePurchase{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2685,13 +2678,6 @@ func (r *AppsListAccountsForPlanStubbedReq) Rel(link RelName, resp *AppsListAcco
 }
 
 /*
-AppsListAccountsForPlanStubbedResponseBody is a response body for AppsListAccountsForPlanStubbed
-
-https://developer.github.com/v3/apps/marketplace/#list-accounts-for-a-plan-stubbed
-*/
-type AppsListAccountsForPlanStubbedResponseBody []components.MarketplacePurchase
-
-/*
 AppsListAccountsForPlanStubbedResponse is a response for AppsListAccountsForPlanStubbed
 
 https://developer.github.com/v3/apps/marketplace/#list-accounts-for-a-plan-stubbed
@@ -2699,7 +2685,7 @@ https://developer.github.com/v3/apps/marketplace/#list-accounts-for-a-plan-stubb
 type AppsListAccountsForPlanStubbedResponse struct {
 	response
 	request *AppsListAccountsForPlanStubbedReq
-	Data    AppsListAccountsForPlanStubbedResponseBody
+	Data    []components.MarketplacePurchase
 }
 
 /*
@@ -2891,7 +2877,7 @@ func AppsListInstallations(ctx context.Context, req *AppsListInstallationsReq, o
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = AppsListInstallationsResponseBody{}
+	resp.Data = []components.Installation{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3017,13 +3003,6 @@ func (r *AppsListInstallationsReq) Rel(link RelName, resp *AppsListInstallations
 }
 
 /*
-AppsListInstallationsResponseBody is a response body for AppsListInstallations
-
-https://developer.github.com/v3/apps/#list-installations-for-the-authenticated-app
-*/
-type AppsListInstallationsResponseBody []components.Installation
-
-/*
 AppsListInstallationsResponse is a response for AppsListInstallations
 
 https://developer.github.com/v3/apps/#list-installations-for-the-authenticated-app
@@ -3031,7 +3010,7 @@ https://developer.github.com/v3/apps/#list-installations-for-the-authenticated-a
 type AppsListInstallationsResponse struct {
 	response
 	request *AppsListInstallationsReq
-	Data    AppsListInstallationsResponseBody
+	Data    []components.Installation
 }
 
 /*
@@ -3208,7 +3187,7 @@ func AppsListPlans(ctx context.Context, req *AppsListPlansReq, opt ...RequestOpt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = AppsListPlansResponseBody{}
+	resp.Data = []components.MarketplaceListingPlan{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3308,13 +3287,6 @@ func (r *AppsListPlansReq) Rel(link RelName, resp *AppsListPlansResponse) bool {
 }
 
 /*
-AppsListPlansResponseBody is a response body for AppsListPlans
-
-https://developer.github.com/v3/apps/marketplace/#list-plans
-*/
-type AppsListPlansResponseBody []components.MarketplaceListingPlan
-
-/*
 AppsListPlansResponse is a response for AppsListPlans
 
 https://developer.github.com/v3/apps/marketplace/#list-plans
@@ -3322,7 +3294,7 @@ https://developer.github.com/v3/apps/marketplace/#list-plans
 type AppsListPlansResponse struct {
 	response
 	request *AppsListPlansReq
-	Data    AppsListPlansResponseBody
+	Data    []components.MarketplaceListingPlan
 }
 
 /*
@@ -3346,7 +3318,7 @@ func AppsListPlansStubbed(ctx context.Context, req *AppsListPlansStubbedReq, opt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = AppsListPlansStubbedResponseBody{}
+	resp.Data = []components.MarketplaceListingPlan{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3446,13 +3418,6 @@ func (r *AppsListPlansStubbedReq) Rel(link RelName, resp *AppsListPlansStubbedRe
 }
 
 /*
-AppsListPlansStubbedResponseBody is a response body for AppsListPlansStubbed
-
-https://developer.github.com/v3/apps/marketplace/#list-plans-stubbed
-*/
-type AppsListPlansStubbedResponseBody []components.MarketplaceListingPlan
-
-/*
 AppsListPlansStubbedResponse is a response for AppsListPlansStubbed
 
 https://developer.github.com/v3/apps/marketplace/#list-plans-stubbed
@@ -3460,7 +3425,7 @@ https://developer.github.com/v3/apps/marketplace/#list-plans-stubbed
 type AppsListPlansStubbedResponse struct {
 	response
 	request *AppsListPlansStubbedReq
-	Data    AppsListPlansStubbedResponseBody
+	Data    []components.MarketplaceListingPlan
 }
 
 /*
@@ -3649,7 +3614,7 @@ func AppsListSubscriptionsForAuthenticatedUser(ctx context.Context, req *AppsLis
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = AppsListSubscriptionsForAuthenticatedUserResponseBody{}
+	resp.Data = []components.UserMarketplacePurchase{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3749,13 +3714,6 @@ func (r *AppsListSubscriptionsForAuthenticatedUserReq) Rel(link RelName, resp *A
 }
 
 /*
-AppsListSubscriptionsForAuthenticatedUserResponseBody is a response body for AppsListSubscriptionsForAuthenticatedUser
-
-https://developer.github.com/v3/apps/marketplace/#list-subscriptions-for-the-authenticated-user
-*/
-type AppsListSubscriptionsForAuthenticatedUserResponseBody []components.UserMarketplacePurchase
-
-/*
 AppsListSubscriptionsForAuthenticatedUserResponse is a response for AppsListSubscriptionsForAuthenticatedUser
 
 https://developer.github.com/v3/apps/marketplace/#list-subscriptions-for-the-authenticated-user
@@ -3763,7 +3721,7 @@ https://developer.github.com/v3/apps/marketplace/#list-subscriptions-for-the-aut
 type AppsListSubscriptionsForAuthenticatedUserResponse struct {
 	response
 	request *AppsListSubscriptionsForAuthenticatedUserReq
-	Data    AppsListSubscriptionsForAuthenticatedUserResponseBody
+	Data    []components.UserMarketplacePurchase
 }
 
 /*
@@ -3787,7 +3745,7 @@ func AppsListSubscriptionsForAuthenticatedUserStubbed(ctx context.Context, req *
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = AppsListSubscriptionsForAuthenticatedUserStubbedResponseBody{}
+	resp.Data = []components.UserMarketplacePurchase{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3887,13 +3845,6 @@ func (r *AppsListSubscriptionsForAuthenticatedUserStubbedReq) Rel(link RelName, 
 }
 
 /*
-AppsListSubscriptionsForAuthenticatedUserStubbedResponseBody is a response body for AppsListSubscriptionsForAuthenticatedUserStubbed
-
-https://developer.github.com/v3/apps/marketplace/#list-subscriptions-for-the-authenticated-user-stubbed
-*/
-type AppsListSubscriptionsForAuthenticatedUserStubbedResponseBody []components.UserMarketplacePurchase
-
-/*
 AppsListSubscriptionsForAuthenticatedUserStubbedResponse is a response for AppsListSubscriptionsForAuthenticatedUserStubbed
 
 https://developer.github.com/v3/apps/marketplace/#list-subscriptions-for-the-authenticated-user-stubbed
@@ -3901,7 +3852,7 @@ https://developer.github.com/v3/apps/marketplace/#list-subscriptions-for-the-aut
 type AppsListSubscriptionsForAuthenticatedUserStubbedResponse struct {
 	response
 	request *AppsListSubscriptionsForAuthenticatedUserStubbedReq
-	Data    AppsListSubscriptionsForAuthenticatedUserStubbedResponseBody
+	Data    []components.UserMarketplacePurchase
 }
 
 /*

--- a/zz_billing_gen.go
+++ b/zz_billing_gen.go
@@ -31,7 +31,7 @@ func BillingGetGithubActionsBillingGhe(ctx context.Context, req *BillingGetGithu
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = BillingGetGithubActionsBillingGheResponseBody{}
+	resp.Data = components.ActionsBillingUsage{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -122,13 +122,6 @@ func (r *BillingGetGithubActionsBillingGheReq) Rel(link RelName, resp *BillingGe
 }
 
 /*
-BillingGetGithubActionsBillingGheResponseBody is a response body for BillingGetGithubActionsBillingGhe
-
-https://developer.github.com/v3/billing/#get-github-actions-billing-for-an-enterprise
-*/
-type BillingGetGithubActionsBillingGheResponseBody components.ActionsBillingUsage
-
-/*
 BillingGetGithubActionsBillingGheResponse is a response for BillingGetGithubActionsBillingGhe
 
 https://developer.github.com/v3/billing/#get-github-actions-billing-for-an-enterprise
@@ -136,7 +129,7 @@ https://developer.github.com/v3/billing/#get-github-actions-billing-for-an-enter
 type BillingGetGithubActionsBillingGheResponse struct {
 	response
 	request *BillingGetGithubActionsBillingGheReq
-	Data    BillingGetGithubActionsBillingGheResponseBody
+	Data    components.ActionsBillingUsage
 }
 
 /*
@@ -160,7 +153,7 @@ func BillingGetGithubActionsBillingOrg(ctx context.Context, req *BillingGetGithu
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = BillingGetGithubActionsBillingOrgResponseBody{}
+	resp.Data = components.ActionsBillingUsage{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -249,13 +242,6 @@ func (r *BillingGetGithubActionsBillingOrgReq) Rel(link RelName, resp *BillingGe
 }
 
 /*
-BillingGetGithubActionsBillingOrgResponseBody is a response body for BillingGetGithubActionsBillingOrg
-
-https://developer.github.com/v3/billing/#get-github-actions-billing-for-an-organization
-*/
-type BillingGetGithubActionsBillingOrgResponseBody components.ActionsBillingUsage
-
-/*
 BillingGetGithubActionsBillingOrgResponse is a response for BillingGetGithubActionsBillingOrg
 
 https://developer.github.com/v3/billing/#get-github-actions-billing-for-an-organization
@@ -263,7 +249,7 @@ https://developer.github.com/v3/billing/#get-github-actions-billing-for-an-organ
 type BillingGetGithubActionsBillingOrgResponse struct {
 	response
 	request *BillingGetGithubActionsBillingOrgReq
-	Data    BillingGetGithubActionsBillingOrgResponseBody
+	Data    components.ActionsBillingUsage
 }
 
 /*
@@ -287,7 +273,7 @@ func BillingGetGithubActionsBillingUser(ctx context.Context, req *BillingGetGith
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = BillingGetGithubActionsBillingUserResponseBody{}
+	resp.Data = components.ActionsBillingUsage{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -376,13 +362,6 @@ func (r *BillingGetGithubActionsBillingUserReq) Rel(link RelName, resp *BillingG
 }
 
 /*
-BillingGetGithubActionsBillingUserResponseBody is a response body for BillingGetGithubActionsBillingUser
-
-https://developer.github.com/v3/billing/#get-github-actions-billing-for-a-user
-*/
-type BillingGetGithubActionsBillingUserResponseBody components.ActionsBillingUsage
-
-/*
 BillingGetGithubActionsBillingUserResponse is a response for BillingGetGithubActionsBillingUser
 
 https://developer.github.com/v3/billing/#get-github-actions-billing-for-a-user
@@ -390,7 +369,7 @@ https://developer.github.com/v3/billing/#get-github-actions-billing-for-a-user
 type BillingGetGithubActionsBillingUserResponse struct {
 	response
 	request *BillingGetGithubActionsBillingUserReq
-	Data    BillingGetGithubActionsBillingUserResponseBody
+	Data    components.ActionsBillingUsage
 }
 
 /*
@@ -414,7 +393,7 @@ func BillingGetGithubPackagesBillingGhe(ctx context.Context, req *BillingGetGith
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = BillingGetGithubPackagesBillingGheResponseBody{}
+	resp.Data = components.PackagesBillingUsage{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -505,13 +484,6 @@ func (r *BillingGetGithubPackagesBillingGheReq) Rel(link RelName, resp *BillingG
 }
 
 /*
-BillingGetGithubPackagesBillingGheResponseBody is a response body for BillingGetGithubPackagesBillingGhe
-
-https://developer.github.com/v3/billing/#get-github-packages-billing-for-an-enterprise
-*/
-type BillingGetGithubPackagesBillingGheResponseBody components.PackagesBillingUsage
-
-/*
 BillingGetGithubPackagesBillingGheResponse is a response for BillingGetGithubPackagesBillingGhe
 
 https://developer.github.com/v3/billing/#get-github-packages-billing-for-an-enterprise
@@ -519,7 +491,7 @@ https://developer.github.com/v3/billing/#get-github-packages-billing-for-an-ente
 type BillingGetGithubPackagesBillingGheResponse struct {
 	response
 	request *BillingGetGithubPackagesBillingGheReq
-	Data    BillingGetGithubPackagesBillingGheResponseBody
+	Data    components.PackagesBillingUsage
 }
 
 /*
@@ -543,7 +515,7 @@ func BillingGetGithubPackagesBillingOrg(ctx context.Context, req *BillingGetGith
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = BillingGetGithubPackagesBillingOrgResponseBody{}
+	resp.Data = components.PackagesBillingUsage{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -632,13 +604,6 @@ func (r *BillingGetGithubPackagesBillingOrgReq) Rel(link RelName, resp *BillingG
 }
 
 /*
-BillingGetGithubPackagesBillingOrgResponseBody is a response body for BillingGetGithubPackagesBillingOrg
-
-https://developer.github.com/v3/billing/#get-github-packages-billing-for-an-organization
-*/
-type BillingGetGithubPackagesBillingOrgResponseBody components.PackagesBillingUsage
-
-/*
 BillingGetGithubPackagesBillingOrgResponse is a response for BillingGetGithubPackagesBillingOrg
 
 https://developer.github.com/v3/billing/#get-github-packages-billing-for-an-organization
@@ -646,7 +611,7 @@ https://developer.github.com/v3/billing/#get-github-packages-billing-for-an-orga
 type BillingGetGithubPackagesBillingOrgResponse struct {
 	response
 	request *BillingGetGithubPackagesBillingOrgReq
-	Data    BillingGetGithubPackagesBillingOrgResponseBody
+	Data    components.PackagesBillingUsage
 }
 
 /*
@@ -670,7 +635,7 @@ func BillingGetGithubPackagesBillingUser(ctx context.Context, req *BillingGetGit
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = BillingGetGithubPackagesBillingUserResponseBody{}
+	resp.Data = components.PackagesBillingUsage{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -759,13 +724,6 @@ func (r *BillingGetGithubPackagesBillingUserReq) Rel(link RelName, resp *Billing
 }
 
 /*
-BillingGetGithubPackagesBillingUserResponseBody is a response body for BillingGetGithubPackagesBillingUser
-
-https://developer.github.com/v3/billing/#get-github-packages-billing-for-a-user
-*/
-type BillingGetGithubPackagesBillingUserResponseBody components.PackagesBillingUsage
-
-/*
 BillingGetGithubPackagesBillingUserResponse is a response for BillingGetGithubPackagesBillingUser
 
 https://developer.github.com/v3/billing/#get-github-packages-billing-for-a-user
@@ -773,7 +731,7 @@ https://developer.github.com/v3/billing/#get-github-packages-billing-for-a-user
 type BillingGetGithubPackagesBillingUserResponse struct {
 	response
 	request *BillingGetGithubPackagesBillingUserReq
-	Data    BillingGetGithubPackagesBillingUserResponseBody
+	Data    components.PackagesBillingUsage
 }
 
 /*
@@ -797,7 +755,7 @@ func BillingGetSharedStorageBillingGhe(ctx context.Context, req *BillingGetShare
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = BillingGetSharedStorageBillingGheResponseBody{}
+	resp.Data = components.CombinedBillingUsage{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -888,13 +846,6 @@ func (r *BillingGetSharedStorageBillingGheReq) Rel(link RelName, resp *BillingGe
 }
 
 /*
-BillingGetSharedStorageBillingGheResponseBody is a response body for BillingGetSharedStorageBillingGhe
-
-https://developer.github.com/v3/billing/#get-shared-storage-billing-for-an-enterprise
-*/
-type BillingGetSharedStorageBillingGheResponseBody components.CombinedBillingUsage
-
-/*
 BillingGetSharedStorageBillingGheResponse is a response for BillingGetSharedStorageBillingGhe
 
 https://developer.github.com/v3/billing/#get-shared-storage-billing-for-an-enterprise
@@ -902,7 +853,7 @@ https://developer.github.com/v3/billing/#get-shared-storage-billing-for-an-enter
 type BillingGetSharedStorageBillingGheResponse struct {
 	response
 	request *BillingGetSharedStorageBillingGheReq
-	Data    BillingGetSharedStorageBillingGheResponseBody
+	Data    components.CombinedBillingUsage
 }
 
 /*
@@ -926,7 +877,7 @@ func BillingGetSharedStorageBillingOrg(ctx context.Context, req *BillingGetShare
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = BillingGetSharedStorageBillingOrgResponseBody{}
+	resp.Data = components.CombinedBillingUsage{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1015,13 +966,6 @@ func (r *BillingGetSharedStorageBillingOrgReq) Rel(link RelName, resp *BillingGe
 }
 
 /*
-BillingGetSharedStorageBillingOrgResponseBody is a response body for BillingGetSharedStorageBillingOrg
-
-https://developer.github.com/v3/billing/#get-shared-storage-billing-for-an-organization
-*/
-type BillingGetSharedStorageBillingOrgResponseBody components.CombinedBillingUsage
-
-/*
 BillingGetSharedStorageBillingOrgResponse is a response for BillingGetSharedStorageBillingOrg
 
 https://developer.github.com/v3/billing/#get-shared-storage-billing-for-an-organization
@@ -1029,7 +973,7 @@ https://developer.github.com/v3/billing/#get-shared-storage-billing-for-an-organ
 type BillingGetSharedStorageBillingOrgResponse struct {
 	response
 	request *BillingGetSharedStorageBillingOrgReq
-	Data    BillingGetSharedStorageBillingOrgResponseBody
+	Data    components.CombinedBillingUsage
 }
 
 /*
@@ -1053,7 +997,7 @@ func BillingGetSharedStorageBillingUser(ctx context.Context, req *BillingGetShar
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = BillingGetSharedStorageBillingUserResponseBody{}
+	resp.Data = components.CombinedBillingUsage{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1142,13 +1086,6 @@ func (r *BillingGetSharedStorageBillingUserReq) Rel(link RelName, resp *BillingG
 }
 
 /*
-BillingGetSharedStorageBillingUserResponseBody is a response body for BillingGetSharedStorageBillingUser
-
-https://developer.github.com/v3/billing/#get-shared-storage-billing-for-a-user
-*/
-type BillingGetSharedStorageBillingUserResponseBody components.CombinedBillingUsage
-
-/*
 BillingGetSharedStorageBillingUserResponse is a response for BillingGetSharedStorageBillingUser
 
 https://developer.github.com/v3/billing/#get-shared-storage-billing-for-a-user
@@ -1156,5 +1093,5 @@ https://developer.github.com/v3/billing/#get-shared-storage-billing-for-a-user
 type BillingGetSharedStorageBillingUserResponse struct {
 	response
 	request *BillingGetSharedStorageBillingUserReq
-	Data    BillingGetSharedStorageBillingUserResponseBody
+	Data    components.CombinedBillingUsage
 }

--- a/zz_checks_gen.go
+++ b/zz_checks_gen.go
@@ -32,7 +32,7 @@ func ChecksCreate(ctx context.Context, req *ChecksCreateReq, opt ...RequestOptio
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ChecksCreateResponseBody{}
+	resp.Data = components.CheckRun{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -319,13 +319,6 @@ type ChecksCreateReqBody struct {
 }
 
 /*
-ChecksCreateResponseBody is a response body for ChecksCreate
-
-https://developer.github.com/v3/checks/runs/#create-a-check-run
-*/
-type ChecksCreateResponseBody components.CheckRun
-
-/*
 ChecksCreateResponse is a response for ChecksCreate
 
 https://developer.github.com/v3/checks/runs/#create-a-check-run
@@ -333,7 +326,7 @@ https://developer.github.com/v3/checks/runs/#create-a-check-run
 type ChecksCreateResponse struct {
 	response
 	request *ChecksCreateReq
-	Data    ChecksCreateResponseBody
+	Data    components.CheckRun
 }
 
 /*
@@ -357,7 +350,7 @@ func ChecksCreateSuite(ctx context.Context, req *ChecksCreateSuiteReq, opt ...Re
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ChecksCreateSuiteResponseBody{}
+	resp.Data = components.CheckSuite{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -477,13 +470,6 @@ type ChecksCreateSuiteReqBody struct {
 }
 
 /*
-ChecksCreateSuiteResponseBody is a response body for ChecksCreateSuite
-
-https://developer.github.com/v3/checks/suites/#create-a-check-suite
-*/
-type ChecksCreateSuiteResponseBody components.CheckSuite
-
-/*
 ChecksCreateSuiteResponse is a response for ChecksCreateSuite
 
 https://developer.github.com/v3/checks/suites/#create-a-check-suite
@@ -491,7 +477,7 @@ https://developer.github.com/v3/checks/suites/#create-a-check-suite
 type ChecksCreateSuiteResponse struct {
 	response
 	request *ChecksCreateSuiteReq
-	Data    ChecksCreateSuiteResponseBody
+	Data    components.CheckSuite
 }
 
 /*
@@ -515,7 +501,7 @@ func ChecksGet(ctx context.Context, req *ChecksGetReq, opt ...RequestOption) (*C
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ChecksGetResponseBody{}
+	resp.Data = components.CheckRun{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -623,13 +609,6 @@ func (r *ChecksGetReq) Rel(link RelName, resp *ChecksGetResponse) bool {
 }
 
 /*
-ChecksGetResponseBody is a response body for ChecksGet
-
-https://developer.github.com/v3/checks/runs/#get-a-check-run
-*/
-type ChecksGetResponseBody components.CheckRun
-
-/*
 ChecksGetResponse is a response for ChecksGet
 
 https://developer.github.com/v3/checks/runs/#get-a-check-run
@@ -637,7 +616,7 @@ https://developer.github.com/v3/checks/runs/#get-a-check-run
 type ChecksGetResponse struct {
 	response
 	request *ChecksGetReq
-	Data    ChecksGetResponseBody
+	Data    components.CheckRun
 }
 
 /*
@@ -661,7 +640,7 @@ func ChecksGetSuite(ctx context.Context, req *ChecksGetSuiteReq, opt ...RequestO
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ChecksGetSuiteResponseBody{}
+	resp.Data = components.CheckSuite{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -769,13 +748,6 @@ func (r *ChecksGetSuiteReq) Rel(link RelName, resp *ChecksGetSuiteResponse) bool
 }
 
 /*
-ChecksGetSuiteResponseBody is a response body for ChecksGetSuite
-
-https://developer.github.com/v3/checks/suites/#get-a-check-suite
-*/
-type ChecksGetSuiteResponseBody components.CheckSuite
-
-/*
 ChecksGetSuiteResponse is a response for ChecksGetSuite
 
 https://developer.github.com/v3/checks/suites/#get-a-check-suite
@@ -783,7 +755,7 @@ https://developer.github.com/v3/checks/suites/#get-a-check-suite
 type ChecksGetSuiteResponse struct {
 	response
 	request *ChecksGetSuiteReq
-	Data    ChecksGetSuiteResponseBody
+	Data    components.CheckSuite
 }
 
 /*
@@ -1645,7 +1617,7 @@ func ChecksSetSuitesPreferences(ctx context.Context, req *ChecksSetSuitesPrefere
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ChecksSetSuitesPreferencesResponseBody{}
+	resp.Data = components.CheckSuitePreference{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1783,13 +1755,6 @@ type ChecksSetSuitesPreferencesReqBody struct {
 }
 
 /*
-ChecksSetSuitesPreferencesResponseBody is a response body for ChecksSetSuitesPreferences
-
-https://developer.github.com/v3/checks/suites/#update-repository-preferences-for-check-suites
-*/
-type ChecksSetSuitesPreferencesResponseBody components.CheckSuitePreference
-
-/*
 ChecksSetSuitesPreferencesResponse is a response for ChecksSetSuitesPreferences
 
 https://developer.github.com/v3/checks/suites/#update-repository-preferences-for-check-suites
@@ -1797,7 +1762,7 @@ https://developer.github.com/v3/checks/suites/#update-repository-preferences-for
 type ChecksSetSuitesPreferencesResponse struct {
 	response
 	request *ChecksSetSuitesPreferencesReq
-	Data    ChecksSetSuitesPreferencesResponseBody
+	Data    components.CheckSuitePreference
 }
 
 /*
@@ -1821,7 +1786,7 @@ func ChecksUpdate(ctx context.Context, req *ChecksUpdateReq, opt ...RequestOptio
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ChecksUpdateResponseBody{}
+	resp.Data = components.CheckRun{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2094,13 +2059,6 @@ type ChecksUpdateReqBody struct {
 }
 
 /*
-ChecksUpdateResponseBody is a response body for ChecksUpdate
-
-https://developer.github.com/v3/checks/runs/#update-a-check-run
-*/
-type ChecksUpdateResponseBody components.CheckRun
-
-/*
 ChecksUpdateResponse is a response for ChecksUpdate
 
 https://developer.github.com/v3/checks/runs/#update-a-check-run
@@ -2108,5 +2066,5 @@ https://developer.github.com/v3/checks/runs/#update-a-check-run
 type ChecksUpdateResponse struct {
 	response
 	request *ChecksUpdateReq
-	Data    ChecksUpdateResponseBody
+	Data    components.CheckRun
 }

--- a/zz_checks_gen.go
+++ b/zz_checks_gen.go
@@ -779,7 +779,7 @@ func ChecksListAnnotations(ctx context.Context, req *ChecksListAnnotationsReq, o
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ChecksListAnnotationsResponseBody{}
+	resp.Data = []components.CheckAnnotation{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -899,13 +899,6 @@ func (r *ChecksListAnnotationsReq) Rel(link RelName, resp *ChecksListAnnotations
 }
 
 /*
-ChecksListAnnotationsResponseBody is a response body for ChecksListAnnotations
-
-https://developer.github.com/v3/checks/runs/#list-check-run-annotations
-*/
-type ChecksListAnnotationsResponseBody []components.CheckAnnotation
-
-/*
 ChecksListAnnotationsResponse is a response for ChecksListAnnotations
 
 https://developer.github.com/v3/checks/runs/#list-check-run-annotations
@@ -913,7 +906,7 @@ https://developer.github.com/v3/checks/runs/#list-check-run-annotations
 type ChecksListAnnotationsResponse struct {
 	response
 	request *ChecksListAnnotationsReq
-	Data    ChecksListAnnotationsResponseBody
+	Data    []components.CheckAnnotation
 }
 
 /*

--- a/zz_code_scanning_gen.go
+++ b/zz_code_scanning_gen.go
@@ -31,7 +31,7 @@ func CodeScanningGetAlert(ctx context.Context, req *CodeScanningGetAlertReq, opt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = CodeScanningGetAlertResponseBody{}
+	resp.Data = components.CodeScanningAlert{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -124,13 +124,6 @@ func (r *CodeScanningGetAlertReq) Rel(link RelName, resp *CodeScanningGetAlertRe
 }
 
 /*
-CodeScanningGetAlertResponseBody is a response body for CodeScanningGetAlert
-
-https://developer.github.com/v3/code-scanning/#get-a-code-scanning-alert
-*/
-type CodeScanningGetAlertResponseBody components.CodeScanningAlert
-
-/*
 CodeScanningGetAlertResponse is a response for CodeScanningGetAlert
 
 https://developer.github.com/v3/code-scanning/#get-a-code-scanning-alert
@@ -138,7 +131,7 @@ https://developer.github.com/v3/code-scanning/#get-a-code-scanning-alert
 type CodeScanningGetAlertResponse struct {
 	response
 	request *CodeScanningGetAlertReq
-	Data    CodeScanningGetAlertResponseBody
+	Data    components.CodeScanningAlert
 }
 
 /*

--- a/zz_code_scanning_gen.go
+++ b/zz_code_scanning_gen.go
@@ -155,7 +155,7 @@ func CodeScanningListAlertsForRepo(ctx context.Context, req *CodeScanningListAle
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = CodeScanningListAlertsForRepoResponseBody{}
+	resp.Data = []components.CodeScanningAlert{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -260,13 +260,6 @@ func (r *CodeScanningListAlertsForRepoReq) Rel(link RelName, resp *CodeScanningL
 }
 
 /*
-CodeScanningListAlertsForRepoResponseBody is a response body for CodeScanningListAlertsForRepo
-
-https://developer.github.com/v3/code-scanning/#list-code-scanning-alerts-for-a-repository
-*/
-type CodeScanningListAlertsForRepoResponseBody []components.CodeScanningAlert
-
-/*
 CodeScanningListAlertsForRepoResponse is a response for CodeScanningListAlertsForRepo
 
 https://developer.github.com/v3/code-scanning/#list-code-scanning-alerts-for-a-repository
@@ -274,5 +267,5 @@ https://developer.github.com/v3/code-scanning/#list-code-scanning-alerts-for-a-r
 type CodeScanningListAlertsForRepoResponse struct {
 	response
 	request *CodeScanningListAlertsForRepoReq
-	Data    CodeScanningListAlertsForRepoResponseBody
+	Data    []components.CodeScanningAlert
 }

--- a/zz_codes_of_conduct_gen.go
+++ b/zz_codes_of_conduct_gen.go
@@ -170,7 +170,7 @@ func CodesOfConductGetConductCode(ctx context.Context, req *CodesOfConductGetCon
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = CodesOfConductGetConductCodeResponseBody{}
+	resp.Data = components.CodeOfConduct{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -274,13 +274,6 @@ func (r *CodesOfConductGetConductCodeReq) Rel(link RelName, resp *CodesOfConduct
 }
 
 /*
-CodesOfConductGetConductCodeResponseBody is a response body for CodesOfConductGetConductCode
-
-https://developer.github.com/v3/codes_of_conduct/#get-a-code-of-conduct
-*/
-type CodesOfConductGetConductCodeResponseBody components.CodeOfConduct
-
-/*
 CodesOfConductGetConductCodeResponse is a response for CodesOfConductGetConductCode
 
 https://developer.github.com/v3/codes_of_conduct/#get-a-code-of-conduct
@@ -288,7 +281,7 @@ https://developer.github.com/v3/codes_of_conduct/#get-a-code-of-conduct
 type CodesOfConductGetConductCodeResponse struct {
 	response
 	request *CodesOfConductGetConductCodeReq
-	Data    CodesOfConductGetConductCodeResponseBody
+	Data    components.CodeOfConduct
 }
 
 /*
@@ -312,7 +305,7 @@ func CodesOfConductGetForRepo(ctx context.Context, req *CodesOfConductGetForRepo
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = CodesOfConductGetForRepoResponseBody{}
+	resp.Data = components.CodeOfConduct{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -415,13 +408,6 @@ func (r *CodesOfConductGetForRepoReq) Rel(link RelName, resp *CodesOfConductGetF
 }
 
 /*
-CodesOfConductGetForRepoResponseBody is a response body for CodesOfConductGetForRepo
-
-https://developer.github.com/v3/codes_of_conduct/#get-the-code-of-conduct-for-a-repository
-*/
-type CodesOfConductGetForRepoResponseBody components.CodeOfConduct
-
-/*
 CodesOfConductGetForRepoResponse is a response for CodesOfConductGetForRepo
 
 https://developer.github.com/v3/codes_of_conduct/#get-the-code-of-conduct-for-a-repository
@@ -429,5 +415,5 @@ https://developer.github.com/v3/codes_of_conduct/#get-the-code-of-conduct-for-a-
 type CodesOfConductGetForRepoResponse struct {
 	response
 	request *CodesOfConductGetForRepoReq
-	Data    CodesOfConductGetForRepoResponseBody
+	Data    components.CodeOfConduct
 }

--- a/zz_codes_of_conduct_gen.go
+++ b/zz_codes_of_conduct_gen.go
@@ -31,7 +31,7 @@ func CodesOfConductGetAllCodesOfConduct(ctx context.Context, req *CodesOfConduct
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = CodesOfConductGetAllCodesOfConductResponseBody{}
+	resp.Data = []components.CodeOfConduct{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -132,13 +132,6 @@ func (r *CodesOfConductGetAllCodesOfConductReq) Rel(link RelName, resp *CodesOfC
 }
 
 /*
-CodesOfConductGetAllCodesOfConductResponseBody is a response body for CodesOfConductGetAllCodesOfConduct
-
-https://developer.github.com/v3/codes_of_conduct/#get-all-codes-of-conduct
-*/
-type CodesOfConductGetAllCodesOfConductResponseBody []components.CodeOfConduct
-
-/*
 CodesOfConductGetAllCodesOfConductResponse is a response for CodesOfConductGetAllCodesOfConduct
 
 https://developer.github.com/v3/codes_of_conduct/#get-all-codes-of-conduct
@@ -146,7 +139,7 @@ https://developer.github.com/v3/codes_of_conduct/#get-all-codes-of-conduct
 type CodesOfConductGetAllCodesOfConductResponse struct {
 	response
 	request *CodesOfConductGetAllCodesOfConductReq
-	Data    CodesOfConductGetAllCodesOfConductResponseBody
+	Data    []components.CodeOfConduct
 }
 
 /*

--- a/zz_gists_gen.go
+++ b/zz_gists_gen.go
@@ -152,7 +152,7 @@ func GistsCreate(ctx context.Context, req *GistsCreateReq, opt ...RequestOption)
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GistsCreateResponseBody{}
+	resp.Data = components.GistFull{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -268,13 +268,6 @@ type GistsCreateReqBody struct {
 }
 
 /*
-GistsCreateResponseBody is a response body for GistsCreate
-
-https://developer.github.com/v3/gists/#create-a-gist
-*/
-type GistsCreateResponseBody components.GistFull
-
-/*
 GistsCreateResponse is a response for GistsCreate
 
 https://developer.github.com/v3/gists/#create-a-gist
@@ -282,7 +275,7 @@ https://developer.github.com/v3/gists/#create-a-gist
 type GistsCreateResponse struct {
 	response
 	request *GistsCreateReq
-	Data    GistsCreateResponseBody
+	Data    components.GistFull
 }
 
 /*
@@ -306,7 +299,7 @@ func GistsCreateComment(ctx context.Context, req *GistsCreateCommentReq, opt ...
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GistsCreateCommentResponseBody{}
+	resp.Data = components.GistComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -412,13 +405,6 @@ type GistsCreateCommentReqBody struct {
 }
 
 /*
-GistsCreateCommentResponseBody is a response body for GistsCreateComment
-
-https://developer.github.com/v3/gists/comments/#create-a-gist-comment
-*/
-type GistsCreateCommentResponseBody components.GistComment
-
-/*
 GistsCreateCommentResponse is a response for GistsCreateComment
 
 https://developer.github.com/v3/gists/comments/#create-a-gist-comment
@@ -426,7 +412,7 @@ https://developer.github.com/v3/gists/comments/#create-a-gist-comment
 type GistsCreateCommentResponse struct {
 	response
 	request *GistsCreateCommentReq
-	Data    GistsCreateCommentResponseBody
+	Data    components.GistComment
 }
 
 /*
@@ -693,7 +679,7 @@ func GistsFork(ctx context.Context, req *GistsForkReq, opt ...RequestOption) (*G
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GistsForkResponseBody{}
+	resp.Data = components.BaseGist{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -784,13 +770,6 @@ func (r *GistsForkReq) Rel(link RelName, resp *GistsForkResponse) bool {
 }
 
 /*
-GistsForkResponseBody is a response body for GistsFork
-
-https://developer.github.com/v3/gists/#fork-a-gist
-*/
-type GistsForkResponseBody components.BaseGist
-
-/*
 GistsForkResponse is a response for GistsFork
 
 https://developer.github.com/v3/gists/#fork-a-gist
@@ -798,7 +777,7 @@ https://developer.github.com/v3/gists/#fork-a-gist
 type GistsForkResponse struct {
 	response
 	request *GistsForkReq
-	Data    GistsForkResponseBody
+	Data    components.BaseGist
 }
 
 /*
@@ -822,7 +801,7 @@ func GistsGet(ctx context.Context, req *GistsGetReq, opt ...RequestOption) (*Gis
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GistsGetResponseBody{}
+	resp.Data = components.GistFull{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -913,13 +892,6 @@ func (r *GistsGetReq) Rel(link RelName, resp *GistsGetResponse) bool {
 }
 
 /*
-GistsGetResponseBody is a response body for GistsGet
-
-https://developer.github.com/v3/gists/#get-a-gist
-*/
-type GistsGetResponseBody components.GistFull
-
-/*
 GistsGetResponse is a response for GistsGet
 
 https://developer.github.com/v3/gists/#get-a-gist
@@ -927,7 +899,7 @@ https://developer.github.com/v3/gists/#get-a-gist
 type GistsGetResponse struct {
 	response
 	request *GistsGetReq
-	Data    GistsGetResponseBody
+	Data    components.GistFull
 }
 
 /*
@@ -951,7 +923,7 @@ func GistsGetComment(ctx context.Context, req *GistsGetCommentReq, opt ...Reques
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GistsGetCommentResponseBody{}
+	resp.Data = components.GistComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1045,13 +1017,6 @@ func (r *GistsGetCommentReq) Rel(link RelName, resp *GistsGetCommentResponse) bo
 }
 
 /*
-GistsGetCommentResponseBody is a response body for GistsGetComment
-
-https://developer.github.com/v3/gists/comments/#get-a-gist-comment
-*/
-type GistsGetCommentResponseBody components.GistComment
-
-/*
 GistsGetCommentResponse is a response for GistsGetComment
 
 https://developer.github.com/v3/gists/comments/#get-a-gist-comment
@@ -1059,7 +1024,7 @@ https://developer.github.com/v3/gists/comments/#get-a-gist-comment
 type GistsGetCommentResponse struct {
 	response
 	request *GistsGetCommentReq
-	Data    GistsGetCommentResponseBody
+	Data    components.GistComment
 }
 
 /*
@@ -1083,7 +1048,7 @@ func GistsGetRevision(ctx context.Context, req *GistsGetRevisionReq, opt ...Requ
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GistsGetRevisionResponseBody{}
+	resp.Data = components.GistFull{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1177,13 +1142,6 @@ func (r *GistsGetRevisionReq) Rel(link RelName, resp *GistsGetRevisionResponse) 
 }
 
 /*
-GistsGetRevisionResponseBody is a response body for GistsGetRevision
-
-https://developer.github.com/v3/gists/#get-a-gist-revision
-*/
-type GistsGetRevisionResponseBody components.GistFull
-
-/*
 GistsGetRevisionResponse is a response for GistsGetRevision
 
 https://developer.github.com/v3/gists/#get-a-gist-revision
@@ -1191,7 +1149,7 @@ https://developer.github.com/v3/gists/#get-a-gist-revision
 type GistsGetRevisionResponse struct {
 	response
 	request *GistsGetRevisionReq
-	Data    GistsGetRevisionResponseBody
+	Data    components.GistFull
 }
 
 /*
@@ -2471,7 +2429,7 @@ func GistsUpdate(ctx context.Context, req *GistsUpdateReq, opt ...RequestOption)
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GistsUpdateResponseBody{}
+	resp.Data = components.GistFull{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2590,13 +2548,6 @@ type GistsUpdateReqBody struct {
 }
 
 /*
-GistsUpdateResponseBody is a response body for GistsUpdate
-
-https://developer.github.com/v3/gists/#update-a-gist
-*/
-type GistsUpdateResponseBody components.GistFull
-
-/*
 GistsUpdateResponse is a response for GistsUpdate
 
 https://developer.github.com/v3/gists/#update-a-gist
@@ -2604,7 +2555,7 @@ https://developer.github.com/v3/gists/#update-a-gist
 type GistsUpdateResponse struct {
 	response
 	request *GistsUpdateReq
-	Data    GistsUpdateResponseBody
+	Data    components.GistFull
 }
 
 /*
@@ -2628,7 +2579,7 @@ func GistsUpdateComment(ctx context.Context, req *GistsUpdateCommentReq, opt ...
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GistsUpdateCommentResponseBody{}
+	resp.Data = components.GistComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2737,13 +2688,6 @@ type GistsUpdateCommentReqBody struct {
 }
 
 /*
-GistsUpdateCommentResponseBody is a response body for GistsUpdateComment
-
-https://developer.github.com/v3/gists/comments/#update-a-gist-comment
-*/
-type GistsUpdateCommentResponseBody components.GistComment
-
-/*
 GistsUpdateCommentResponse is a response for GistsUpdateComment
 
 https://developer.github.com/v3/gists/comments/#update-a-gist-comment
@@ -2751,5 +2695,5 @@ https://developer.github.com/v3/gists/comments/#update-a-gist-comment
 type GistsUpdateCommentResponse struct {
 	response
 	request *GistsUpdateCommentReq
-	Data    GistsUpdateCommentResponseBody
+	Data    components.GistComment
 }

--- a/zz_gists_gen.go
+++ b/zz_gists_gen.go
@@ -1173,7 +1173,7 @@ func GistsList(ctx context.Context, req *GistsListReq, opt ...RequestOption) (*G
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GistsListResponseBody{}
+	resp.Data = []components.BaseGist{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1283,13 +1283,6 @@ func (r *GistsListReq) Rel(link RelName, resp *GistsListResponse) bool {
 }
 
 /*
-GistsListResponseBody is a response body for GistsList
-
-https://developer.github.com/v3/gists/#list-gists-for-the-authenticated-user
-*/
-type GistsListResponseBody []components.BaseGist
-
-/*
 GistsListResponse is a response for GistsList
 
 https://developer.github.com/v3/gists/#list-gists-for-the-authenticated-user
@@ -1297,7 +1290,7 @@ https://developer.github.com/v3/gists/#list-gists-for-the-authenticated-user
 type GistsListResponse struct {
 	response
 	request *GistsListReq
-	Data    GistsListResponseBody
+	Data    []components.BaseGist
 }
 
 /*
@@ -1321,7 +1314,7 @@ func GistsListComments(ctx context.Context, req *GistsListCommentsReq, opt ...Re
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GistsListCommentsResponseBody{}
+	resp.Data = []components.GistComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1424,13 +1417,6 @@ func (r *GistsListCommentsReq) Rel(link RelName, resp *GistsListCommentsResponse
 }
 
 /*
-GistsListCommentsResponseBody is a response body for GistsListComments
-
-https://developer.github.com/v3/gists/comments/#list-gist-comments
-*/
-type GistsListCommentsResponseBody []components.GistComment
-
-/*
 GistsListCommentsResponse is a response for GistsListComments
 
 https://developer.github.com/v3/gists/comments/#list-gist-comments
@@ -1438,7 +1424,7 @@ https://developer.github.com/v3/gists/comments/#list-gist-comments
 type GistsListCommentsResponse struct {
 	response
 	request *GistsListCommentsReq
-	Data    GistsListCommentsResponseBody
+	Data    []components.GistComment
 }
 
 /*
@@ -1462,7 +1448,7 @@ func GistsListCommits(ctx context.Context, req *GistsListCommitsReq, opt ...Requ
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GistsListCommitsResponseBody{}
+	resp.Data = []components.GistCommit{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1565,13 +1551,6 @@ func (r *GistsListCommitsReq) Rel(link RelName, resp *GistsListCommitsResponse) 
 }
 
 /*
-GistsListCommitsResponseBody is a response body for GistsListCommits
-
-https://developer.github.com/v3/gists/#list-gist-commits
-*/
-type GistsListCommitsResponseBody []components.GistCommit
-
-/*
 GistsListCommitsResponse is a response for GistsListCommits
 
 https://developer.github.com/v3/gists/#list-gist-commits
@@ -1579,7 +1558,7 @@ https://developer.github.com/v3/gists/#list-gist-commits
 type GistsListCommitsResponse struct {
 	response
 	request *GistsListCommitsReq
-	Data    GistsListCommitsResponseBody
+	Data    []components.GistCommit
 }
 
 /*
@@ -1603,7 +1582,7 @@ func GistsListForUser(ctx context.Context, req *GistsListForUserReq, opt ...Requ
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GistsListForUserResponseBody{}
+	resp.Data = []components.BaseGist{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1714,13 +1693,6 @@ func (r *GistsListForUserReq) Rel(link RelName, resp *GistsListForUserResponse) 
 }
 
 /*
-GistsListForUserResponseBody is a response body for GistsListForUser
-
-https://developer.github.com/v3/gists/#list-gists-for-a-user
-*/
-type GistsListForUserResponseBody []components.BaseGist
-
-/*
 GistsListForUserResponse is a response for GistsListForUser
 
 https://developer.github.com/v3/gists/#list-gists-for-a-user
@@ -1728,7 +1700,7 @@ https://developer.github.com/v3/gists/#list-gists-for-a-user
 type GistsListForUserResponse struct {
 	response
 	request *GistsListForUserReq
-	Data    GistsListForUserResponseBody
+	Data    []components.BaseGist
 }
 
 /*
@@ -1752,7 +1724,7 @@ func GistsListForks(ctx context.Context, req *GistsListForksReq, opt ...RequestO
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GistsListForksResponseBody{}
+	resp.Data = []components.GistFull{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1855,13 +1827,6 @@ func (r *GistsListForksReq) Rel(link RelName, resp *GistsListForksResponse) bool
 }
 
 /*
-GistsListForksResponseBody is a response body for GistsListForks
-
-https://developer.github.com/v3/gists/#list-gist-forks
-*/
-type GistsListForksResponseBody []components.GistFull
-
-/*
 GistsListForksResponse is a response for GistsListForks
 
 https://developer.github.com/v3/gists/#list-gist-forks
@@ -1869,7 +1834,7 @@ https://developer.github.com/v3/gists/#list-gist-forks
 type GistsListForksResponse struct {
 	response
 	request *GistsListForksReq
-	Data    GistsListForksResponseBody
+	Data    []components.GistFull
 }
 
 /*
@@ -1893,7 +1858,7 @@ func GistsListPublic(ctx context.Context, req *GistsListPublicReq, opt ...Reques
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GistsListPublicResponseBody{}
+	resp.Data = []components.BaseGist{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2003,13 +1968,6 @@ func (r *GistsListPublicReq) Rel(link RelName, resp *GistsListPublicResponse) bo
 }
 
 /*
-GistsListPublicResponseBody is a response body for GistsListPublic
-
-https://developer.github.com/v3/gists/#list-public-gists
-*/
-type GistsListPublicResponseBody []components.BaseGist
-
-/*
 GistsListPublicResponse is a response for GistsListPublic
 
 https://developer.github.com/v3/gists/#list-public-gists
@@ -2017,7 +1975,7 @@ https://developer.github.com/v3/gists/#list-public-gists
 type GistsListPublicResponse struct {
 	response
 	request *GistsListPublicReq
-	Data    GistsListPublicResponseBody
+	Data    []components.BaseGist
 }
 
 /*
@@ -2041,7 +1999,7 @@ func GistsListStarred(ctx context.Context, req *GistsListStarredReq, opt ...Requ
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GistsListStarredResponseBody{}
+	resp.Data = []components.BaseGist{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2151,13 +2109,6 @@ func (r *GistsListStarredReq) Rel(link RelName, resp *GistsListStarredResponse) 
 }
 
 /*
-GistsListStarredResponseBody is a response body for GistsListStarred
-
-https://developer.github.com/v3/gists/#list-starred-gists
-*/
-type GistsListStarredResponseBody []components.BaseGist
-
-/*
 GistsListStarredResponse is a response for GistsListStarred
 
 https://developer.github.com/v3/gists/#list-starred-gists
@@ -2165,7 +2116,7 @@ https://developer.github.com/v3/gists/#list-starred-gists
 type GistsListStarredResponse struct {
 	response
 	request *GistsListStarredReq
-	Data    GistsListStarredResponseBody
+	Data    []components.BaseGist
 }
 
 /*

--- a/zz_git_gen.go
+++ b/zz_git_gen.go
@@ -1618,7 +1618,7 @@ func GitListMatchingRefs(ctx context.Context, req *GitListMatchingRefsReq, opt .
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GitListMatchingRefsResponseBody{}
+	resp.Data = []components.GitRef{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1723,13 +1723,6 @@ func (r *GitListMatchingRefsReq) Rel(link RelName, resp *GitListMatchingRefsResp
 }
 
 /*
-GitListMatchingRefsResponseBody is a response body for GitListMatchingRefs
-
-https://developer.github.com/v3/git/refs/#list-matching-references
-*/
-type GitListMatchingRefsResponseBody []components.GitRef
-
-/*
 GitListMatchingRefsResponse is a response for GitListMatchingRefs
 
 https://developer.github.com/v3/git/refs/#list-matching-references
@@ -1737,7 +1730,7 @@ https://developer.github.com/v3/git/refs/#list-matching-references
 type GitListMatchingRefsResponse struct {
 	response
 	request *GitListMatchingRefsReq
-	Data    GitListMatchingRefsResponseBody
+	Data    []components.GitRef
 }
 
 /*

--- a/zz_git_gen.go
+++ b/zz_git_gen.go
@@ -32,7 +32,7 @@ func GitCreateBlob(ctx context.Context, req *GitCreateBlobReq, opt ...RequestOpt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GitCreateBlobResponseBody{}
+	resp.Data = components.ShortBlob{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -140,13 +140,6 @@ type GitCreateBlobReqBody struct {
 }
 
 /*
-GitCreateBlobResponseBody is a response body for GitCreateBlob
-
-https://developer.github.com/v3/git/blobs/#create-a-blob
-*/
-type GitCreateBlobResponseBody components.ShortBlob
-
-/*
 GitCreateBlobResponse is a response for GitCreateBlob
 
 https://developer.github.com/v3/git/blobs/#create-a-blob
@@ -154,7 +147,7 @@ https://developer.github.com/v3/git/blobs/#create-a-blob
 type GitCreateBlobResponse struct {
 	response
 	request *GitCreateBlobReq
-	Data    GitCreateBlobResponseBody
+	Data    components.ShortBlob
 }
 
 /*
@@ -178,7 +171,7 @@ func GitCreateCommit(ctx context.Context, req *GitCreateCommitReq, opt ...Reques
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GitCreateCommitResponseBody{}
+	resp.Data = components.GitCommit{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -355,13 +348,6 @@ type GitCreateCommitReqBody struct {
 }
 
 /*
-GitCreateCommitResponseBody is a response body for GitCreateCommit
-
-https://developer.github.com/v3/git/commits/#create-a-commit
-*/
-type GitCreateCommitResponseBody components.GitCommit
-
-/*
 GitCreateCommitResponse is a response for GitCreateCommit
 
 https://developer.github.com/v3/git/commits/#create-a-commit
@@ -369,7 +355,7 @@ https://developer.github.com/v3/git/commits/#create-a-commit
 type GitCreateCommitResponse struct {
 	response
 	request *GitCreateCommitReq
-	Data    GitCreateCommitResponseBody
+	Data    components.GitCommit
 }
 
 /*
@@ -393,7 +379,7 @@ func GitCreateRef(ctx context.Context, req *GitCreateRefReq, opt ...RequestOptio
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GitCreateRefResponseBody{}
+	resp.Data = components.GitRef{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -505,13 +491,6 @@ type GitCreateRefReqBody struct {
 }
 
 /*
-GitCreateRefResponseBody is a response body for GitCreateRef
-
-https://developer.github.com/v3/git/refs/#create-a-reference
-*/
-type GitCreateRefResponseBody components.GitRef
-
-/*
 GitCreateRefResponse is a response for GitCreateRef
 
 https://developer.github.com/v3/git/refs/#create-a-reference
@@ -519,7 +498,7 @@ https://developer.github.com/v3/git/refs/#create-a-reference
 type GitCreateRefResponse struct {
 	response
 	request *GitCreateRefReq
-	Data    GitCreateRefResponseBody
+	Data    components.GitRef
 }
 
 /*
@@ -543,7 +522,7 @@ func GitCreateTag(ctx context.Context, req *GitCreateTagReq, opt ...RequestOptio
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GitCreateTagResponseBody{}
+	resp.Data = components.GitTag{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -676,13 +655,6 @@ type GitCreateTagReqBody struct {
 }
 
 /*
-GitCreateTagResponseBody is a response body for GitCreateTag
-
-https://developer.github.com/v3/git/tags/#create-a-tag-object
-*/
-type GitCreateTagResponseBody components.GitTag
-
-/*
 GitCreateTagResponse is a response for GitCreateTag
 
 https://developer.github.com/v3/git/tags/#create-a-tag-object
@@ -690,7 +662,7 @@ https://developer.github.com/v3/git/tags/#create-a-tag-object
 type GitCreateTagResponse struct {
 	response
 	request *GitCreateTagReq
-	Data    GitCreateTagResponseBody
+	Data    components.GitTag
 }
 
 /*
@@ -714,7 +686,7 @@ func GitCreateTree(ctx context.Context, req *GitCreateTreeReq, opt ...RequestOpt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GitCreateTreeResponseBody{}
+	resp.Data = components.GitTree{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -861,13 +833,6 @@ type GitCreateTreeReqBody struct {
 }
 
 /*
-GitCreateTreeResponseBody is a response body for GitCreateTree
-
-https://developer.github.com/v3/git/trees/#create-a-tree
-*/
-type GitCreateTreeResponseBody components.GitTree
-
-/*
 GitCreateTreeResponse is a response for GitCreateTree
 
 https://developer.github.com/v3/git/trees/#create-a-tree
@@ -875,7 +840,7 @@ https://developer.github.com/v3/git/trees/#create-a-tree
 type GitCreateTreeResponse struct {
 	response
 	request *GitCreateTreeReq
-	Data    GitCreateTreeResponseBody
+	Data    components.GitTree
 }
 
 /*
@@ -1021,7 +986,7 @@ func GitGetBlob(ctx context.Context, req *GitGetBlobReq, opt ...RequestOption) (
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GitGetBlobResponseBody{}
+	resp.Data = components.Blob{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1114,13 +1079,6 @@ func (r *GitGetBlobReq) Rel(link RelName, resp *GitGetBlobResponse) bool {
 }
 
 /*
-GitGetBlobResponseBody is a response body for GitGetBlob
-
-https://developer.github.com/v3/git/blobs/#get-a-blob
-*/
-type GitGetBlobResponseBody components.Blob
-
-/*
 GitGetBlobResponse is a response for GitGetBlob
 
 https://developer.github.com/v3/git/blobs/#get-a-blob
@@ -1128,7 +1086,7 @@ https://developer.github.com/v3/git/blobs/#get-a-blob
 type GitGetBlobResponse struct {
 	response
 	request *GitGetBlobReq
-	Data    GitGetBlobResponseBody
+	Data    components.Blob
 }
 
 /*
@@ -1152,7 +1110,7 @@ func GitGetCommit(ctx context.Context, req *GitGetCommitReq, opt ...RequestOptio
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GitGetCommitResponseBody{}
+	resp.Data = components.GitCommit{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1245,13 +1203,6 @@ func (r *GitGetCommitReq) Rel(link RelName, resp *GitGetCommitResponse) bool {
 }
 
 /*
-GitGetCommitResponseBody is a response body for GitGetCommit
-
-https://developer.github.com/v3/git/commits/#get-a-commit
-*/
-type GitGetCommitResponseBody components.GitCommit
-
-/*
 GitGetCommitResponse is a response for GitGetCommit
 
 https://developer.github.com/v3/git/commits/#get-a-commit
@@ -1259,7 +1210,7 @@ https://developer.github.com/v3/git/commits/#get-a-commit
 type GitGetCommitResponse struct {
 	response
 	request *GitGetCommitReq
-	Data    GitGetCommitResponseBody
+	Data    components.GitCommit
 }
 
 /*
@@ -1283,7 +1234,7 @@ func GitGetRef(ctx context.Context, req *GitGetRefReq, opt ...RequestOption) (*G
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GitGetRefResponseBody{}
+	resp.Data = components.GitRef{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1376,13 +1327,6 @@ func (r *GitGetRefReq) Rel(link RelName, resp *GitGetRefResponse) bool {
 }
 
 /*
-GitGetRefResponseBody is a response body for GitGetRef
-
-https://developer.github.com/v3/git/refs/#get-a-reference
-*/
-type GitGetRefResponseBody components.GitRef
-
-/*
 GitGetRefResponse is a response for GitGetRef
 
 https://developer.github.com/v3/git/refs/#get-a-reference
@@ -1390,7 +1334,7 @@ https://developer.github.com/v3/git/refs/#get-a-reference
 type GitGetRefResponse struct {
 	response
 	request *GitGetRefReq
-	Data    GitGetRefResponseBody
+	Data    components.GitRef
 }
 
 /*
@@ -1414,7 +1358,7 @@ func GitGetTag(ctx context.Context, req *GitGetTagReq, opt ...RequestOption) (*G
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GitGetTagResponseBody{}
+	resp.Data = components.GitTag{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1507,13 +1451,6 @@ func (r *GitGetTagReq) Rel(link RelName, resp *GitGetTagResponse) bool {
 }
 
 /*
-GitGetTagResponseBody is a response body for GitGetTag
-
-https://developer.github.com/v3/git/tags/#get-a-tag
-*/
-type GitGetTagResponseBody components.GitTag
-
-/*
 GitGetTagResponse is a response for GitGetTag
 
 https://developer.github.com/v3/git/tags/#get-a-tag
@@ -1521,7 +1458,7 @@ https://developer.github.com/v3/git/tags/#get-a-tag
 type GitGetTagResponse struct {
 	response
 	request *GitGetTagReq
-	Data    GitGetTagResponseBody
+	Data    components.GitTag
 }
 
 /*
@@ -1545,7 +1482,7 @@ func GitGetTree(ctx context.Context, req *GitGetTreeReq, opt ...RequestOption) (
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GitGetTreeResponseBody{}
+	resp.Data = components.GitTree{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1650,13 +1587,6 @@ func (r *GitGetTreeReq) Rel(link RelName, resp *GitGetTreeResponse) bool {
 }
 
 /*
-GitGetTreeResponseBody is a response body for GitGetTree
-
-https://developer.github.com/v3/git/trees/#get-a-tree
-*/
-type GitGetTreeResponseBody components.GitTree
-
-/*
 GitGetTreeResponse is a response for GitGetTree
 
 https://developer.github.com/v3/git/trees/#get-a-tree
@@ -1664,7 +1594,7 @@ https://developer.github.com/v3/git/trees/#get-a-tree
 type GitGetTreeResponse struct {
 	response
 	request *GitGetTreeReq
-	Data    GitGetTreeResponseBody
+	Data    components.GitTree
 }
 
 /*
@@ -1831,7 +1761,7 @@ func GitUpdateRef(ctx context.Context, req *GitUpdateRefReq, opt ...RequestOptio
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GitUpdateRefResponseBody{}
+	resp.Data = components.GitRef{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1946,13 +1876,6 @@ type GitUpdateRefReqBody struct {
 }
 
 /*
-GitUpdateRefResponseBody is a response body for GitUpdateRef
-
-https://developer.github.com/v3/git/refs/#update-a-reference
-*/
-type GitUpdateRefResponseBody components.GitRef
-
-/*
 GitUpdateRefResponse is a response for GitUpdateRef
 
 https://developer.github.com/v3/git/refs/#update-a-reference
@@ -1960,5 +1883,5 @@ https://developer.github.com/v3/git/refs/#update-a-reference
 type GitUpdateRefResponse struct {
 	response
 	request *GitUpdateRefReq
-	Data    GitUpdateRefResponseBody
+	Data    components.GitRef
 }

--- a/zz_gitignore_gen.go
+++ b/zz_gitignore_gen.go
@@ -157,7 +157,7 @@ func GitignoreGetTemplate(ctx context.Context, req *GitignoreGetTemplateReq, opt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = GitignoreGetTemplateResponseBody{}
+	resp.Data = components.GitignoreTemplate{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -248,13 +248,6 @@ func (r *GitignoreGetTemplateReq) Rel(link RelName, resp *GitignoreGetTemplateRe
 }
 
 /*
-GitignoreGetTemplateResponseBody is a response body for GitignoreGetTemplate
-
-https://developer.github.com/v3/gitignore/#get-a-gitignore-template
-*/
-type GitignoreGetTemplateResponseBody components.GitignoreTemplate
-
-/*
 GitignoreGetTemplateResponse is a response for GitignoreGetTemplate
 
 https://developer.github.com/v3/gitignore/#get-a-gitignore-template
@@ -262,5 +255,5 @@ https://developer.github.com/v3/gitignore/#get-a-gitignore-template
 type GitignoreGetTemplateResponse struct {
 	response
 	request *GitignoreGetTemplateReq
-	Data    GitignoreGetTemplateResponseBody
+	Data    components.GitignoreTemplate
 }

--- a/zz_interactions_gen.go
+++ b/zz_interactions_gen.go
@@ -31,7 +31,7 @@ func InteractionsGetRestrictionsForOrg(ctx context.Context, req *InteractionsGet
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = InteractionsGetRestrictionsForOrgResponseBody{}
+	resp.Data = components.InteractionLimit{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -134,13 +134,6 @@ func (r *InteractionsGetRestrictionsForOrgReq) Rel(link RelName, resp *Interacti
 }
 
 /*
-InteractionsGetRestrictionsForOrgResponseBody is a response body for InteractionsGetRestrictionsForOrg
-
-https://developer.github.com/v3/interactions/orgs/#get-interaction-restrictions-for-an-organization
-*/
-type InteractionsGetRestrictionsForOrgResponseBody components.InteractionLimit
-
-/*
 InteractionsGetRestrictionsForOrgResponse is a response for InteractionsGetRestrictionsForOrg
 
 https://developer.github.com/v3/interactions/orgs/#get-interaction-restrictions-for-an-organization
@@ -148,7 +141,7 @@ https://developer.github.com/v3/interactions/orgs/#get-interaction-restrictions-
 type InteractionsGetRestrictionsForOrgResponse struct {
 	response
 	request *InteractionsGetRestrictionsForOrgReq
-	Data    InteractionsGetRestrictionsForOrgResponseBody
+	Data    components.InteractionLimit
 }
 
 /*
@@ -172,7 +165,7 @@ func InteractionsGetRestrictionsForRepo(ctx context.Context, req *InteractionsGe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = InteractionsGetRestrictionsForRepoResponseBody{}
+	resp.Data = components.InteractionLimit{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -276,13 +269,6 @@ func (r *InteractionsGetRestrictionsForRepoReq) Rel(link RelName, resp *Interact
 }
 
 /*
-InteractionsGetRestrictionsForRepoResponseBody is a response body for InteractionsGetRestrictionsForRepo
-
-https://developer.github.com/v3/interactions/repos/#get-interaction-restrictions-for-a-repository
-*/
-type InteractionsGetRestrictionsForRepoResponseBody components.InteractionLimit
-
-/*
 InteractionsGetRestrictionsForRepoResponse is a response for InteractionsGetRestrictionsForRepo
 
 https://developer.github.com/v3/interactions/repos/#get-interaction-restrictions-for-a-repository
@@ -290,7 +276,7 @@ https://developer.github.com/v3/interactions/repos/#get-interaction-restrictions
 type InteractionsGetRestrictionsForRepoResponse struct {
 	response
 	request *InteractionsGetRestrictionsForRepoReq
-	Data    InteractionsGetRestrictionsForRepoResponseBody
+	Data    components.InteractionLimit
 }
 
 /*
@@ -579,7 +565,7 @@ func InteractionsSetRestrictionsForOrg(ctx context.Context, req *InteractionsSet
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = InteractionsSetRestrictionsForOrgResponseBody{}
+	resp.Data = components.InteractionLimit{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -701,13 +687,6 @@ type InteractionsSetRestrictionsForOrgReqBody struct {
 }
 
 /*
-InteractionsSetRestrictionsForOrgResponseBody is a response body for InteractionsSetRestrictionsForOrg
-
-https://developer.github.com/v3/interactions/orgs/#set-interaction-restrictions-for-an-organization
-*/
-type InteractionsSetRestrictionsForOrgResponseBody components.InteractionLimit
-
-/*
 InteractionsSetRestrictionsForOrgResponse is a response for InteractionsSetRestrictionsForOrg
 
 https://developer.github.com/v3/interactions/orgs/#set-interaction-restrictions-for-an-organization
@@ -715,7 +694,7 @@ https://developer.github.com/v3/interactions/orgs/#set-interaction-restrictions-
 type InteractionsSetRestrictionsForOrgResponse struct {
 	response
 	request *InteractionsSetRestrictionsForOrgReq
-	Data    InteractionsSetRestrictionsForOrgResponseBody
+	Data    components.InteractionLimit
 }
 
 /*
@@ -739,7 +718,7 @@ func InteractionsSetRestrictionsForRepo(ctx context.Context, req *InteractionsSe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = InteractionsSetRestrictionsForRepoResponseBody{}
+	resp.Data = components.InteractionLimit{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -862,13 +841,6 @@ type InteractionsSetRestrictionsForRepoReqBody struct {
 }
 
 /*
-InteractionsSetRestrictionsForRepoResponseBody is a response body for InteractionsSetRestrictionsForRepo
-
-https://developer.github.com/v3/interactions/repos/#set-interaction-restrictions-for-a-repository
-*/
-type InteractionsSetRestrictionsForRepoResponseBody components.InteractionLimit
-
-/*
 InteractionsSetRestrictionsForRepoResponse is a response for InteractionsSetRestrictionsForRepo
 
 https://developer.github.com/v3/interactions/repos/#set-interaction-restrictions-for-a-repository
@@ -876,5 +848,5 @@ https://developer.github.com/v3/interactions/repos/#set-interaction-restrictions
 type InteractionsSetRestrictionsForRepoResponse struct {
 	response
 	request *InteractionsSetRestrictionsForRepoReq
-	Data    InteractionsSetRestrictionsForRepoResponseBody
+	Data    components.InteractionLimit
 }

--- a/zz_issues_gen.go
+++ b/zz_issues_gen.go
@@ -174,7 +174,7 @@ func IssuesAddLabels(ctx context.Context, req *IssuesAddLabelsReq, opt ...Reques
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesAddLabelsResponseBody{}
+	resp.Data = []components.Label{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -287,13 +287,6 @@ type IssuesAddLabelsReqBody struct {
 }
 
 /*
-IssuesAddLabelsResponseBody is a response body for IssuesAddLabels
-
-https://developer.github.com/v3/issues/labels/#add-labels-to-an-issue
-*/
-type IssuesAddLabelsResponseBody []components.Label
-
-/*
 IssuesAddLabelsResponse is a response for IssuesAddLabels
 
 https://developer.github.com/v3/issues/labels/#add-labels-to-an-issue
@@ -301,7 +294,7 @@ https://developer.github.com/v3/issues/labels/#add-labels-to-an-issue
 type IssuesAddLabelsResponse struct {
 	response
 	request *IssuesAddLabelsReq
-	Data    IssuesAddLabelsResponseBody
+	Data    []components.Label
 }
 
 /*
@@ -2119,7 +2112,7 @@ func IssuesList(ctx context.Context, req *IssuesListReq, opt ...RequestOption) (
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesListResponseBody{}
+	resp.Data = []components.Issue{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2310,13 +2303,6 @@ func (r *IssuesListReq) Rel(link RelName, resp *IssuesListResponse) bool {
 }
 
 /*
-IssuesListResponseBody is a response body for IssuesList
-
-https://developer.github.com/v3/issues/#list-issues-assigned-to-the-authenticated-user
-*/
-type IssuesListResponseBody []components.Issue
-
-/*
 IssuesListResponse is a response for IssuesList
 
 https://developer.github.com/v3/issues/#list-issues-assigned-to-the-authenticated-user
@@ -2324,7 +2310,7 @@ https://developer.github.com/v3/issues/#list-issues-assigned-to-the-authenticate
 type IssuesListResponse struct {
 	response
 	request *IssuesListReq
-	Data    IssuesListResponseBody
+	Data    []components.Issue
 }
 
 /*
@@ -2348,7 +2334,7 @@ func IssuesListAssignees(ctx context.Context, req *IssuesListAssigneesReq, opt .
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesListAssigneesResponseBody{}
+	resp.Data = []components.SimpleUser{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2450,13 +2436,6 @@ func (r *IssuesListAssigneesReq) Rel(link RelName, resp *IssuesListAssigneesResp
 }
 
 /*
-IssuesListAssigneesResponseBody is a response body for IssuesListAssignees
-
-https://developer.github.com/v3/issues/assignees/#list-assignees
-*/
-type IssuesListAssigneesResponseBody []components.SimpleUser
-
-/*
 IssuesListAssigneesResponse is a response for IssuesListAssignees
 
 https://developer.github.com/v3/issues/assignees/#list-assignees
@@ -2464,7 +2443,7 @@ https://developer.github.com/v3/issues/assignees/#list-assignees
 type IssuesListAssigneesResponse struct {
 	response
 	request *IssuesListAssigneesReq
-	Data    IssuesListAssigneesResponseBody
+	Data    []components.SimpleUser
 }
 
 /*
@@ -2488,7 +2467,7 @@ func IssuesListComments(ctx context.Context, req *IssuesListCommentsReq, opt ...
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesListCommentsResponseBody{}
+	resp.Data = []components.IssueComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2617,13 +2596,6 @@ func (r *IssuesListCommentsReq) Rel(link RelName, resp *IssuesListCommentsRespon
 }
 
 /*
-IssuesListCommentsResponseBody is a response body for IssuesListComments
-
-https://developer.github.com/v3/issues/comments/#list-issue-comments
-*/
-type IssuesListCommentsResponseBody []components.IssueComment
-
-/*
 IssuesListCommentsResponse is a response for IssuesListComments
 
 https://developer.github.com/v3/issues/comments/#list-issue-comments
@@ -2631,7 +2603,7 @@ https://developer.github.com/v3/issues/comments/#list-issue-comments
 type IssuesListCommentsResponse struct {
 	response
 	request *IssuesListCommentsReq
-	Data    IssuesListCommentsResponseBody
+	Data    []components.IssueComment
 }
 
 /*
@@ -2655,7 +2627,7 @@ func IssuesListCommentsForRepo(ctx context.Context, req *IssuesListCommentsForRe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesListCommentsForRepoResponseBody{}
+	resp.Data = []components.IssueComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2796,13 +2768,6 @@ func (r *IssuesListCommentsForRepoReq) Rel(link RelName, resp *IssuesListComment
 }
 
 /*
-IssuesListCommentsForRepoResponseBody is a response body for IssuesListCommentsForRepo
-
-https://developer.github.com/v3/issues/comments/#list-issue-comments-for-a-repository
-*/
-type IssuesListCommentsForRepoResponseBody []components.IssueComment
-
-/*
 IssuesListCommentsForRepoResponse is a response for IssuesListCommentsForRepo
 
 https://developer.github.com/v3/issues/comments/#list-issue-comments-for-a-repository
@@ -2810,7 +2775,7 @@ https://developer.github.com/v3/issues/comments/#list-issue-comments-for-a-repos
 type IssuesListCommentsForRepoResponse struct {
 	response
 	request *IssuesListCommentsForRepoReq
-	Data    IssuesListCommentsForRepoResponseBody
+	Data    []components.IssueComment
 }
 
 /*
@@ -2834,7 +2799,7 @@ func IssuesListEvents(ctx context.Context, req *IssuesListEventsReq, opt ...Requ
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesListEventsResponseBody{}
+	resp.Data = []components.IssueEventForIssue{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2968,13 +2933,6 @@ func (r *IssuesListEventsReq) Rel(link RelName, resp *IssuesListEventsResponse) 
 }
 
 /*
-IssuesListEventsResponseBody is a response body for IssuesListEvents
-
-https://developer.github.com/v3/issues/events/#list-issue-events
-*/
-type IssuesListEventsResponseBody []components.IssueEventForIssue
-
-/*
 IssuesListEventsResponse is a response for IssuesListEvents
 
 https://developer.github.com/v3/issues/events/#list-issue-events
@@ -2982,7 +2940,7 @@ https://developer.github.com/v3/issues/events/#list-issue-events
 type IssuesListEventsResponse struct {
 	response
 	request *IssuesListEventsReq
-	Data    IssuesListEventsResponseBody
+	Data    []components.IssueEventForIssue
 }
 
 /*
@@ -3006,7 +2964,7 @@ func IssuesListEventsForRepo(ctx context.Context, req *IssuesListEventsForRepoRe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesListEventsForRepoResponseBody{}
+	resp.Data = []components.IssueEvent{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3137,13 +3095,6 @@ func (r *IssuesListEventsForRepoReq) Rel(link RelName, resp *IssuesListEventsFor
 }
 
 /*
-IssuesListEventsForRepoResponseBody is a response body for IssuesListEventsForRepo
-
-https://developer.github.com/v3/issues/events/#list-issue-events-for-a-repository
-*/
-type IssuesListEventsForRepoResponseBody []components.IssueEvent
-
-/*
 IssuesListEventsForRepoResponse is a response for IssuesListEventsForRepo
 
 https://developer.github.com/v3/issues/events/#list-issue-events-for-a-repository
@@ -3151,7 +3102,7 @@ https://developer.github.com/v3/issues/events/#list-issue-events-for-a-repositor
 type IssuesListEventsForRepoResponse struct {
 	response
 	request *IssuesListEventsForRepoReq
-	Data    IssuesListEventsForRepoResponseBody
+	Data    []components.IssueEvent
 }
 
 /*
@@ -3175,7 +3126,7 @@ func IssuesListEventsForTimeline(ctx context.Context, req *IssuesListEventsForTi
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesListEventsForTimelineResponseBody{}
+	resp.Data = []components.IssueEventForIssue{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3311,13 +3262,6 @@ func (r *IssuesListEventsForTimelineReq) Rel(link RelName, resp *IssuesListEvent
 }
 
 /*
-IssuesListEventsForTimelineResponseBody is a response body for IssuesListEventsForTimeline
-
-https://developer.github.com/v3/issues/timeline/#list-timeline-events-for-an-issue
-*/
-type IssuesListEventsForTimelineResponseBody []components.IssueEventForIssue
-
-/*
 IssuesListEventsForTimelineResponse is a response for IssuesListEventsForTimeline
 
 https://developer.github.com/v3/issues/timeline/#list-timeline-events-for-an-issue
@@ -3325,7 +3269,7 @@ https://developer.github.com/v3/issues/timeline/#list-timeline-events-for-an-iss
 type IssuesListEventsForTimelineResponse struct {
 	response
 	request *IssuesListEventsForTimelineReq
-	Data    IssuesListEventsForTimelineResponseBody
+	Data    []components.IssueEventForIssue
 }
 
 /*
@@ -3349,7 +3293,7 @@ func IssuesListForAuthenticatedUser(ctx context.Context, req *IssuesListForAuthe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesListForAuthenticatedUserResponseBody{}
+	resp.Data = []components.Issue{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3524,13 +3468,6 @@ func (r *IssuesListForAuthenticatedUserReq) Rel(link RelName, resp *IssuesListFo
 }
 
 /*
-IssuesListForAuthenticatedUserResponseBody is a response body for IssuesListForAuthenticatedUser
-
-https://developer.github.com/v3/issues/#list-user-account-issues-assigned-to-the-authenticated-user
-*/
-type IssuesListForAuthenticatedUserResponseBody []components.Issue
-
-/*
 IssuesListForAuthenticatedUserResponse is a response for IssuesListForAuthenticatedUser
 
 https://developer.github.com/v3/issues/#list-user-account-issues-assigned-to-the-authenticated-user
@@ -3538,7 +3475,7 @@ https://developer.github.com/v3/issues/#list-user-account-issues-assigned-to-the
 type IssuesListForAuthenticatedUserResponse struct {
 	response
 	request *IssuesListForAuthenticatedUserReq
-	Data    IssuesListForAuthenticatedUserResponseBody
+	Data    []components.Issue
 }
 
 /*
@@ -3562,7 +3499,7 @@ func IssuesListForOrg(ctx context.Context, req *IssuesListForOrgReq, opt ...Requ
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesListForOrgResponseBody{}
+	resp.Data = []components.Issue{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3738,13 +3675,6 @@ func (r *IssuesListForOrgReq) Rel(link RelName, resp *IssuesListForOrgResponse) 
 }
 
 /*
-IssuesListForOrgResponseBody is a response body for IssuesListForOrg
-
-https://developer.github.com/v3/issues/#list-organization-issues-assigned-to-the-authenticated-user
-*/
-type IssuesListForOrgResponseBody []components.Issue
-
-/*
 IssuesListForOrgResponse is a response for IssuesListForOrg
 
 https://developer.github.com/v3/issues/#list-organization-issues-assigned-to-the-authenticated-user
@@ -3752,7 +3682,7 @@ https://developer.github.com/v3/issues/#list-organization-issues-assigned-to-the
 type IssuesListForOrgResponse struct {
 	response
 	request *IssuesListForOrgReq
-	Data    IssuesListForOrgResponseBody
+	Data    []components.Issue
 }
 
 /*
@@ -3776,7 +3706,7 @@ func IssuesListForRepo(ctx context.Context, req *IssuesListForRepoReq, opt ...Re
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesListForRepoResponseBody{}
+	resp.Data = []components.IssueSimple{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3970,13 +3900,6 @@ func (r *IssuesListForRepoReq) Rel(link RelName, resp *IssuesListForRepoResponse
 }
 
 /*
-IssuesListForRepoResponseBody is a response body for IssuesListForRepo
-
-https://developer.github.com/v3/issues/#list-repository-issues
-*/
-type IssuesListForRepoResponseBody []components.IssueSimple
-
-/*
 IssuesListForRepoResponse is a response for IssuesListForRepo
 
 https://developer.github.com/v3/issues/#list-repository-issues
@@ -3984,7 +3907,7 @@ https://developer.github.com/v3/issues/#list-repository-issues
 type IssuesListForRepoResponse struct {
 	response
 	request *IssuesListForRepoReq
-	Data    IssuesListForRepoResponseBody
+	Data    []components.IssueSimple
 }
 
 /*
@@ -4008,7 +3931,7 @@ func IssuesListLabelsForMilestone(ctx context.Context, req *IssuesListLabelsForM
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesListLabelsForMilestoneResponseBody{}
+	resp.Data = []components.Label{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -4113,13 +4036,6 @@ func (r *IssuesListLabelsForMilestoneReq) Rel(link RelName, resp *IssuesListLabe
 }
 
 /*
-IssuesListLabelsForMilestoneResponseBody is a response body for IssuesListLabelsForMilestone
-
-https://developer.github.com/v3/issues/labels/#list-labels-for-issues-in-a-milestone
-*/
-type IssuesListLabelsForMilestoneResponseBody []components.Label
-
-/*
 IssuesListLabelsForMilestoneResponse is a response for IssuesListLabelsForMilestone
 
 https://developer.github.com/v3/issues/labels/#list-labels-for-issues-in-a-milestone
@@ -4127,7 +4043,7 @@ https://developer.github.com/v3/issues/labels/#list-labels-for-issues-in-a-miles
 type IssuesListLabelsForMilestoneResponse struct {
 	response
 	request *IssuesListLabelsForMilestoneReq
-	Data    IssuesListLabelsForMilestoneResponseBody
+	Data    []components.Label
 }
 
 /*
@@ -4151,7 +4067,7 @@ func IssuesListLabelsForRepo(ctx context.Context, req *IssuesListLabelsForRepoRe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesListLabelsForRepoResponseBody{}
+	resp.Data = []components.Label{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -4253,13 +4169,6 @@ func (r *IssuesListLabelsForRepoReq) Rel(link RelName, resp *IssuesListLabelsFor
 }
 
 /*
-IssuesListLabelsForRepoResponseBody is a response body for IssuesListLabelsForRepo
-
-https://developer.github.com/v3/issues/labels/#list-labels-for-a-repository
-*/
-type IssuesListLabelsForRepoResponseBody []components.Label
-
-/*
 IssuesListLabelsForRepoResponse is a response for IssuesListLabelsForRepo
 
 https://developer.github.com/v3/issues/labels/#list-labels-for-a-repository
@@ -4267,7 +4176,7 @@ https://developer.github.com/v3/issues/labels/#list-labels-for-a-repository
 type IssuesListLabelsForRepoResponse struct {
 	response
 	request *IssuesListLabelsForRepoReq
-	Data    IssuesListLabelsForRepoResponseBody
+	Data    []components.Label
 }
 
 /*
@@ -4291,7 +4200,7 @@ func IssuesListLabelsOnIssue(ctx context.Context, req *IssuesListLabelsOnIssueRe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesListLabelsOnIssueResponseBody{}
+	resp.Data = []components.Label{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -4396,13 +4305,6 @@ func (r *IssuesListLabelsOnIssueReq) Rel(link RelName, resp *IssuesListLabelsOnI
 }
 
 /*
-IssuesListLabelsOnIssueResponseBody is a response body for IssuesListLabelsOnIssue
-
-https://developer.github.com/v3/issues/labels/#list-labels-for-an-issue
-*/
-type IssuesListLabelsOnIssueResponseBody []components.Label
-
-/*
 IssuesListLabelsOnIssueResponse is a response for IssuesListLabelsOnIssue
 
 https://developer.github.com/v3/issues/labels/#list-labels-for-an-issue
@@ -4410,7 +4312,7 @@ https://developer.github.com/v3/issues/labels/#list-labels-for-an-issue
 type IssuesListLabelsOnIssueResponse struct {
 	response
 	request *IssuesListLabelsOnIssueReq
-	Data    IssuesListLabelsOnIssueResponseBody
+	Data    []components.Label
 }
 
 /*
@@ -4434,7 +4336,7 @@ func IssuesListMilestones(ctx context.Context, req *IssuesListMilestonesReq, opt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesListMilestonesResponseBody{}
+	resp.Data = []components.Milestone{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -4554,13 +4456,6 @@ func (r *IssuesListMilestonesReq) Rel(link RelName, resp *IssuesListMilestonesRe
 }
 
 /*
-IssuesListMilestonesResponseBody is a response body for IssuesListMilestones
-
-https://developer.github.com/v3/issues/milestones/#list-milestones
-*/
-type IssuesListMilestonesResponseBody []components.Milestone
-
-/*
 IssuesListMilestonesResponse is a response for IssuesListMilestones
 
 https://developer.github.com/v3/issues/milestones/#list-milestones
@@ -4568,7 +4463,7 @@ https://developer.github.com/v3/issues/milestones/#list-milestones
 type IssuesListMilestonesResponse struct {
 	response
 	request *IssuesListMilestonesReq
-	Data    IssuesListMilestonesResponseBody
+	Data    []components.Milestone
 }
 
 /*
@@ -5011,7 +4906,7 @@ func IssuesRemoveLabel(ctx context.Context, req *IssuesRemoveLabelReq, opt ...Re
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesRemoveLabelResponseBody{}
+	resp.Data = []components.Label{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -5107,13 +5002,6 @@ func (r *IssuesRemoveLabelReq) Rel(link RelName, resp *IssuesRemoveLabelResponse
 }
 
 /*
-IssuesRemoveLabelResponseBody is a response body for IssuesRemoveLabel
-
-https://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue
-*/
-type IssuesRemoveLabelResponseBody []components.Label
-
-/*
 IssuesRemoveLabelResponse is a response for IssuesRemoveLabel
 
 https://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue
@@ -5121,7 +5009,7 @@ https://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue
 type IssuesRemoveLabelResponse struct {
 	response
 	request *IssuesRemoveLabelReq
-	Data    IssuesRemoveLabelResponseBody
+	Data    []components.Label
 }
 
 /*
@@ -5145,7 +5033,7 @@ func IssuesSetLabels(ctx context.Context, req *IssuesSetLabelsReq, opt ...Reques
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesSetLabelsResponseBody{}
+	resp.Data = []components.Label{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -5258,13 +5146,6 @@ type IssuesSetLabelsReqBody struct {
 }
 
 /*
-IssuesSetLabelsResponseBody is a response body for IssuesSetLabels
-
-https://developer.github.com/v3/issues/labels/#set-labels-for-an-issue
-*/
-type IssuesSetLabelsResponseBody []components.Label
-
-/*
 IssuesSetLabelsResponse is a response for IssuesSetLabels
 
 https://developer.github.com/v3/issues/labels/#set-labels-for-an-issue
@@ -5272,7 +5153,7 @@ https://developer.github.com/v3/issues/labels/#set-labels-for-an-issue
 type IssuesSetLabelsResponse struct {
 	response
 	request *IssuesSetLabelsReq
-	Data    IssuesSetLabelsResponseBody
+	Data    []components.Label
 }
 
 /*

--- a/zz_issues_gen.go
+++ b/zz_issues_gen.go
@@ -32,7 +32,7 @@ func IssuesAddAssignees(ctx context.Context, req *IssuesAddAssigneesReq, opt ...
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesAddAssigneesResponseBody{}
+	resp.Data = components.IssueSimple{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -143,13 +143,6 @@ type IssuesAddAssigneesReqBody struct {
 }
 
 /*
-IssuesAddAssigneesResponseBody is a response body for IssuesAddAssignees
-
-https://developer.github.com/v3/issues/assignees/#add-assignees-to-an-issue
-*/
-type IssuesAddAssigneesResponseBody components.IssueSimple
-
-/*
 IssuesAddAssigneesResponse is a response for IssuesAddAssignees
 
 https://developer.github.com/v3/issues/assignees/#add-assignees-to-an-issue
@@ -157,7 +150,7 @@ https://developer.github.com/v3/issues/assignees/#add-assignees-to-an-issue
 type IssuesAddAssigneesResponse struct {
 	response
 	request *IssuesAddAssigneesReq
-	Data    IssuesAddAssigneesResponseBody
+	Data    components.IssueSimple
 }
 
 /*
@@ -459,7 +452,7 @@ func IssuesCreate(ctx context.Context, req *IssuesCreateReq, opt ...RequestOptio
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesCreateResponseBody{}
+	resp.Data = components.Issue{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -593,13 +586,6 @@ type IssuesCreateReqBody struct {
 }
 
 /*
-IssuesCreateResponseBody is a response body for IssuesCreate
-
-https://developer.github.com/v3/issues/#create-an-issue
-*/
-type IssuesCreateResponseBody components.Issue
-
-/*
 IssuesCreateResponse is a response for IssuesCreate
 
 https://developer.github.com/v3/issues/#create-an-issue
@@ -607,7 +593,7 @@ https://developer.github.com/v3/issues/#create-an-issue
 type IssuesCreateResponse struct {
 	response
 	request *IssuesCreateReq
-	Data    IssuesCreateResponseBody
+	Data    components.Issue
 }
 
 /*
@@ -631,7 +617,7 @@ func IssuesCreateComment(ctx context.Context, req *IssuesCreateCommentReq, opt .
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesCreateCommentResponseBody{}
+	resp.Data = components.IssueComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -739,13 +725,6 @@ type IssuesCreateCommentReqBody struct {
 }
 
 /*
-IssuesCreateCommentResponseBody is a response body for IssuesCreateComment
-
-https://developer.github.com/v3/issues/comments/#create-an-issue-comment
-*/
-type IssuesCreateCommentResponseBody components.IssueComment
-
-/*
 IssuesCreateCommentResponse is a response for IssuesCreateComment
 
 https://developer.github.com/v3/issues/comments/#create-an-issue-comment
@@ -753,7 +732,7 @@ https://developer.github.com/v3/issues/comments/#create-an-issue-comment
 type IssuesCreateCommentResponse struct {
 	response
 	request *IssuesCreateCommentReq
-	Data    IssuesCreateCommentResponseBody
+	Data    components.IssueComment
 }
 
 /*
@@ -777,7 +756,7 @@ func IssuesCreateLabel(ctx context.Context, req *IssuesCreateLabelReq, opt ...Re
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesCreateLabelResponseBody{}
+	resp.Data = components.Label{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -895,13 +874,6 @@ type IssuesCreateLabelReqBody struct {
 }
 
 /*
-IssuesCreateLabelResponseBody is a response body for IssuesCreateLabel
-
-https://developer.github.com/v3/issues/labels/#create-a-label
-*/
-type IssuesCreateLabelResponseBody components.Label
-
-/*
 IssuesCreateLabelResponse is a response for IssuesCreateLabel
 
 https://developer.github.com/v3/issues/labels/#create-a-label
@@ -909,7 +881,7 @@ https://developer.github.com/v3/issues/labels/#create-a-label
 type IssuesCreateLabelResponse struct {
 	response
 	request *IssuesCreateLabelReq
-	Data    IssuesCreateLabelResponseBody
+	Data    components.Label
 }
 
 /*
@@ -933,7 +905,7 @@ func IssuesCreateMilestone(ctx context.Context, req *IssuesCreateMilestoneReq, o
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesCreateMilestoneResponseBody{}
+	resp.Data = components.Milestone{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1050,13 +1022,6 @@ type IssuesCreateMilestoneReqBody struct {
 }
 
 /*
-IssuesCreateMilestoneResponseBody is a response body for IssuesCreateMilestone
-
-https://developer.github.com/v3/issues/milestones/#create-a-milestone
-*/
-type IssuesCreateMilestoneResponseBody components.Milestone
-
-/*
 IssuesCreateMilestoneResponse is a response for IssuesCreateMilestone
 
 https://developer.github.com/v3/issues/milestones/#create-a-milestone
@@ -1064,7 +1029,7 @@ https://developer.github.com/v3/issues/milestones/#create-a-milestone
 type IssuesCreateMilestoneResponse struct {
 	response
 	request *IssuesCreateMilestoneReq
-	Data    IssuesCreateMilestoneResponseBody
+	Data    components.Milestone
 }
 
 /*
@@ -1459,7 +1424,7 @@ func IssuesGet(ctx context.Context, req *IssuesGetReq, opt ...RequestOption) (*I
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesGetResponseBody{}
+	resp.Data = components.Issue{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1566,13 +1531,6 @@ func (r *IssuesGetReq) Rel(link RelName, resp *IssuesGetResponse) bool {
 }
 
 /*
-IssuesGetResponseBody is a response body for IssuesGet
-
-https://developer.github.com/v3/issues/#get-an-issue
-*/
-type IssuesGetResponseBody components.Issue
-
-/*
 IssuesGetResponse is a response for IssuesGet
 
 https://developer.github.com/v3/issues/#get-an-issue
@@ -1580,7 +1538,7 @@ https://developer.github.com/v3/issues/#get-an-issue
 type IssuesGetResponse struct {
 	response
 	request *IssuesGetReq
-	Data    IssuesGetResponseBody
+	Data    components.Issue
 }
 
 /*
@@ -1604,7 +1562,7 @@ func IssuesGetComment(ctx context.Context, req *IssuesGetCommentReq, opt ...Requ
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesGetCommentResponseBody{}
+	resp.Data = components.IssueComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1721,13 +1679,6 @@ func (r *IssuesGetCommentReq) Rel(link RelName, resp *IssuesGetCommentResponse) 
 }
 
 /*
-IssuesGetCommentResponseBody is a response body for IssuesGetComment
-
-https://developer.github.com/v3/issues/comments/#get-an-issue-comment
-*/
-type IssuesGetCommentResponseBody components.IssueComment
-
-/*
 IssuesGetCommentResponse is a response for IssuesGetComment
 
 https://developer.github.com/v3/issues/comments/#get-an-issue-comment
@@ -1735,7 +1686,7 @@ https://developer.github.com/v3/issues/comments/#get-an-issue-comment
 type IssuesGetCommentResponse struct {
 	response
 	request *IssuesGetCommentReq
-	Data    IssuesGetCommentResponseBody
+	Data    components.IssueComment
 }
 
 /*
@@ -1759,7 +1710,7 @@ func IssuesGetEvent(ctx context.Context, req *IssuesGetEventReq, opt ...RequestO
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesGetEventResponseBody{}
+	resp.Data = components.IssueEvent{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1889,13 +1840,6 @@ func (r *IssuesGetEventReq) Rel(link RelName, resp *IssuesGetEventResponse) bool
 }
 
 /*
-IssuesGetEventResponseBody is a response body for IssuesGetEvent
-
-https://developer.github.com/v3/issues/events/#get-an-issue-event
-*/
-type IssuesGetEventResponseBody components.IssueEvent
-
-/*
 IssuesGetEventResponse is a response for IssuesGetEvent
 
 https://developer.github.com/v3/issues/events/#get-an-issue-event
@@ -1903,7 +1847,7 @@ https://developer.github.com/v3/issues/events/#get-an-issue-event
 type IssuesGetEventResponse struct {
 	response
 	request *IssuesGetEventReq
-	Data    IssuesGetEventResponseBody
+	Data    components.IssueEvent
 }
 
 /*
@@ -1927,7 +1871,7 @@ func IssuesGetLabel(ctx context.Context, req *IssuesGetLabelReq, opt ...RequestO
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesGetLabelResponseBody{}
+	resp.Data = components.Label{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2020,13 +1964,6 @@ func (r *IssuesGetLabelReq) Rel(link RelName, resp *IssuesGetLabelResponse) bool
 }
 
 /*
-IssuesGetLabelResponseBody is a response body for IssuesGetLabel
-
-https://developer.github.com/v3/issues/labels/#get-a-label
-*/
-type IssuesGetLabelResponseBody components.Label
-
-/*
 IssuesGetLabelResponse is a response for IssuesGetLabel
 
 https://developer.github.com/v3/issues/labels/#get-a-label
@@ -2034,7 +1971,7 @@ https://developer.github.com/v3/issues/labels/#get-a-label
 type IssuesGetLabelResponse struct {
 	response
 	request *IssuesGetLabelReq
-	Data    IssuesGetLabelResponseBody
+	Data    components.Label
 }
 
 /*
@@ -2058,7 +1995,7 @@ func IssuesGetMilestone(ctx context.Context, req *IssuesGetMilestoneReq, opt ...
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesGetMilestoneResponseBody{}
+	resp.Data = components.Milestone{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2151,13 +2088,6 @@ func (r *IssuesGetMilestoneReq) Rel(link RelName, resp *IssuesGetMilestoneRespon
 }
 
 /*
-IssuesGetMilestoneResponseBody is a response body for IssuesGetMilestone
-
-https://developer.github.com/v3/issues/milestones/#get-a-milestone
-*/
-type IssuesGetMilestoneResponseBody components.Milestone
-
-/*
 IssuesGetMilestoneResponse is a response for IssuesGetMilestone
 
 https://developer.github.com/v3/issues/milestones/#get-a-milestone
@@ -2165,7 +2095,7 @@ https://developer.github.com/v3/issues/milestones/#get-a-milestone
 type IssuesGetMilestoneResponse struct {
 	response
 	request *IssuesGetMilestoneReq
-	Data    IssuesGetMilestoneResponseBody
+	Data    components.Milestone
 }
 
 /*
@@ -4938,7 +4868,7 @@ func IssuesRemoveAssignees(ctx context.Context, req *IssuesRemoveAssigneesReq, o
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesRemoveAssigneesResponseBody{}
+	resp.Data = components.IssueSimple{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -5050,13 +4980,6 @@ type IssuesRemoveAssigneesReqBody struct {
 }
 
 /*
-IssuesRemoveAssigneesResponseBody is a response body for IssuesRemoveAssignees
-
-https://developer.github.com/v3/issues/assignees/#remove-assignees-from-an-issue
-*/
-type IssuesRemoveAssigneesResponseBody components.IssueSimple
-
-/*
 IssuesRemoveAssigneesResponse is a response for IssuesRemoveAssignees
 
 https://developer.github.com/v3/issues/assignees/#remove-assignees-from-an-issue
@@ -5064,7 +4987,7 @@ https://developer.github.com/v3/issues/assignees/#remove-assignees-from-an-issue
 type IssuesRemoveAssigneesResponse struct {
 	response
 	request *IssuesRemoveAssigneesReq
-	Data    IssuesRemoveAssigneesResponseBody
+	Data    components.IssueSimple
 }
 
 /*
@@ -5495,7 +5418,7 @@ func IssuesUpdate(ctx context.Context, req *IssuesUpdateReq, opt ...RequestOptio
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesUpdateResponseBody{}
+	resp.Data = components.Issue{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -5635,13 +5558,6 @@ type IssuesUpdateReqBody struct {
 }
 
 /*
-IssuesUpdateResponseBody is a response body for IssuesUpdate
-
-https://developer.github.com/v3/issues/#update-an-issue
-*/
-type IssuesUpdateResponseBody components.Issue
-
-/*
 IssuesUpdateResponse is a response for IssuesUpdate
 
 https://developer.github.com/v3/issues/#update-an-issue
@@ -5649,7 +5565,7 @@ https://developer.github.com/v3/issues/#update-an-issue
 type IssuesUpdateResponse struct {
 	response
 	request *IssuesUpdateReq
-	Data    IssuesUpdateResponseBody
+	Data    components.Issue
 }
 
 /*
@@ -5673,7 +5589,7 @@ func IssuesUpdateComment(ctx context.Context, req *IssuesUpdateCommentReq, opt .
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesUpdateCommentResponseBody{}
+	resp.Data = components.IssueComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -5781,13 +5697,6 @@ type IssuesUpdateCommentReqBody struct {
 }
 
 /*
-IssuesUpdateCommentResponseBody is a response body for IssuesUpdateComment
-
-https://developer.github.com/v3/issues/comments/#update-an-issue-comment
-*/
-type IssuesUpdateCommentResponseBody components.IssueComment
-
-/*
 IssuesUpdateCommentResponse is a response for IssuesUpdateComment
 
 https://developer.github.com/v3/issues/comments/#update-an-issue-comment
@@ -5795,7 +5704,7 @@ https://developer.github.com/v3/issues/comments/#update-an-issue-comment
 type IssuesUpdateCommentResponse struct {
 	response
 	request *IssuesUpdateCommentReq
-	Data    IssuesUpdateCommentResponseBody
+	Data    components.IssueComment
 }
 
 /*
@@ -5819,7 +5728,7 @@ func IssuesUpdateLabel(ctx context.Context, req *IssuesUpdateLabelReq, opt ...Re
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesUpdateLabelResponseBody{}
+	resp.Data = components.Label{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -5941,13 +5850,6 @@ type IssuesUpdateLabelReqBody struct {
 }
 
 /*
-IssuesUpdateLabelResponseBody is a response body for IssuesUpdateLabel
-
-https://developer.github.com/v3/issues/labels/#update-a-label
-*/
-type IssuesUpdateLabelResponseBody components.Label
-
-/*
 IssuesUpdateLabelResponse is a response for IssuesUpdateLabel
 
 https://developer.github.com/v3/issues/labels/#update-a-label
@@ -5955,7 +5857,7 @@ https://developer.github.com/v3/issues/labels/#update-a-label
 type IssuesUpdateLabelResponse struct {
 	response
 	request *IssuesUpdateLabelReq
-	Data    IssuesUpdateLabelResponseBody
+	Data    components.Label
 }
 
 /*
@@ -5979,7 +5881,7 @@ func IssuesUpdateMilestone(ctx context.Context, req *IssuesUpdateMilestoneReq, o
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = IssuesUpdateMilestoneResponseBody{}
+	resp.Data = components.Milestone{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -6099,13 +6001,6 @@ type IssuesUpdateMilestoneReqBody struct {
 }
 
 /*
-IssuesUpdateMilestoneResponseBody is a response body for IssuesUpdateMilestone
-
-https://developer.github.com/v3/issues/milestones/#update-a-milestone
-*/
-type IssuesUpdateMilestoneResponseBody components.Milestone
-
-/*
 IssuesUpdateMilestoneResponse is a response for IssuesUpdateMilestone
 
 https://developer.github.com/v3/issues/milestones/#update-a-milestone
@@ -6113,5 +6008,5 @@ https://developer.github.com/v3/issues/milestones/#update-a-milestone
 type IssuesUpdateMilestoneResponse struct {
 	response
 	request *IssuesUpdateMilestoneReq
-	Data    IssuesUpdateMilestoneResponseBody
+	Data    components.Milestone
 }

--- a/zz_lic_gen.go
+++ b/zz_lic_gen.go
@@ -154,7 +154,7 @@ func LicensesGetAllCommonlyUsed(ctx context.Context, req *LicensesGetAllCommonly
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = LicensesGetAllCommonlyUsedResponseBody{}
+	resp.Data = []components.LicenseSimple{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -252,13 +252,6 @@ func (r *LicensesGetAllCommonlyUsedReq) Rel(link RelName, resp *LicensesGetAllCo
 }
 
 /*
-LicensesGetAllCommonlyUsedResponseBody is a response body for LicensesGetAllCommonlyUsed
-
-https://developer.github.com/v3/licenses/#get-all-commonly-used-licenses
-*/
-type LicensesGetAllCommonlyUsedResponseBody []components.LicenseSimple
-
-/*
 LicensesGetAllCommonlyUsedResponse is a response for LicensesGetAllCommonlyUsed
 
 https://developer.github.com/v3/licenses/#get-all-commonly-used-licenses
@@ -266,7 +259,7 @@ https://developer.github.com/v3/licenses/#get-all-commonly-used-licenses
 type LicensesGetAllCommonlyUsedResponse struct {
 	response
 	request *LicensesGetAllCommonlyUsedReq
-	Data    LicensesGetAllCommonlyUsedResponseBody
+	Data    []components.LicenseSimple
 }
 
 /*

--- a/zz_lic_gen.go
+++ b/zz_lic_gen.go
@@ -32,7 +32,7 @@ func LicensesGet(ctx context.Context, req *LicensesGetReq, opt ...RequestOption)
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = LicensesGetResponseBody{}
+	resp.Data = components.License{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -123,13 +123,6 @@ func (r *LicensesGetReq) Rel(link RelName, resp *LicensesGetResponse) bool {
 }
 
 /*
-LicensesGetResponseBody is a response body for LicensesGet
-
-https://developer.github.com/v3/licenses/#get-a-license
-*/
-type LicensesGetResponseBody components.License
-
-/*
 LicensesGetResponse is a response for LicensesGet
 
 https://developer.github.com/v3/licenses/#get-a-license
@@ -137,7 +130,7 @@ https://developer.github.com/v3/licenses/#get-a-license
 type LicensesGetResponse struct {
 	response
 	request *LicensesGetReq
-	Data    LicensesGetResponseBody
+	Data    components.License
 }
 
 /*
@@ -297,7 +290,7 @@ func LicensesGetForRepo(ctx context.Context, req *LicensesGetForRepoReq, opt ...
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = LicensesGetForRepoResponseBody{}
+	resp.Data = components.LicenseContent{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -387,13 +380,6 @@ func (r *LicensesGetForRepoReq) Rel(link RelName, resp *LicensesGetForRepoRespon
 }
 
 /*
-LicensesGetForRepoResponseBody is a response body for LicensesGetForRepo
-
-https://developer.github.com/v3/licenses/#get-the-license-for-a-repository
-*/
-type LicensesGetForRepoResponseBody components.LicenseContent
-
-/*
 LicensesGetForRepoResponse is a response for LicensesGetForRepo
 
 https://developer.github.com/v3/licenses/#get-the-license-for-a-repository
@@ -401,5 +387,5 @@ https://developer.github.com/v3/licenses/#get-the-license-for-a-repository
 type LicensesGetForRepoResponse struct {
 	response
 	request *LicensesGetForRepoReq
-	Data    LicensesGetForRepoResponseBody
+	Data    components.LicenseContent
 }

--- a/zz_meta_gen.go
+++ b/zz_meta_gen.go
@@ -31,7 +31,7 @@ func MetaGet(ctx context.Context, req *MetaGetReq, opt ...RequestOption) (*MetaG
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = MetaGetResponseBody{}
+	resp.Data = components.ApiOverview{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -119,13 +119,6 @@ func (r *MetaGetReq) Rel(link RelName, resp *MetaGetResponse) bool {
 }
 
 /*
-MetaGetResponseBody is a response body for MetaGet
-
-https://developer.github.com/v3/meta/#get-github-meta-information
-*/
-type MetaGetResponseBody components.ApiOverview
-
-/*
 MetaGetResponse is a response for MetaGet
 
 https://developer.github.com/v3/meta/#get-github-meta-information
@@ -133,7 +126,7 @@ https://developer.github.com/v3/meta/#get-github-meta-information
 type MetaGetResponse struct {
 	response
 	request *MetaGetReq
-	Data    MetaGetResponseBody
+	Data    components.ApiOverview
 }
 
 /*

--- a/zz_migrations_gen.go
+++ b/zz_migrations_gen.go
@@ -812,7 +812,7 @@ func MigrationsGetImportStatus(ctx context.Context, req *MigrationsGetImportStat
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = MigrationsGetImportStatusResponseBody{}
+	resp.Data = components.Import{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -902,13 +902,6 @@ func (r *MigrationsGetImportStatusReq) Rel(link RelName, resp *MigrationsGetImpo
 }
 
 /*
-MigrationsGetImportStatusResponseBody is a response body for MigrationsGetImportStatus
-
-https://developer.github.com/v3/migrations/source_imports/#get-an-import-status
-*/
-type MigrationsGetImportStatusResponseBody components.Import
-
-/*
 MigrationsGetImportStatusResponse is a response for MigrationsGetImportStatus
 
 https://developer.github.com/v3/migrations/source_imports/#get-an-import-status
@@ -916,7 +909,7 @@ https://developer.github.com/v3/migrations/source_imports/#get-an-import-status
 type MigrationsGetImportStatusResponse struct {
 	response
 	request *MigrationsGetImportStatusReq
-	Data    MigrationsGetImportStatusResponseBody
+	Data    components.Import
 }
 
 /*
@@ -1068,7 +1061,7 @@ func MigrationsGetStatusForAuthenticatedUser(ctx context.Context, req *Migration
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = MigrationsGetStatusForAuthenticatedUserResponseBody{}
+	resp.Data = components.Migration{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1168,13 +1161,6 @@ func (r *MigrationsGetStatusForAuthenticatedUserReq) Rel(link RelName, resp *Mig
 }
 
 /*
-MigrationsGetStatusForAuthenticatedUserResponseBody is a response body for MigrationsGetStatusForAuthenticatedUser
-
-https://developer.github.com/v3/migrations/users/#get-a-user-migration-status
-*/
-type MigrationsGetStatusForAuthenticatedUserResponseBody components.Migration
-
-/*
 MigrationsGetStatusForAuthenticatedUserResponse is a response for MigrationsGetStatusForAuthenticatedUser
 
 https://developer.github.com/v3/migrations/users/#get-a-user-migration-status
@@ -1182,7 +1168,7 @@ https://developer.github.com/v3/migrations/users/#get-a-user-migration-status
 type MigrationsGetStatusForAuthenticatedUserResponse struct {
 	response
 	request *MigrationsGetStatusForAuthenticatedUserReq
-	Data    MigrationsGetStatusForAuthenticatedUserResponseBody
+	Data    components.Migration
 }
 
 /*
@@ -1206,7 +1192,7 @@ func MigrationsGetStatusForOrg(ctx context.Context, req *MigrationsGetStatusForO
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = MigrationsGetStatusForOrgResponseBody{}
+	resp.Data = components.Migration{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1307,13 +1293,6 @@ func (r *MigrationsGetStatusForOrgReq) Rel(link RelName, resp *MigrationsGetStat
 }
 
 /*
-MigrationsGetStatusForOrgResponseBody is a response body for MigrationsGetStatusForOrg
-
-https://developer.github.com/v3/migrations/orgs/#get-an-organization-migration-status
-*/
-type MigrationsGetStatusForOrgResponseBody components.Migration
-
-/*
 MigrationsGetStatusForOrgResponse is a response for MigrationsGetStatusForOrg
 
 https://developer.github.com/v3/migrations/orgs/#get-an-organization-migration-status
@@ -1321,7 +1300,7 @@ https://developer.github.com/v3/migrations/orgs/#get-an-organization-migration-s
 type MigrationsGetStatusForOrgResponse struct {
 	response
 	request *MigrationsGetStatusForOrgReq
-	Data    MigrationsGetStatusForOrgResponseBody
+	Data    components.Migration
 }
 
 /*
@@ -1941,7 +1920,7 @@ func MigrationsMapCommitAuthor(ctx context.Context, req *MigrationsMapCommitAuth
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = MigrationsMapCommitAuthorResponseBody{}
+	resp.Data = components.PorterAuthor{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2053,13 +2032,6 @@ type MigrationsMapCommitAuthorReqBody struct {
 }
 
 /*
-MigrationsMapCommitAuthorResponseBody is a response body for MigrationsMapCommitAuthor
-
-https://developer.github.com/v3/migrations/source_imports/#map-a-commit-author
-*/
-type MigrationsMapCommitAuthorResponseBody components.PorterAuthor
-
-/*
 MigrationsMapCommitAuthorResponse is a response for MigrationsMapCommitAuthor
 
 https://developer.github.com/v3/migrations/source_imports/#map-a-commit-author
@@ -2067,7 +2039,7 @@ https://developer.github.com/v3/migrations/source_imports/#map-a-commit-author
 type MigrationsMapCommitAuthorResponse struct {
 	response
 	request *MigrationsMapCommitAuthorReq
-	Data    MigrationsMapCommitAuthorResponseBody
+	Data    components.PorterAuthor
 }
 
 /*
@@ -2091,7 +2063,7 @@ func MigrationsSetLfsPreference(ctx context.Context, req *MigrationsSetLfsPrefer
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = MigrationsSetLfsPreferenceResponseBody{}
+	resp.Data = components.Import{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2199,13 +2171,6 @@ type MigrationsSetLfsPreferenceReqBody struct {
 }
 
 /*
-MigrationsSetLfsPreferenceResponseBody is a response body for MigrationsSetLfsPreference
-
-https://developer.github.com/v3/migrations/source_imports/#update-git-lfs-preference
-*/
-type MigrationsSetLfsPreferenceResponseBody components.Import
-
-/*
 MigrationsSetLfsPreferenceResponse is a response for MigrationsSetLfsPreference
 
 https://developer.github.com/v3/migrations/source_imports/#update-git-lfs-preference
@@ -2213,7 +2178,7 @@ https://developer.github.com/v3/migrations/source_imports/#update-git-lfs-prefer
 type MigrationsSetLfsPreferenceResponse struct {
 	response
 	request *MigrationsSetLfsPreferenceReq
-	Data    MigrationsSetLfsPreferenceResponseBody
+	Data    components.Import
 }
 
 /*
@@ -2237,7 +2202,7 @@ func MigrationsStartForAuthenticatedUser(ctx context.Context, req *MigrationsSta
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = MigrationsStartForAuthenticatedUserResponseBody{}
+	resp.Data = components.Migration{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2347,13 +2312,6 @@ type MigrationsStartForAuthenticatedUserReqBody struct {
 }
 
 /*
-MigrationsStartForAuthenticatedUserResponseBody is a response body for MigrationsStartForAuthenticatedUser
-
-https://developer.github.com/v3/migrations/users/#start-a-user-migration
-*/
-type MigrationsStartForAuthenticatedUserResponseBody components.Migration
-
-/*
 MigrationsStartForAuthenticatedUserResponse is a response for MigrationsStartForAuthenticatedUser
 
 https://developer.github.com/v3/migrations/users/#start-a-user-migration
@@ -2361,7 +2319,7 @@ https://developer.github.com/v3/migrations/users/#start-a-user-migration
 type MigrationsStartForAuthenticatedUserResponse struct {
 	response
 	request *MigrationsStartForAuthenticatedUserReq
-	Data    MigrationsStartForAuthenticatedUserResponseBody
+	Data    components.Migration
 }
 
 /*
@@ -2385,7 +2343,7 @@ func MigrationsStartForOrg(ctx context.Context, req *MigrationsStartForOrgReq, o
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = MigrationsStartForOrgResponseBody{}
+	resp.Data = components.Migration{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2496,13 +2454,6 @@ type MigrationsStartForOrgReqBody struct {
 }
 
 /*
-MigrationsStartForOrgResponseBody is a response body for MigrationsStartForOrg
-
-https://developer.github.com/v3/migrations/orgs/#start-an-organization-migration
-*/
-type MigrationsStartForOrgResponseBody components.Migration
-
-/*
 MigrationsStartForOrgResponse is a response for MigrationsStartForOrg
 
 https://developer.github.com/v3/migrations/orgs/#start-an-organization-migration
@@ -2510,7 +2461,7 @@ https://developer.github.com/v3/migrations/orgs/#start-an-organization-migration
 type MigrationsStartForOrgResponse struct {
 	response
 	request *MigrationsStartForOrgReq
-	Data    MigrationsStartForOrgResponseBody
+	Data    components.Migration
 }
 
 /*
@@ -2534,7 +2485,7 @@ func MigrationsStartImport(ctx context.Context, req *MigrationsStartImportReq, o
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = MigrationsStartImportResponseBody{}
+	resp.Data = components.Import{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2656,13 +2607,6 @@ type MigrationsStartImportReqBody struct {
 }
 
 /*
-MigrationsStartImportResponseBody is a response body for MigrationsStartImport
-
-https://developer.github.com/v3/migrations/source_imports/#start-an-import
-*/
-type MigrationsStartImportResponseBody components.Import
-
-/*
 MigrationsStartImportResponse is a response for MigrationsStartImport
 
 https://developer.github.com/v3/migrations/source_imports/#start-an-import
@@ -2670,7 +2614,7 @@ https://developer.github.com/v3/migrations/source_imports/#start-an-import
 type MigrationsStartImportResponse struct {
 	response
 	request *MigrationsStartImportReq
-	Data    MigrationsStartImportResponseBody
+	Data    components.Import
 }
 
 /*
@@ -2964,7 +2908,7 @@ func MigrationsUpdateImport(ctx context.Context, req *MigrationsUpdateImportReq,
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = MigrationsUpdateImportResponseBody{}
+	resp.Data = components.Import{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3074,13 +3018,6 @@ type MigrationsUpdateImportReqBody struct {
 }
 
 /*
-MigrationsUpdateImportResponseBody is a response body for MigrationsUpdateImport
-
-https://developer.github.com/v3/migrations/source_imports/#update-an-import
-*/
-type MigrationsUpdateImportResponseBody components.Import
-
-/*
 MigrationsUpdateImportResponse is a response for MigrationsUpdateImport
 
 https://developer.github.com/v3/migrations/source_imports/#update-an-import
@@ -3088,5 +3025,5 @@ https://developer.github.com/v3/migrations/source_imports/#update-an-import
 type MigrationsUpdateImportResponse struct {
 	response
 	request *MigrationsUpdateImportReq
-	Data    MigrationsUpdateImportResponseBody
+	Data    components.Import
 }

--- a/zz_migrations_gen.go
+++ b/zz_migrations_gen.go
@@ -674,7 +674,7 @@ func MigrationsGetCommitAuthors(ctx context.Context, req *MigrationsGetCommitAut
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = MigrationsGetCommitAuthorsResponseBody{}
+	resp.Data = []components.PorterAuthor{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -774,13 +774,6 @@ func (r *MigrationsGetCommitAuthorsReq) Rel(link RelName, resp *MigrationsGetCom
 }
 
 /*
-MigrationsGetCommitAuthorsResponseBody is a response body for MigrationsGetCommitAuthors
-
-https://developer.github.com/v3/migrations/source_imports/#get-commit-authors
-*/
-type MigrationsGetCommitAuthorsResponseBody []components.PorterAuthor
-
-/*
 MigrationsGetCommitAuthorsResponse is a response for MigrationsGetCommitAuthors
 
 https://developer.github.com/v3/migrations/source_imports/#get-commit-authors
@@ -788,7 +781,7 @@ https://developer.github.com/v3/migrations/source_imports/#get-commit-authors
 type MigrationsGetCommitAuthorsResponse struct {
 	response
 	request *MigrationsGetCommitAuthorsReq
-	Data    MigrationsGetCommitAuthorsResponseBody
+	Data    []components.PorterAuthor
 }
 
 /*
@@ -933,7 +926,7 @@ func MigrationsGetLargeFiles(ctx context.Context, req *MigrationsGetLargeFilesRe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = MigrationsGetLargeFilesResponseBody{}
+	resp.Data = []components.PorterLargeFile{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1023,13 +1016,6 @@ func (r *MigrationsGetLargeFilesReq) Rel(link RelName, resp *MigrationsGetLargeF
 }
 
 /*
-MigrationsGetLargeFilesResponseBody is a response body for MigrationsGetLargeFiles
-
-https://developer.github.com/v3/migrations/source_imports/#get-large-files
-*/
-type MigrationsGetLargeFilesResponseBody []components.PorterLargeFile
-
-/*
 MigrationsGetLargeFilesResponse is a response for MigrationsGetLargeFiles
 
 https://developer.github.com/v3/migrations/source_imports/#get-large-files
@@ -1037,7 +1023,7 @@ https://developer.github.com/v3/migrations/source_imports/#get-large-files
 type MigrationsGetLargeFilesResponse struct {
 	response
 	request *MigrationsGetLargeFilesReq
-	Data    MigrationsGetLargeFilesResponseBody
+	Data    []components.PorterLargeFile
 }
 
 /*
@@ -1324,7 +1310,7 @@ func MigrationsListForAuthenticatedUser(ctx context.Context, req *MigrationsList
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = MigrationsListForAuthenticatedUserResponseBody{}
+	resp.Data = []components.Migration{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1433,13 +1419,6 @@ func (r *MigrationsListForAuthenticatedUserReq) Rel(link RelName, resp *Migratio
 }
 
 /*
-MigrationsListForAuthenticatedUserResponseBody is a response body for MigrationsListForAuthenticatedUser
-
-https://developer.github.com/v3/migrations/users/#list-user-migrations
-*/
-type MigrationsListForAuthenticatedUserResponseBody []components.Migration
-
-/*
 MigrationsListForAuthenticatedUserResponse is a response for MigrationsListForAuthenticatedUser
 
 https://developer.github.com/v3/migrations/users/#list-user-migrations
@@ -1447,7 +1426,7 @@ https://developer.github.com/v3/migrations/users/#list-user-migrations
 type MigrationsListForAuthenticatedUserResponse struct {
 	response
 	request *MigrationsListForAuthenticatedUserReq
-	Data    MigrationsListForAuthenticatedUserResponseBody
+	Data    []components.Migration
 }
 
 /*
@@ -1471,7 +1450,7 @@ func MigrationsListForOrg(ctx context.Context, req *MigrationsListForOrgReq, opt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = MigrationsListForOrgResponseBody{}
+	resp.Data = []components.Migration{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1581,13 +1560,6 @@ func (r *MigrationsListForOrgReq) Rel(link RelName, resp *MigrationsListForOrgRe
 }
 
 /*
-MigrationsListForOrgResponseBody is a response body for MigrationsListForOrg
-
-https://developer.github.com/v3/migrations/orgs/#list-organization-migrations
-*/
-type MigrationsListForOrgResponseBody []components.Migration
-
-/*
 MigrationsListForOrgResponse is a response for MigrationsListForOrg
 
 https://developer.github.com/v3/migrations/orgs/#list-organization-migrations
@@ -1595,7 +1567,7 @@ https://developer.github.com/v3/migrations/orgs/#list-organization-migrations
 type MigrationsListForOrgResponse struct {
 	response
 	request *MigrationsListForOrgReq
-	Data    MigrationsListForOrgResponseBody
+	Data    []components.Migration
 }
 
 /*
@@ -1619,7 +1591,7 @@ func MigrationsListReposForOrg(ctx context.Context, req *MigrationsListReposForO
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = MigrationsListReposForOrgResponseBody{}
+	resp.Data = []components.MinimalRepository{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1732,13 +1704,6 @@ func (r *MigrationsListReposForOrgReq) Rel(link RelName, resp *MigrationsListRep
 }
 
 /*
-MigrationsListReposForOrgResponseBody is a response body for MigrationsListReposForOrg
-
-https://developer.github.com/v3/migrations/orgs/#list-repositories-in-an-organization-migration
-*/
-type MigrationsListReposForOrgResponseBody []components.MinimalRepository
-
-/*
 MigrationsListReposForOrgResponse is a response for MigrationsListReposForOrg
 
 https://developer.github.com/v3/migrations/orgs/#list-repositories-in-an-organization-migration
@@ -1746,7 +1711,7 @@ https://developer.github.com/v3/migrations/orgs/#list-repositories-in-an-organiz
 type MigrationsListReposForOrgResponse struct {
 	response
 	request *MigrationsListReposForOrgReq
-	Data    MigrationsListReposForOrgResponseBody
+	Data    []components.MinimalRepository
 }
 
 /*
@@ -1770,7 +1735,7 @@ func MigrationsListReposForUser(ctx context.Context, req *MigrationsListReposFor
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = MigrationsListReposForUserResponseBody{}
+	resp.Data = []components.MinimalRepository{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1882,13 +1847,6 @@ func (r *MigrationsListReposForUserReq) Rel(link RelName, resp *MigrationsListRe
 }
 
 /*
-MigrationsListReposForUserResponseBody is a response body for MigrationsListReposForUser
-
-https://developer.github.com/v3/migrations/users/#list-repositories-for-a-user-migration
-*/
-type MigrationsListReposForUserResponseBody []components.MinimalRepository
-
-/*
 MigrationsListReposForUserResponse is a response for MigrationsListReposForUser
 
 https://developer.github.com/v3/migrations/users/#list-repositories-for-a-user-migration
@@ -1896,7 +1854,7 @@ https://developer.github.com/v3/migrations/users/#list-repositories-for-a-user-m
 type MigrationsListReposForUserResponse struct {
 	response
 	request *MigrationsListReposForUserReq
-	Data    MigrationsListReposForUserResponseBody
+	Data    []components.MinimalRepository
 }
 
 /*

--- a/zz_oauth_authorizations_gen.go
+++ b/zz_oauth_authorizations_gen.go
@@ -32,7 +32,7 @@ func OauthAuthorizationsCreateAuthorization(ctx context.Context, req *OauthAutho
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OauthAuthorizationsCreateAuthorizationResponseBody{}
+	resp.Data = components.Authorization{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -150,13 +150,6 @@ type OauthAuthorizationsCreateAuthorizationReqBody struct {
 }
 
 /*
-OauthAuthorizationsCreateAuthorizationResponseBody is a response body for OauthAuthorizationsCreateAuthorization
-
-https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization
-*/
-type OauthAuthorizationsCreateAuthorizationResponseBody components.Authorization
-
-/*
 OauthAuthorizationsCreateAuthorizationResponse is a response for OauthAuthorizationsCreateAuthorization
 
 https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization
@@ -164,7 +157,7 @@ https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization
 type OauthAuthorizationsCreateAuthorizationResponse struct {
 	response
 	request *OauthAuthorizationsCreateAuthorizationReq
-	Data    OauthAuthorizationsCreateAuthorizationResponseBody
+	Data    components.Authorization
 }
 
 /*
@@ -428,7 +421,7 @@ func OauthAuthorizationsGetAuthorization(ctx context.Context, req *OauthAuthoriz
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OauthAuthorizationsGetAuthorizationResponseBody{}
+	resp.Data = components.Authorization{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -519,13 +512,6 @@ func (r *OauthAuthorizationsGetAuthorizationReq) Rel(link RelName, resp *OauthAu
 }
 
 /*
-OauthAuthorizationsGetAuthorizationResponseBody is a response body for OauthAuthorizationsGetAuthorization
-
-https://developer.github.com/v3/oauth_authorizations/#get-a-single-authorization
-*/
-type OauthAuthorizationsGetAuthorizationResponseBody components.Authorization
-
-/*
 OauthAuthorizationsGetAuthorizationResponse is a response for OauthAuthorizationsGetAuthorization
 
 https://developer.github.com/v3/oauth_authorizations/#get-a-single-authorization
@@ -533,7 +519,7 @@ https://developer.github.com/v3/oauth_authorizations/#get-a-single-authorization
 type OauthAuthorizationsGetAuthorizationResponse struct {
 	response
 	request *OauthAuthorizationsGetAuthorizationReq
-	Data    OauthAuthorizationsGetAuthorizationResponseBody
+	Data    components.Authorization
 }
 
 /*
@@ -557,7 +543,7 @@ func OauthAuthorizationsGetGrant(ctx context.Context, req *OauthAuthorizationsGe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OauthAuthorizationsGetGrantResponseBody{}
+	resp.Data = components.ApplicationGrant{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -648,13 +634,6 @@ func (r *OauthAuthorizationsGetGrantReq) Rel(link RelName, resp *OauthAuthorizat
 }
 
 /*
-OauthAuthorizationsGetGrantResponseBody is a response body for OauthAuthorizationsGetGrant
-
-https://developer.github.com/v3/oauth_authorizations/#get-a-single-grant
-*/
-type OauthAuthorizationsGetGrantResponseBody components.ApplicationGrant
-
-/*
 OauthAuthorizationsGetGrantResponse is a response for OauthAuthorizationsGetGrant
 
 https://developer.github.com/v3/oauth_authorizations/#get-a-single-grant
@@ -662,7 +641,7 @@ https://developer.github.com/v3/oauth_authorizations/#get-a-single-grant
 type OauthAuthorizationsGetGrantResponse struct {
 	response
 	request *OauthAuthorizationsGetGrantReq
-	Data    OauthAuthorizationsGetGrantResponseBody
+	Data    components.ApplicationGrant
 }
 
 /*
@@ -686,7 +665,7 @@ func OauthAuthorizationsGetOrCreateAuthorizationForApp(ctx context.Context, req 
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OauthAuthorizationsGetOrCreateAuthorizationForAppResponseBody{}
+	resp.Data = components.Authorization{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -802,13 +781,6 @@ type OauthAuthorizationsGetOrCreateAuthorizationForAppReqBody struct {
 }
 
 /*
-OauthAuthorizationsGetOrCreateAuthorizationForAppResponseBody is a response body for OauthAuthorizationsGetOrCreateAuthorizationForApp
-
-https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app
-*/
-type OauthAuthorizationsGetOrCreateAuthorizationForAppResponseBody components.Authorization
-
-/*
 OauthAuthorizationsGetOrCreateAuthorizationForAppResponse is a response for OauthAuthorizationsGetOrCreateAuthorizationForApp
 
 https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app
@@ -816,7 +788,7 @@ https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authoriza
 type OauthAuthorizationsGetOrCreateAuthorizationForAppResponse struct {
 	response
 	request *OauthAuthorizationsGetOrCreateAuthorizationForAppReq
-	Data    OauthAuthorizationsGetOrCreateAuthorizationForAppResponseBody
+	Data    components.Authorization
 }
 
 /*
@@ -840,7 +812,7 @@ func OauthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprint(ctx context
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OauthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintResponseBody{}
+	resp.Data = components.Authorization{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -956,13 +928,6 @@ type OauthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintReqBody stru
 }
 
 /*
-OauthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintResponseBody is a response body for OauthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprint
-
-https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint
-*/
-type OauthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintResponseBody components.Authorization
-
-/*
 OauthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintResponse is a response for OauthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprint
 
 https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint
@@ -970,7 +935,7 @@ https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authoriza
 type OauthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintResponse struct {
 	response
 	request *OauthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintReq
-	Data    OauthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintResponseBody
+	Data    components.Authorization
 }
 
 /*
@@ -1270,7 +1235,7 @@ func OauthAuthorizationsUpdateAuthorization(ctx context.Context, req *OauthAutho
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OauthAuthorizationsUpdateAuthorizationResponseBody{}
+	resp.Data = components.Authorization{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1391,13 +1356,6 @@ type OauthAuthorizationsUpdateAuthorizationReqBody struct {
 }
 
 /*
-OauthAuthorizationsUpdateAuthorizationResponseBody is a response body for OauthAuthorizationsUpdateAuthorization
-
-https://developer.github.com/v3/oauth_authorizations/#update-an-existing-authorization
-*/
-type OauthAuthorizationsUpdateAuthorizationResponseBody components.Authorization
-
-/*
 OauthAuthorizationsUpdateAuthorizationResponse is a response for OauthAuthorizationsUpdateAuthorization
 
 https://developer.github.com/v3/oauth_authorizations/#update-an-existing-authorization
@@ -1405,5 +1363,5 @@ https://developer.github.com/v3/oauth_authorizations/#update-an-existing-authori
 type OauthAuthorizationsUpdateAuthorizationResponse struct {
 	response
 	request *OauthAuthorizationsUpdateAuthorizationReq
-	Data    OauthAuthorizationsUpdateAuthorizationResponseBody
+	Data    components.Authorization
 }

--- a/zz_oauth_authorizations_gen.go
+++ b/zz_oauth_authorizations_gen.go
@@ -959,7 +959,7 @@ func OauthAuthorizationsListAuthorizations(ctx context.Context, req *OauthAuthor
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OauthAuthorizationsListAuthorizationsResponseBody{}
+	resp.Data = []components.Authorization{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1059,13 +1059,6 @@ func (r *OauthAuthorizationsListAuthorizationsReq) Rel(link RelName, resp *Oauth
 }
 
 /*
-OauthAuthorizationsListAuthorizationsResponseBody is a response body for OauthAuthorizationsListAuthorizations
-
-https://developer.github.com/v3/oauth_authorizations/#list-your-authorizations
-*/
-type OauthAuthorizationsListAuthorizationsResponseBody []components.Authorization
-
-/*
 OauthAuthorizationsListAuthorizationsResponse is a response for OauthAuthorizationsListAuthorizations
 
 https://developer.github.com/v3/oauth_authorizations/#list-your-authorizations
@@ -1073,7 +1066,7 @@ https://developer.github.com/v3/oauth_authorizations/#list-your-authorizations
 type OauthAuthorizationsListAuthorizationsResponse struct {
 	response
 	request *OauthAuthorizationsListAuthorizationsReq
-	Data    OauthAuthorizationsListAuthorizationsResponseBody
+	Data    []components.Authorization
 }
 
 /*
@@ -1097,7 +1090,7 @@ func OauthAuthorizationsListGrants(ctx context.Context, req *OauthAuthorizations
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OauthAuthorizationsListGrantsResponseBody{}
+	resp.Data = []components.ApplicationGrant{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1197,13 +1190,6 @@ func (r *OauthAuthorizationsListGrantsReq) Rel(link RelName, resp *OauthAuthoriz
 }
 
 /*
-OauthAuthorizationsListGrantsResponseBody is a response body for OauthAuthorizationsListGrants
-
-https://developer.github.com/v3/oauth_authorizations/#list-your-grants
-*/
-type OauthAuthorizationsListGrantsResponseBody []components.ApplicationGrant
-
-/*
 OauthAuthorizationsListGrantsResponse is a response for OauthAuthorizationsListGrants
 
 https://developer.github.com/v3/oauth_authorizations/#list-your-grants
@@ -1211,7 +1197,7 @@ https://developer.github.com/v3/oauth_authorizations/#list-your-grants
 type OauthAuthorizationsListGrantsResponse struct {
 	response
 	request *OauthAuthorizationsListGrantsReq
-	Data    OauthAuthorizationsListGrantsResponseBody
+	Data    []components.ApplicationGrant
 }
 
 /*

--- a/zz_orgs_gen.go
+++ b/zz_orgs_gen.go
@@ -637,7 +637,7 @@ func OrgsCreateInvitation(ctx context.Context, req *OrgsCreateInvitationReq, opt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OrgsCreateInvitationResponseBody{}
+	resp.Data = components.OrganizationInvitation{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -761,13 +761,6 @@ type OrgsCreateInvitationReqBody struct {
 }
 
 /*
-OrgsCreateInvitationResponseBody is a response body for OrgsCreateInvitation
-
-https://developer.github.com/v3/orgs/members/#create-an-organization-invitation
-*/
-type OrgsCreateInvitationResponseBody components.OrganizationInvitation
-
-/*
 OrgsCreateInvitationResponse is a response for OrgsCreateInvitation
 
 https://developer.github.com/v3/orgs/members/#create-an-organization-invitation
@@ -775,7 +768,7 @@ https://developer.github.com/v3/orgs/members/#create-an-organization-invitation
 type OrgsCreateInvitationResponse struct {
 	response
 	request *OrgsCreateInvitationReq
-	Data    OrgsCreateInvitationResponseBody
+	Data    components.OrganizationInvitation
 }
 
 /*
@@ -799,7 +792,7 @@ func OrgsCreateWebhook(ctx context.Context, req *OrgsCreateWebhookReq, opt ...Re
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OrgsCreateWebhookResponseBody{}
+	resp.Data = components.OrgHook{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -944,13 +937,6 @@ type OrgsCreateWebhookReqBody struct {
 }
 
 /*
-OrgsCreateWebhookResponseBody is a response body for OrgsCreateWebhook
-
-https://developer.github.com/v3/orgs/hooks/#create-an-organization-webhook
-*/
-type OrgsCreateWebhookResponseBody components.OrgHook
-
-/*
 OrgsCreateWebhookResponse is a response for OrgsCreateWebhook
 
 https://developer.github.com/v3/orgs/hooks/#create-an-organization-webhook
@@ -958,7 +944,7 @@ https://developer.github.com/v3/orgs/hooks/#create-an-organization-webhook
 type OrgsCreateWebhookResponse struct {
 	response
 	request *OrgsCreateWebhookReq
-	Data    OrgsCreateWebhookResponseBody
+	Data    components.OrgHook
 }
 
 /*
@@ -1106,7 +1092,7 @@ func OrgsGet(ctx context.Context, req *OrgsGetReq, opt ...RequestOption) (*OrgsG
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OrgsGetResponseBody{}
+	resp.Data = components.OrganizationFull{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1213,13 +1199,6 @@ func (r *OrgsGetReq) Rel(link RelName, resp *OrgsGetResponse) bool {
 }
 
 /*
-OrgsGetResponseBody is a response body for OrgsGet
-
-https://developer.github.com/v3/orgs/#get-an-organization
-*/
-type OrgsGetResponseBody components.OrganizationFull
-
-/*
 OrgsGetResponse is a response for OrgsGet
 
 https://developer.github.com/v3/orgs/#get-an-organization
@@ -1227,7 +1206,7 @@ https://developer.github.com/v3/orgs/#get-an-organization
 type OrgsGetResponse struct {
 	response
 	request *OrgsGetReq
-	Data    OrgsGetResponseBody
+	Data    components.OrganizationFull
 }
 
 /*
@@ -1251,7 +1230,7 @@ func OrgsGetMembershipForAuthenticatedUser(ctx context.Context, req *OrgsGetMemb
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OrgsGetMembershipForAuthenticatedUserResponseBody{}
+	resp.Data = components.OrgMembership{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1340,13 +1319,6 @@ func (r *OrgsGetMembershipForAuthenticatedUserReq) Rel(link RelName, resp *OrgsG
 }
 
 /*
-OrgsGetMembershipForAuthenticatedUserResponseBody is a response body for OrgsGetMembershipForAuthenticatedUser
-
-https://developer.github.com/v3/orgs/members/#get-an-organization-membership-for-the-authenticated-user
-*/
-type OrgsGetMembershipForAuthenticatedUserResponseBody components.OrgMembership
-
-/*
 OrgsGetMembershipForAuthenticatedUserResponse is a response for OrgsGetMembershipForAuthenticatedUser
 
 https://developer.github.com/v3/orgs/members/#get-an-organization-membership-for-the-authenticated-user
@@ -1354,7 +1326,7 @@ https://developer.github.com/v3/orgs/members/#get-an-organization-membership-for
 type OrgsGetMembershipForAuthenticatedUserResponse struct {
 	response
 	request *OrgsGetMembershipForAuthenticatedUserReq
-	Data    OrgsGetMembershipForAuthenticatedUserResponseBody
+	Data    components.OrgMembership
 }
 
 /*
@@ -1378,7 +1350,7 @@ func OrgsGetMembershipForUser(ctx context.Context, req *OrgsGetMembershipForUser
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OrgsGetMembershipForUserResponseBody{}
+	resp.Data = components.OrgMembership{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1468,13 +1440,6 @@ func (r *OrgsGetMembershipForUserReq) Rel(link RelName, resp *OrgsGetMembershipF
 }
 
 /*
-OrgsGetMembershipForUserResponseBody is a response body for OrgsGetMembershipForUser
-
-https://developer.github.com/v3/orgs/members/#get-organization-membership-for-a-user
-*/
-type OrgsGetMembershipForUserResponseBody components.OrgMembership
-
-/*
 OrgsGetMembershipForUserResponse is a response for OrgsGetMembershipForUser
 
 https://developer.github.com/v3/orgs/members/#get-organization-membership-for-a-user
@@ -1482,7 +1447,7 @@ https://developer.github.com/v3/orgs/members/#get-organization-membership-for-a-
 type OrgsGetMembershipForUserResponse struct {
 	response
 	request *OrgsGetMembershipForUserReq
-	Data    OrgsGetMembershipForUserResponseBody
+	Data    components.OrgMembership
 }
 
 /*
@@ -1506,7 +1471,7 @@ func OrgsGetWebhook(ctx context.Context, req *OrgsGetWebhookReq, opt ...RequestO
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OrgsGetWebhookResponseBody{}
+	resp.Data = components.OrgHook{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1596,13 +1561,6 @@ func (r *OrgsGetWebhookReq) Rel(link RelName, resp *OrgsGetWebhookResponse) bool
 }
 
 /*
-OrgsGetWebhookResponseBody is a response body for OrgsGetWebhook
-
-https://developer.github.com/v3/orgs/hooks/#get-an-organization-webhook
-*/
-type OrgsGetWebhookResponseBody components.OrgHook
-
-/*
 OrgsGetWebhookResponse is a response for OrgsGetWebhook
 
 https://developer.github.com/v3/orgs/hooks/#get-an-organization-webhook
@@ -1610,7 +1568,7 @@ https://developer.github.com/v3/orgs/hooks/#get-an-organization-webhook
 type OrgsGetWebhookResponse struct {
 	response
 	request *OrgsGetWebhookReq
-	Data    OrgsGetWebhookResponseBody
+	Data    components.OrgHook
 }
 
 /*
@@ -4206,7 +4164,7 @@ func OrgsSetMembershipForUser(ctx context.Context, req *OrgsSetMembershipForUser
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OrgsSetMembershipForUserResponseBody{}
+	resp.Data = components.OrgMembership{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -4315,13 +4273,6 @@ type OrgsSetMembershipForUserReqBody struct {
 }
 
 /*
-OrgsSetMembershipForUserResponseBody is a response body for OrgsSetMembershipForUser
-
-https://developer.github.com/v3/orgs/members/#set-organization-membership-for-a-user
-*/
-type OrgsSetMembershipForUserResponseBody components.OrgMembership
-
-/*
 OrgsSetMembershipForUserResponse is a response for OrgsSetMembershipForUser
 
 https://developer.github.com/v3/orgs/members/#set-organization-membership-for-a-user
@@ -4329,7 +4280,7 @@ https://developer.github.com/v3/orgs/members/#set-organization-membership-for-a-
 type OrgsSetMembershipForUserResponse struct {
 	response
 	request *OrgsSetMembershipForUserReq
-	Data    OrgsSetMembershipForUserResponseBody
+	Data    components.OrgMembership
 }
 
 /*
@@ -4591,7 +4542,7 @@ func OrgsUpdate(ctx context.Context, req *OrgsUpdateReq, opt ...RequestOption) (
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OrgsUpdateResponseBody{}
+	resp.Data = components.OrganizationFull{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -4814,13 +4765,6 @@ type OrgsUpdateReqBody struct {
 }
 
 /*
-OrgsUpdateResponseBody is a response body for OrgsUpdate
-
-https://developer.github.com/v3/orgs/#update-an-organization
-*/
-type OrgsUpdateResponseBody components.OrganizationFull
-
-/*
 OrgsUpdateResponse is a response for OrgsUpdate
 
 https://developer.github.com/v3/orgs/#update-an-organization
@@ -4828,7 +4772,7 @@ https://developer.github.com/v3/orgs/#update-an-organization
 type OrgsUpdateResponse struct {
 	response
 	request *OrgsUpdateReq
-	Data    OrgsUpdateResponseBody
+	Data    components.OrganizationFull
 }
 
 /*
@@ -4852,7 +4796,7 @@ func OrgsUpdateMembershipForAuthenticatedUser(ctx context.Context, req *OrgsUpda
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OrgsUpdateMembershipForAuthenticatedUserResponseBody{}
+	resp.Data = components.OrgMembership{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -4956,13 +4900,6 @@ type OrgsUpdateMembershipForAuthenticatedUserReqBody struct {
 }
 
 /*
-OrgsUpdateMembershipForAuthenticatedUserResponseBody is a response body for OrgsUpdateMembershipForAuthenticatedUser
-
-https://developer.github.com/v3/orgs/members/#update-an-organization-membership-for-the-authenticated-user
-*/
-type OrgsUpdateMembershipForAuthenticatedUserResponseBody components.OrgMembership
-
-/*
 OrgsUpdateMembershipForAuthenticatedUserResponse is a response for OrgsUpdateMembershipForAuthenticatedUser
 
 https://developer.github.com/v3/orgs/members/#update-an-organization-membership-for-the-authenticated-user
@@ -4970,7 +4907,7 @@ https://developer.github.com/v3/orgs/members/#update-an-organization-membership-
 type OrgsUpdateMembershipForAuthenticatedUserResponse struct {
 	response
 	request *OrgsUpdateMembershipForAuthenticatedUserReq
-	Data    OrgsUpdateMembershipForAuthenticatedUserResponseBody
+	Data    components.OrgMembership
 }
 
 /*
@@ -4994,7 +4931,7 @@ func OrgsUpdateWebhook(ctx context.Context, req *OrgsUpdateWebhookReq, opt ...Re
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OrgsUpdateWebhookResponseBody{}
+	resp.Data = components.OrgHook{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -5136,13 +5073,6 @@ type OrgsUpdateWebhookReqBody struct {
 }
 
 /*
-OrgsUpdateWebhookResponseBody is a response body for OrgsUpdateWebhook
-
-https://developer.github.com/v3/orgs/hooks/#update-an-organization-webhook
-*/
-type OrgsUpdateWebhookResponseBody components.OrgHook
-
-/*
 OrgsUpdateWebhookResponse is a response for OrgsUpdateWebhook
 
 https://developer.github.com/v3/orgs/hooks/#update-an-organization-webhook
@@ -5150,5 +5080,5 @@ https://developer.github.com/v3/orgs/hooks/#update-an-organization-webhook
 type OrgsUpdateWebhookResponse struct {
 	response
 	request *OrgsUpdateWebhookReq
-	Data    OrgsUpdateWebhookResponseBody
+	Data    components.OrgHook
 }

--- a/zz_orgs_gen.go
+++ b/zz_orgs_gen.go
@@ -1592,7 +1592,7 @@ func OrgsList(ctx context.Context, req *OrgsListReq, opt ...RequestOption) (*Org
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OrgsListResponseBody{}
+	resp.Data = []components.OrganizationSimple{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1696,13 +1696,6 @@ func (r *OrgsListReq) Rel(link RelName, resp *OrgsListResponse) bool {
 }
 
 /*
-OrgsListResponseBody is a response body for OrgsList
-
-https://developer.github.com/v3/orgs/#list-organizations
-*/
-type OrgsListResponseBody []components.OrganizationSimple
-
-/*
 OrgsListResponse is a response for OrgsList
 
 https://developer.github.com/v3/orgs/#list-organizations
@@ -1710,7 +1703,7 @@ https://developer.github.com/v3/orgs/#list-organizations
 type OrgsListResponse struct {
 	response
 	request *OrgsListReq
-	Data    OrgsListResponseBody
+	Data    []components.OrganizationSimple
 }
 
 /*
@@ -1888,7 +1881,7 @@ func OrgsListBlockedUsers(ctx context.Context, req *OrgsListBlockedUsersReq, opt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OrgsListBlockedUsersResponseBody{}
+	resp.Data = []components.SimpleUser{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1977,13 +1970,6 @@ func (r *OrgsListBlockedUsersReq) Rel(link RelName, resp *OrgsListBlockedUsersRe
 }
 
 /*
-OrgsListBlockedUsersResponseBody is a response body for OrgsListBlockedUsers
-
-https://developer.github.com/v3/orgs/blocking/#list-users-blocked-by-an-organization
-*/
-type OrgsListBlockedUsersResponseBody []components.SimpleUser
-
-/*
 OrgsListBlockedUsersResponse is a response for OrgsListBlockedUsers
 
 https://developer.github.com/v3/orgs/blocking/#list-users-blocked-by-an-organization
@@ -1991,7 +1977,7 @@ https://developer.github.com/v3/orgs/blocking/#list-users-blocked-by-an-organiza
 type OrgsListBlockedUsersResponse struct {
 	response
 	request *OrgsListBlockedUsersReq
-	Data    OrgsListBlockedUsersResponseBody
+	Data    []components.SimpleUser
 }
 
 /*
@@ -2015,7 +2001,7 @@ func OrgsListForAuthenticatedUser(ctx context.Context, req *OrgsListForAuthentic
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OrgsListForAuthenticatedUserResponseBody{}
+	resp.Data = []components.OrganizationSimple{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2115,13 +2101,6 @@ func (r *OrgsListForAuthenticatedUserReq) Rel(link RelName, resp *OrgsListForAut
 }
 
 /*
-OrgsListForAuthenticatedUserResponseBody is a response body for OrgsListForAuthenticatedUser
-
-https://developer.github.com/v3/orgs/#list-organizations-for-the-authenticated-user
-*/
-type OrgsListForAuthenticatedUserResponseBody []components.OrganizationSimple
-
-/*
 OrgsListForAuthenticatedUserResponse is a response for OrgsListForAuthenticatedUser
 
 https://developer.github.com/v3/orgs/#list-organizations-for-the-authenticated-user
@@ -2129,7 +2108,7 @@ https://developer.github.com/v3/orgs/#list-organizations-for-the-authenticated-u
 type OrgsListForAuthenticatedUserResponse struct {
 	response
 	request *OrgsListForAuthenticatedUserReq
-	Data    OrgsListForAuthenticatedUserResponseBody
+	Data    []components.OrganizationSimple
 }
 
 /*
@@ -2153,7 +2132,7 @@ func OrgsListForUser(ctx context.Context, req *OrgsListForUserReq, opt ...Reques
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OrgsListForUserResponseBody{}
+	resp.Data = []components.OrganizationSimple{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2254,13 +2233,6 @@ func (r *OrgsListForUserReq) Rel(link RelName, resp *OrgsListForUserResponse) bo
 }
 
 /*
-OrgsListForUserResponseBody is a response body for OrgsListForUser
-
-https://developer.github.com/v3/orgs/#list-organizations-for-a-user
-*/
-type OrgsListForUserResponseBody []components.OrganizationSimple
-
-/*
 OrgsListForUserResponse is a response for OrgsListForUser
 
 https://developer.github.com/v3/orgs/#list-organizations-for-a-user
@@ -2268,7 +2240,7 @@ https://developer.github.com/v3/orgs/#list-organizations-for-a-user
 type OrgsListForUserResponse struct {
 	response
 	request *OrgsListForUserReq
-	Data    OrgsListForUserResponseBody
+	Data    []components.OrganizationSimple
 }
 
 /*
@@ -2292,7 +2264,7 @@ func OrgsListInvitationTeams(ctx context.Context, req *OrgsListInvitationTeamsRe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OrgsListInvitationTeamsResponseBody{}
+	resp.Data = []components.Team{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2396,13 +2368,6 @@ func (r *OrgsListInvitationTeamsReq) Rel(link RelName, resp *OrgsListInvitationT
 }
 
 /*
-OrgsListInvitationTeamsResponseBody is a response body for OrgsListInvitationTeams
-
-https://developer.github.com/v3/orgs/members/#list-organization-invitation-teams
-*/
-type OrgsListInvitationTeamsResponseBody []components.Team
-
-/*
 OrgsListInvitationTeamsResponse is a response for OrgsListInvitationTeams
 
 https://developer.github.com/v3/orgs/members/#list-organization-invitation-teams
@@ -2410,7 +2375,7 @@ https://developer.github.com/v3/orgs/members/#list-organization-invitation-teams
 type OrgsListInvitationTeamsResponse struct {
 	response
 	request *OrgsListInvitationTeamsReq
-	Data    OrgsListInvitationTeamsResponseBody
+	Data    []components.Team
 }
 
 /*
@@ -2434,7 +2399,7 @@ func OrgsListMembers(ctx context.Context, req *OrgsListMembersReq, opt ...Reques
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OrgsListMembersResponseBody{}
+	resp.Data = []components.SimpleUser{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2558,13 +2523,6 @@ func (r *OrgsListMembersReq) Rel(link RelName, resp *OrgsListMembersResponse) bo
 }
 
 /*
-OrgsListMembersResponseBody is a response body for OrgsListMembers
-
-https://developer.github.com/v3/orgs/members/#list-organization-members
-*/
-type OrgsListMembersResponseBody []components.SimpleUser
-
-/*
 OrgsListMembersResponse is a response for OrgsListMembers
 
 https://developer.github.com/v3/orgs/members/#list-organization-members
@@ -2572,7 +2530,7 @@ https://developer.github.com/v3/orgs/members/#list-organization-members
 type OrgsListMembersResponse struct {
 	response
 	request *OrgsListMembersReq
-	Data    OrgsListMembersResponseBody
+	Data    []components.SimpleUser
 }
 
 /*
@@ -2596,7 +2554,7 @@ func OrgsListMembershipsForAuthenticatedUser(ctx context.Context, req *OrgsListM
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OrgsListMembershipsForAuthenticatedUserResponseBody{}
+	resp.Data = []components.OrgMembership{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2706,13 +2664,6 @@ func (r *OrgsListMembershipsForAuthenticatedUserReq) Rel(link RelName, resp *Org
 }
 
 /*
-OrgsListMembershipsForAuthenticatedUserResponseBody is a response body for OrgsListMembershipsForAuthenticatedUser
-
-https://developer.github.com/v3/orgs/members/#list-organization-memberships-for-the-authenticated-user
-*/
-type OrgsListMembershipsForAuthenticatedUserResponseBody []components.OrgMembership
-
-/*
 OrgsListMembershipsForAuthenticatedUserResponse is a response for OrgsListMembershipsForAuthenticatedUser
 
 https://developer.github.com/v3/orgs/members/#list-organization-memberships-for-the-authenticated-user
@@ -2720,7 +2671,7 @@ https://developer.github.com/v3/orgs/members/#list-organization-memberships-for-
 type OrgsListMembershipsForAuthenticatedUserResponse struct {
 	response
 	request *OrgsListMembershipsForAuthenticatedUserReq
-	Data    OrgsListMembershipsForAuthenticatedUserResponseBody
+	Data    []components.OrgMembership
 }
 
 /*
@@ -2744,7 +2695,7 @@ func OrgsListOutsideCollaborators(ctx context.Context, req *OrgsListOutsideColla
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OrgsListOutsideCollaboratorsResponseBody{}
+	resp.Data = []components.SimpleUser{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2856,13 +2807,6 @@ func (r *OrgsListOutsideCollaboratorsReq) Rel(link RelName, resp *OrgsListOutsid
 }
 
 /*
-OrgsListOutsideCollaboratorsResponseBody is a response body for OrgsListOutsideCollaborators
-
-https://developer.github.com/v3/orgs/outside_collaborators/#list-outside-collaborators-for-an-organization
-*/
-type OrgsListOutsideCollaboratorsResponseBody []components.SimpleUser
-
-/*
 OrgsListOutsideCollaboratorsResponse is a response for OrgsListOutsideCollaborators
 
 https://developer.github.com/v3/orgs/outside_collaborators/#list-outside-collaborators-for-an-organization
@@ -2870,7 +2814,7 @@ https://developer.github.com/v3/orgs/outside_collaborators/#list-outside-collabo
 type OrgsListOutsideCollaboratorsResponse struct {
 	response
 	request *OrgsListOutsideCollaboratorsReq
-	Data    OrgsListOutsideCollaboratorsResponseBody
+	Data    []components.SimpleUser
 }
 
 /*
@@ -2894,7 +2838,7 @@ func OrgsListPendingInvitations(ctx context.Context, req *OrgsListPendingInvitat
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OrgsListPendingInvitationsResponseBody{}
+	resp.Data = []components.OrganizationInvitation{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2995,13 +2939,6 @@ func (r *OrgsListPendingInvitationsReq) Rel(link RelName, resp *OrgsListPendingI
 }
 
 /*
-OrgsListPendingInvitationsResponseBody is a response body for OrgsListPendingInvitations
-
-https://developer.github.com/v3/orgs/members/#list-pending-organization-invitations
-*/
-type OrgsListPendingInvitationsResponseBody []components.OrganizationInvitation
-
-/*
 OrgsListPendingInvitationsResponse is a response for OrgsListPendingInvitations
 
 https://developer.github.com/v3/orgs/members/#list-pending-organization-invitations
@@ -3009,7 +2946,7 @@ https://developer.github.com/v3/orgs/members/#list-pending-organization-invitati
 type OrgsListPendingInvitationsResponse struct {
 	response
 	request *OrgsListPendingInvitationsReq
-	Data    OrgsListPendingInvitationsResponseBody
+	Data    []components.OrganizationInvitation
 }
 
 /*
@@ -3033,7 +2970,7 @@ func OrgsListPublicMembers(ctx context.Context, req *OrgsListPublicMembersReq, o
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OrgsListPublicMembersResponseBody{}
+	resp.Data = []components.SimpleUser{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3134,13 +3071,6 @@ func (r *OrgsListPublicMembersReq) Rel(link RelName, resp *OrgsListPublicMembers
 }
 
 /*
-OrgsListPublicMembersResponseBody is a response body for OrgsListPublicMembers
-
-https://developer.github.com/v3/orgs/members/#list-public-organization-members
-*/
-type OrgsListPublicMembersResponseBody []components.SimpleUser
-
-/*
 OrgsListPublicMembersResponse is a response for OrgsListPublicMembers
 
 https://developer.github.com/v3/orgs/members/#list-public-organization-members
@@ -3148,7 +3078,7 @@ https://developer.github.com/v3/orgs/members/#list-public-organization-members
 type OrgsListPublicMembersResponse struct {
 	response
 	request *OrgsListPublicMembersReq
-	Data    OrgsListPublicMembersResponseBody
+	Data    []components.SimpleUser
 }
 
 /*
@@ -3172,7 +3102,7 @@ func OrgsListSamlSsoAuthorizations(ctx context.Context, req *OrgsListSamlSsoAuth
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OrgsListSamlSsoAuthorizationsResponseBody{}
+	resp.Data = []components.CredentialAuthorization{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3261,13 +3191,6 @@ func (r *OrgsListSamlSsoAuthorizationsReq) Rel(link RelName, resp *OrgsListSamlS
 }
 
 /*
-OrgsListSamlSsoAuthorizationsResponseBody is a response body for OrgsListSamlSsoAuthorizations
-
-https://developer.github.com/v3/orgs/#list-saml-sso-authorizations-for-an-organization
-*/
-type OrgsListSamlSsoAuthorizationsResponseBody []components.CredentialAuthorization
-
-/*
 OrgsListSamlSsoAuthorizationsResponse is a response for OrgsListSamlSsoAuthorizations
 
 https://developer.github.com/v3/orgs/#list-saml-sso-authorizations-for-an-organization
@@ -3275,7 +3198,7 @@ https://developer.github.com/v3/orgs/#list-saml-sso-authorizations-for-an-organi
 type OrgsListSamlSsoAuthorizationsResponse struct {
 	response
 	request *OrgsListSamlSsoAuthorizationsReq
-	Data    OrgsListSamlSsoAuthorizationsResponseBody
+	Data    []components.CredentialAuthorization
 }
 
 /*
@@ -3299,7 +3222,7 @@ func OrgsListWebhooks(ctx context.Context, req *OrgsListWebhooksReq, opt ...Requ
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = OrgsListWebhooksResponseBody{}
+	resp.Data = []components.OrgHook{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3400,13 +3323,6 @@ func (r *OrgsListWebhooksReq) Rel(link RelName, resp *OrgsListWebhooksResponse) 
 }
 
 /*
-OrgsListWebhooksResponseBody is a response body for OrgsListWebhooks
-
-https://developer.github.com/v3/orgs/hooks/#list-organization-webhooks
-*/
-type OrgsListWebhooksResponseBody []components.OrgHook
-
-/*
 OrgsListWebhooksResponse is a response for OrgsListWebhooks
 
 https://developer.github.com/v3/orgs/hooks/#list-organization-webhooks
@@ -3414,7 +3330,7 @@ https://developer.github.com/v3/orgs/hooks/#list-organization-webhooks
 type OrgsListWebhooksResponse struct {
 	response
 	request *OrgsListWebhooksReq
-	Data    OrgsListWebhooksResponseBody
+	Data    []components.OrgHook
 }
 
 /*

--- a/zz_projects_gen.go
+++ b/zz_projects_gen.go
@@ -178,7 +178,7 @@ func ProjectsCreateCard(ctx context.Context, req *ProjectsCreateCardReq, opt ...
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ProjectsCreateCardResponseBody{}
+	resp.Data = components.ProjectCard{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -302,13 +302,6 @@ type ProjectsCreateCardReqBody struct {
 }
 
 /*
-ProjectsCreateCardResponseBody is a response body for ProjectsCreateCard
-
-https://developer.github.com/v3/projects/cards/#create-a-project-card
-*/
-type ProjectsCreateCardResponseBody components.ProjectCard
-
-/*
 ProjectsCreateCardResponse is a response for ProjectsCreateCard
 
 https://developer.github.com/v3/projects/cards/#create-a-project-card
@@ -316,7 +309,7 @@ https://developer.github.com/v3/projects/cards/#create-a-project-card
 type ProjectsCreateCardResponse struct {
 	response
 	request *ProjectsCreateCardReq
-	Data    ProjectsCreateCardResponseBody
+	Data    components.ProjectCard
 }
 
 /*
@@ -340,7 +333,7 @@ func ProjectsCreateColumn(ctx context.Context, req *ProjectsCreateColumnReq, opt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ProjectsCreateColumnResponseBody{}
+	resp.Data = components.ProjectColumn{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -459,13 +452,6 @@ type ProjectsCreateColumnReqBody struct {
 }
 
 /*
-ProjectsCreateColumnResponseBody is a response body for ProjectsCreateColumn
-
-https://developer.github.com/v3/projects/columns/#create-a-project-column
-*/
-type ProjectsCreateColumnResponseBody components.ProjectColumn
-
-/*
 ProjectsCreateColumnResponse is a response for ProjectsCreateColumn
 
 https://developer.github.com/v3/projects/columns/#create-a-project-column
@@ -473,7 +459,7 @@ https://developer.github.com/v3/projects/columns/#create-a-project-column
 type ProjectsCreateColumnResponse struct {
 	response
 	request *ProjectsCreateColumnReq
-	Data    ProjectsCreateColumnResponseBody
+	Data    components.ProjectColumn
 }
 
 /*
@@ -497,7 +483,7 @@ func ProjectsCreateForAuthenticatedUser(ctx context.Context, req *ProjectsCreate
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ProjectsCreateForAuthenticatedUserResponseBody{}
+	resp.Data = components.Project{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -618,13 +604,6 @@ type ProjectsCreateForAuthenticatedUserReqBody struct {
 }
 
 /*
-ProjectsCreateForAuthenticatedUserResponseBody is a response body for ProjectsCreateForAuthenticatedUser
-
-https://developer.github.com/v3/projects/#create-a-user-project
-*/
-type ProjectsCreateForAuthenticatedUserResponseBody components.Project
-
-/*
 ProjectsCreateForAuthenticatedUserResponse is a response for ProjectsCreateForAuthenticatedUser
 
 https://developer.github.com/v3/projects/#create-a-user-project
@@ -632,7 +611,7 @@ https://developer.github.com/v3/projects/#create-a-user-project
 type ProjectsCreateForAuthenticatedUserResponse struct {
 	response
 	request *ProjectsCreateForAuthenticatedUserReq
-	Data    ProjectsCreateForAuthenticatedUserResponseBody
+	Data    components.Project
 }
 
 /*
@@ -656,7 +635,7 @@ func ProjectsCreateForOrg(ctx context.Context, req *ProjectsCreateForOrgReq, opt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ProjectsCreateForOrgResponseBody{}
+	resp.Data = components.Project{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -778,13 +757,6 @@ type ProjectsCreateForOrgReqBody struct {
 }
 
 /*
-ProjectsCreateForOrgResponseBody is a response body for ProjectsCreateForOrg
-
-https://developer.github.com/v3/projects/#create-an-organization-project
-*/
-type ProjectsCreateForOrgResponseBody components.Project
-
-/*
 ProjectsCreateForOrgResponse is a response for ProjectsCreateForOrg
 
 https://developer.github.com/v3/projects/#create-an-organization-project
@@ -792,7 +764,7 @@ https://developer.github.com/v3/projects/#create-an-organization-project
 type ProjectsCreateForOrgResponse struct {
 	response
 	request *ProjectsCreateForOrgReq
-	Data    ProjectsCreateForOrgResponseBody
+	Data    components.Project
 }
 
 /*
@@ -816,7 +788,7 @@ func ProjectsCreateForRepo(ctx context.Context, req *ProjectsCreateForRepoReq, o
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ProjectsCreateForRepoResponseBody{}
+	resp.Data = components.Project{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -939,13 +911,6 @@ type ProjectsCreateForRepoReqBody struct {
 }
 
 /*
-ProjectsCreateForRepoResponseBody is a response body for ProjectsCreateForRepo
-
-https://developer.github.com/v3/projects/#create-a-repository-project
-*/
-type ProjectsCreateForRepoResponseBody components.Project
-
-/*
 ProjectsCreateForRepoResponse is a response for ProjectsCreateForRepo
 
 https://developer.github.com/v3/projects/#create-a-repository-project
@@ -953,7 +918,7 @@ https://developer.github.com/v3/projects/#create-a-repository-project
 type ProjectsCreateForRepoResponse struct {
 	response
 	request *ProjectsCreateForRepoReq
-	Data    ProjectsCreateForRepoResponseBody
+	Data    components.Project
 }
 
 /*
@@ -1380,7 +1345,7 @@ func ProjectsGet(ctx context.Context, req *ProjectsGetReq, opt ...RequestOption)
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ProjectsGetResponseBody{}
+	resp.Data = components.Project{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1484,13 +1449,6 @@ func (r *ProjectsGetReq) Rel(link RelName, resp *ProjectsGetResponse) bool {
 }
 
 /*
-ProjectsGetResponseBody is a response body for ProjectsGet
-
-https://developer.github.com/v3/projects/#get-a-project
-*/
-type ProjectsGetResponseBody components.Project
-
-/*
 ProjectsGetResponse is a response for ProjectsGet
 
 https://developer.github.com/v3/projects/#get-a-project
@@ -1498,7 +1456,7 @@ https://developer.github.com/v3/projects/#get-a-project
 type ProjectsGetResponse struct {
 	response
 	request *ProjectsGetReq
-	Data    ProjectsGetResponseBody
+	Data    components.Project
 }
 
 /*
@@ -1522,7 +1480,7 @@ func ProjectsGetCard(ctx context.Context, req *ProjectsGetCardReq, opt ...Reques
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ProjectsGetCardResponseBody{}
+	resp.Data = components.ProjectCard{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1628,13 +1586,6 @@ func (r *ProjectsGetCardReq) Rel(link RelName, resp *ProjectsGetCardResponse) bo
 }
 
 /*
-ProjectsGetCardResponseBody is a response body for ProjectsGetCard
-
-https://developer.github.com/v3/projects/cards/#get-a-project-card
-*/
-type ProjectsGetCardResponseBody components.ProjectCard
-
-/*
 ProjectsGetCardResponse is a response for ProjectsGetCard
 
 https://developer.github.com/v3/projects/cards/#get-a-project-card
@@ -1642,7 +1593,7 @@ https://developer.github.com/v3/projects/cards/#get-a-project-card
 type ProjectsGetCardResponse struct {
 	response
 	request *ProjectsGetCardReq
-	Data    ProjectsGetCardResponseBody
+	Data    components.ProjectCard
 }
 
 /*
@@ -1666,7 +1617,7 @@ func ProjectsGetColumn(ctx context.Context, req *ProjectsGetColumnReq, opt ...Re
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ProjectsGetColumnResponseBody{}
+	resp.Data = components.ProjectColumn{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1772,13 +1723,6 @@ func (r *ProjectsGetColumnReq) Rel(link RelName, resp *ProjectsGetColumnResponse
 }
 
 /*
-ProjectsGetColumnResponseBody is a response body for ProjectsGetColumn
-
-https://developer.github.com/v3/projects/columns/#get-a-project-column
-*/
-type ProjectsGetColumnResponseBody components.ProjectColumn
-
-/*
 ProjectsGetColumnResponse is a response for ProjectsGetColumn
 
 https://developer.github.com/v3/projects/columns/#get-a-project-column
@@ -1786,7 +1730,7 @@ https://developer.github.com/v3/projects/columns/#get-a-project-column
 type ProjectsGetColumnResponse struct {
 	response
 	request *ProjectsGetColumnReq
-	Data    ProjectsGetColumnResponseBody
+	Data    components.ProjectColumn
 }
 
 /*
@@ -1810,7 +1754,7 @@ func ProjectsGetPermissionForUser(ctx context.Context, req *ProjectsGetPermissio
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ProjectsGetPermissionForUserResponseBody{}
+	resp.Data = components.RepositoryCollaboratorPermission{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1915,13 +1859,6 @@ func (r *ProjectsGetPermissionForUserReq) Rel(link RelName, resp *ProjectsGetPer
 }
 
 /*
-ProjectsGetPermissionForUserResponseBody is a response body for ProjectsGetPermissionForUser
-
-https://developer.github.com/v3/projects/collaborators/#get-project-permission-for-a-user
-*/
-type ProjectsGetPermissionForUserResponseBody components.RepositoryCollaboratorPermission
-
-/*
 ProjectsGetPermissionForUserResponse is a response for ProjectsGetPermissionForUser
 
 https://developer.github.com/v3/projects/collaborators/#get-project-permission-for-a-user
@@ -1929,7 +1866,7 @@ https://developer.github.com/v3/projects/collaborators/#get-project-permission-f
 type ProjectsGetPermissionForUserResponse struct {
 	response
 	request *ProjectsGetPermissionForUserReq
-	Data    ProjectsGetPermissionForUserResponseBody
+	Data    components.RepositoryCollaboratorPermission
 }
 
 /*
@@ -3366,7 +3303,7 @@ func ProjectsUpdate(ctx context.Context, req *ProjectsUpdateReq, opt ...RequestO
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ProjectsUpdateResponseBody{}
+	resp.Data = components.Project{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3497,13 +3434,6 @@ type ProjectsUpdateReqBody struct {
 }
 
 /*
-ProjectsUpdateResponseBody is a response body for ProjectsUpdate
-
-https://developer.github.com/v3/projects/#update-a-project
-*/
-type ProjectsUpdateResponseBody components.Project
-
-/*
 ProjectsUpdateResponse is a response for ProjectsUpdate
 
 https://developer.github.com/v3/projects/#update-a-project
@@ -3511,7 +3441,7 @@ https://developer.github.com/v3/projects/#update-a-project
 type ProjectsUpdateResponse struct {
 	response
 	request *ProjectsUpdateReq
-	Data    ProjectsUpdateResponseBody
+	Data    components.Project
 }
 
 /*
@@ -3535,7 +3465,7 @@ func ProjectsUpdateCard(ctx context.Context, req *ProjectsUpdateCardReq, opt ...
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ProjectsUpdateCardResponseBody{}
+	resp.Data = components.ProjectCard{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3659,13 +3589,6 @@ type ProjectsUpdateCardReqBody struct {
 }
 
 /*
-ProjectsUpdateCardResponseBody is a response body for ProjectsUpdateCard
-
-https://developer.github.com/v3/projects/cards/#update-a-project-card
-*/
-type ProjectsUpdateCardResponseBody components.ProjectCard
-
-/*
 ProjectsUpdateCardResponse is a response for ProjectsUpdateCard
 
 https://developer.github.com/v3/projects/cards/#update-a-project-card
@@ -3673,7 +3596,7 @@ https://developer.github.com/v3/projects/cards/#update-a-project-card
 type ProjectsUpdateCardResponse struct {
 	response
 	request *ProjectsUpdateCardReq
-	Data    ProjectsUpdateCardResponseBody
+	Data    components.ProjectCard
 }
 
 /*
@@ -3697,7 +3620,7 @@ func ProjectsUpdateColumn(ctx context.Context, req *ProjectsUpdateColumnReq, opt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ProjectsUpdateColumnResponseBody{}
+	resp.Data = components.ProjectColumn{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3818,13 +3741,6 @@ type ProjectsUpdateColumnReqBody struct {
 }
 
 /*
-ProjectsUpdateColumnResponseBody is a response body for ProjectsUpdateColumn
-
-https://developer.github.com/v3/projects/columns/#update-a-project-column
-*/
-type ProjectsUpdateColumnResponseBody components.ProjectColumn
-
-/*
 ProjectsUpdateColumnResponse is a response for ProjectsUpdateColumn
 
 https://developer.github.com/v3/projects/columns/#update-a-project-column
@@ -3832,5 +3748,5 @@ https://developer.github.com/v3/projects/columns/#update-a-project-column
 type ProjectsUpdateColumnResponse struct {
 	response
 	request *ProjectsUpdateColumnReq
-	Data    ProjectsUpdateColumnResponseBody
+	Data    components.ProjectColumn
 }

--- a/zz_projects_gen.go
+++ b/zz_projects_gen.go
@@ -1890,7 +1890,7 @@ func ProjectsListCards(ctx context.Context, req *ProjectsListCardsReq, opt ...Re
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ProjectsListCardsResponseBody{}
+	resp.Data = []components.ProjectCard{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2017,13 +2017,6 @@ func (r *ProjectsListCardsReq) Rel(link RelName, resp *ProjectsListCardsResponse
 }
 
 /*
-ProjectsListCardsResponseBody is a response body for ProjectsListCards
-
-https://developer.github.com/v3/projects/cards/#list-project-cards
-*/
-type ProjectsListCardsResponseBody []components.ProjectCard
-
-/*
 ProjectsListCardsResponse is a response for ProjectsListCards
 
 https://developer.github.com/v3/projects/cards/#list-project-cards
@@ -2031,7 +2024,7 @@ https://developer.github.com/v3/projects/cards/#list-project-cards
 type ProjectsListCardsResponse struct {
 	response
 	request *ProjectsListCardsReq
-	Data    ProjectsListCardsResponseBody
+	Data    []components.ProjectCard
 }
 
 /*
@@ -2055,7 +2048,7 @@ func ProjectsListCollaborators(ctx context.Context, req *ProjectsListCollaborato
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ProjectsListCollaboratorsResponseBody{}
+	resp.Data = []components.SimpleUser{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2184,13 +2177,6 @@ func (r *ProjectsListCollaboratorsReq) Rel(link RelName, resp *ProjectsListColla
 }
 
 /*
-ProjectsListCollaboratorsResponseBody is a response body for ProjectsListCollaborators
-
-https://developer.github.com/v3/projects/collaborators/#list-project-collaborators
-*/
-type ProjectsListCollaboratorsResponseBody []components.SimpleUser
-
-/*
 ProjectsListCollaboratorsResponse is a response for ProjectsListCollaborators
 
 https://developer.github.com/v3/projects/collaborators/#list-project-collaborators
@@ -2198,7 +2184,7 @@ https://developer.github.com/v3/projects/collaborators/#list-project-collaborato
 type ProjectsListCollaboratorsResponse struct {
 	response
 	request *ProjectsListCollaboratorsReq
-	Data    ProjectsListCollaboratorsResponseBody
+	Data    []components.SimpleUser
 }
 
 /*
@@ -2222,7 +2208,7 @@ func ProjectsListColumns(ctx context.Context, req *ProjectsListColumnsReq, opt .
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ProjectsListColumnsResponseBody{}
+	resp.Data = []components.ProjectColumn{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2338,13 +2324,6 @@ func (r *ProjectsListColumnsReq) Rel(link RelName, resp *ProjectsListColumnsResp
 }
 
 /*
-ProjectsListColumnsResponseBody is a response body for ProjectsListColumns
-
-https://developer.github.com/v3/projects/columns/#list-project-columns
-*/
-type ProjectsListColumnsResponseBody []components.ProjectColumn
-
-/*
 ProjectsListColumnsResponse is a response for ProjectsListColumns
 
 https://developer.github.com/v3/projects/columns/#list-project-columns
@@ -2352,7 +2331,7 @@ https://developer.github.com/v3/projects/columns/#list-project-columns
 type ProjectsListColumnsResponse struct {
 	response
 	request *ProjectsListColumnsReq
-	Data    ProjectsListColumnsResponseBody
+	Data    []components.ProjectColumn
 }
 
 /*
@@ -2376,7 +2355,7 @@ func ProjectsListForOrg(ctx context.Context, req *ProjectsListForOrgReq, opt ...
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ProjectsListForOrgResponseBody{}
+	resp.Data = []components.Project{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2501,13 +2480,6 @@ func (r *ProjectsListForOrgReq) Rel(link RelName, resp *ProjectsListForOrgRespon
 }
 
 /*
-ProjectsListForOrgResponseBody is a response body for ProjectsListForOrg
-
-https://developer.github.com/v3/projects/#list-organization-projects
-*/
-type ProjectsListForOrgResponseBody []components.Project
-
-/*
 ProjectsListForOrgResponse is a response for ProjectsListForOrg
 
 https://developer.github.com/v3/projects/#list-organization-projects
@@ -2515,7 +2487,7 @@ https://developer.github.com/v3/projects/#list-organization-projects
 type ProjectsListForOrgResponse struct {
 	response
 	request *ProjectsListForOrgReq
-	Data    ProjectsListForOrgResponseBody
+	Data    []components.Project
 }
 
 /*
@@ -2539,7 +2511,7 @@ func ProjectsListForRepo(ctx context.Context, req *ProjectsListForRepoReq, opt .
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ProjectsListForRepoResponseBody{}
+	resp.Data = []components.Project{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2665,13 +2637,6 @@ func (r *ProjectsListForRepoReq) Rel(link RelName, resp *ProjectsListForRepoResp
 }
 
 /*
-ProjectsListForRepoResponseBody is a response body for ProjectsListForRepo
-
-https://developer.github.com/v3/projects/#list-repository-projects
-*/
-type ProjectsListForRepoResponseBody []components.Project
-
-/*
 ProjectsListForRepoResponse is a response for ProjectsListForRepo
 
 https://developer.github.com/v3/projects/#list-repository-projects
@@ -2679,7 +2644,7 @@ https://developer.github.com/v3/projects/#list-repository-projects
 type ProjectsListForRepoResponse struct {
 	response
 	request *ProjectsListForRepoReq
-	Data    ProjectsListForRepoResponseBody
+	Data    []components.Project
 }
 
 /*
@@ -2703,7 +2668,7 @@ func ProjectsListForUser(ctx context.Context, req *ProjectsListForUserReq, opt .
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ProjectsListForUserResponseBody{}
+	resp.Data = []components.Project{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2828,13 +2793,6 @@ func (r *ProjectsListForUserReq) Rel(link RelName, resp *ProjectsListForUserResp
 }
 
 /*
-ProjectsListForUserResponseBody is a response body for ProjectsListForUser
-
-https://developer.github.com/v3/projects/#list-user-projects
-*/
-type ProjectsListForUserResponseBody []components.Project
-
-/*
 ProjectsListForUserResponse is a response for ProjectsListForUser
 
 https://developer.github.com/v3/projects/#list-user-projects
@@ -2842,7 +2800,7 @@ https://developer.github.com/v3/projects/#list-user-projects
 type ProjectsListForUserResponse struct {
 	response
 	request *ProjectsListForUserReq
-	Data    ProjectsListForUserResponseBody
+	Data    []components.Project
 }
 
 /*

--- a/zz_pulls_gen.go
+++ b/zz_pulls_gen.go
@@ -157,7 +157,7 @@ func PullsCreate(ctx context.Context, req *PullsCreateReq, opt ...RequestOption)
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = PullsCreateResponseBody{}
+	resp.Data = components.PullRequest{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -307,13 +307,6 @@ type PullsCreateReqBody struct {
 }
 
 /*
-PullsCreateResponseBody is a response body for PullsCreate
-
-https://developer.github.com/v3/pulls/#create-a-pull-request
-*/
-type PullsCreateResponseBody components.PullRequest
-
-/*
 PullsCreateResponse is a response for PullsCreate
 
 https://developer.github.com/v3/pulls/#create-a-pull-request
@@ -321,7 +314,7 @@ https://developer.github.com/v3/pulls/#create-a-pull-request
 type PullsCreateResponse struct {
 	response
 	request *PullsCreateReq
-	Data    PullsCreateResponseBody
+	Data    components.PullRequest
 }
 
 /*
@@ -345,7 +338,7 @@ func PullsCreateReplyForReviewComment(ctx context.Context, req *PullsCreateReply
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = PullsCreateReplyForReviewCommentResponseBody{}
+	resp.Data = components.PullRequestReviewComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -454,13 +447,6 @@ type PullsCreateReplyForReviewCommentReqBody struct {
 }
 
 /*
-PullsCreateReplyForReviewCommentResponseBody is a response body for PullsCreateReplyForReviewComment
-
-https://developer.github.com/v3/pulls/comments/#create-a-reply-for-a-review-comment
-*/
-type PullsCreateReplyForReviewCommentResponseBody components.PullRequestReviewComment
-
-/*
 PullsCreateReplyForReviewCommentResponse is a response for PullsCreateReplyForReviewComment
 
 https://developer.github.com/v3/pulls/comments/#create-a-reply-for-a-review-comment
@@ -468,7 +454,7 @@ https://developer.github.com/v3/pulls/comments/#create-a-reply-for-a-review-comm
 type PullsCreateReplyForReviewCommentResponse struct {
 	response
 	request *PullsCreateReplyForReviewCommentReq
-	Data    PullsCreateReplyForReviewCommentResponseBody
+	Data    components.PullRequestReviewComment
 }
 
 /*
@@ -492,7 +478,7 @@ func PullsCreateReview(ctx context.Context, req *PullsCreateReviewReq, opt ...Re
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = PullsCreateReviewResponseBody{}
+	resp.Data = components.PullRequestReview{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -642,13 +628,6 @@ type PullsCreateReviewReqBody struct {
 }
 
 /*
-PullsCreateReviewResponseBody is a response body for PullsCreateReview
-
-https://developer.github.com/v3/pulls/reviews/#create-a-review-for-a-pull-request
-*/
-type PullsCreateReviewResponseBody components.PullRequestReview
-
-/*
 PullsCreateReviewResponse is a response for PullsCreateReview
 
 https://developer.github.com/v3/pulls/reviews/#create-a-review-for-a-pull-request
@@ -656,7 +635,7 @@ https://developer.github.com/v3/pulls/reviews/#create-a-review-for-a-pull-reques
 type PullsCreateReviewResponse struct {
 	response
 	request *PullsCreateReviewReq
-	Data    PullsCreateReviewResponseBody
+	Data    components.PullRequestReview
 }
 
 /*
@@ -680,7 +659,7 @@ func PullsCreateReviewComment(ctx context.Context, req *PullsCreateReviewComment
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = PullsCreateReviewCommentResponseBody{}
+	resp.Data = components.PullRequestReviewComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -854,13 +833,6 @@ type PullsCreateReviewCommentReqBody struct {
 }
 
 /*
-PullsCreateReviewCommentResponseBody is a response body for PullsCreateReviewComment
-
-https://developer.github.com/v3/pulls/comments/#create-a-review-comment-for-a-pull-request
-*/
-type PullsCreateReviewCommentResponseBody components.PullRequestReviewComment
-
-/*
 PullsCreateReviewCommentResponse is a response for PullsCreateReviewComment
 
 https://developer.github.com/v3/pulls/comments/#create-a-review-comment-for-a-pull-request
@@ -868,7 +840,7 @@ https://developer.github.com/v3/pulls/comments/#create-a-review-comment-for-a-pu
 type PullsCreateReviewCommentResponse struct {
 	response
 	request *PullsCreateReviewCommentReq
-	Data    PullsCreateReviewCommentResponseBody
+	Data    components.PullRequestReviewComment
 }
 
 /*
@@ -892,7 +864,7 @@ func PullsDeletePendingReview(ctx context.Context, req *PullsDeletePendingReview
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = PullsDeletePendingReviewResponseBody{}
+	resp.Data = components.PullRequestReview{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -986,13 +958,6 @@ func (r *PullsDeletePendingReviewReq) Rel(link RelName, resp *PullsDeletePending
 }
 
 /*
-PullsDeletePendingReviewResponseBody is a response body for PullsDeletePendingReview
-
-https://developer.github.com/v3/pulls/reviews/#delete-a-pending-review-for-a-pull-request
-*/
-type PullsDeletePendingReviewResponseBody components.PullRequestReview
-
-/*
 PullsDeletePendingReviewResponse is a response for PullsDeletePendingReview
 
 https://developer.github.com/v3/pulls/reviews/#delete-a-pending-review-for-a-pull-request
@@ -1000,7 +965,7 @@ https://developer.github.com/v3/pulls/reviews/#delete-a-pending-review-for-a-pul
 type PullsDeletePendingReviewResponse struct {
 	response
 	request *PullsDeletePendingReviewReq
-	Data    PullsDeletePendingReviewResponseBody
+	Data    components.PullRequestReview
 }
 
 /*
@@ -1151,7 +1116,7 @@ func PullsDismissReview(ctx context.Context, req *PullsDismissReviewReq, opt ...
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = PullsDismissReviewResponseBody{}
+	resp.Data = components.PullRequestReview{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1261,13 +1226,6 @@ type PullsDismissReviewReqBody struct {
 }
 
 /*
-PullsDismissReviewResponseBody is a response body for PullsDismissReview
-
-https://developer.github.com/v3/pulls/reviews/#dismiss-a-review-for-a-pull-request
-*/
-type PullsDismissReviewResponseBody components.PullRequestReview
-
-/*
 PullsDismissReviewResponse is a response for PullsDismissReview
 
 https://developer.github.com/v3/pulls/reviews/#dismiss-a-review-for-a-pull-request
@@ -1275,7 +1233,7 @@ https://developer.github.com/v3/pulls/reviews/#dismiss-a-review-for-a-pull-reque
 type PullsDismissReviewResponse struct {
 	response
 	request *PullsDismissReviewReq
-	Data    PullsDismissReviewResponseBody
+	Data    components.PullRequestReview
 }
 
 /*
@@ -1299,7 +1257,7 @@ func PullsGet(ctx context.Context, req *PullsGetReq, opt ...RequestOption) (*Pul
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = PullsGetResponseBody{}
+	resp.Data = components.PullRequest{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1403,13 +1361,6 @@ func (r *PullsGetReq) Rel(link RelName, resp *PullsGetResponse) bool {
 }
 
 /*
-PullsGetResponseBody is a response body for PullsGet
-
-https://developer.github.com/v3/pulls/#get-a-pull-request
-*/
-type PullsGetResponseBody components.PullRequest
-
-/*
 PullsGetResponse is a response for PullsGet
 
 https://developer.github.com/v3/pulls/#get-a-pull-request
@@ -1417,7 +1368,7 @@ https://developer.github.com/v3/pulls/#get-a-pull-request
 type PullsGetResponse struct {
 	response
 	request *PullsGetReq
-	Data    PullsGetResponseBody
+	Data    components.PullRequest
 }
 
 /*
@@ -1441,7 +1392,7 @@ func PullsGetReview(ctx context.Context, req *PullsGetReviewReq, opt ...RequestO
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = PullsGetReviewResponseBody{}
+	resp.Data = components.PullRequestReview{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1535,13 +1486,6 @@ func (r *PullsGetReviewReq) Rel(link RelName, resp *PullsGetReviewResponse) bool
 }
 
 /*
-PullsGetReviewResponseBody is a response body for PullsGetReview
-
-https://developer.github.com/v3/pulls/reviews/#get-a-review-for-a-pull-request
-*/
-type PullsGetReviewResponseBody components.PullRequestReview
-
-/*
 PullsGetReviewResponse is a response for PullsGetReview
 
 https://developer.github.com/v3/pulls/reviews/#get-a-review-for-a-pull-request
@@ -1549,7 +1493,7 @@ https://developer.github.com/v3/pulls/reviews/#get-a-review-for-a-pull-request
 type PullsGetReviewResponse struct {
 	response
 	request *PullsGetReviewReq
-	Data    PullsGetReviewResponseBody
+	Data    components.PullRequestReview
 }
 
 /*
@@ -1573,7 +1517,7 @@ func PullsGetReviewComment(ctx context.Context, req *PullsGetReviewCommentReq, o
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = PullsGetReviewCommentResponseBody{}
+	resp.Data = components.PullRequestReviewComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1691,13 +1635,6 @@ func (r *PullsGetReviewCommentReq) Rel(link RelName, resp *PullsGetReviewComment
 }
 
 /*
-PullsGetReviewCommentResponseBody is a response body for PullsGetReviewComment
-
-https://developer.github.com/v3/pulls/comments/#get-a-review-comment-for-a-pull-request
-*/
-type PullsGetReviewCommentResponseBody components.PullRequestReviewComment
-
-/*
 PullsGetReviewCommentResponse is a response for PullsGetReviewComment
 
 https://developer.github.com/v3/pulls/comments/#get-a-review-comment-for-a-pull-request
@@ -1705,7 +1642,7 @@ https://developer.github.com/v3/pulls/comments/#get-a-review-comment-for-a-pull-
 type PullsGetReviewCommentResponse struct {
 	response
 	request *PullsGetReviewCommentReq
-	Data    PullsGetReviewCommentResponseBody
+	Data    components.PullRequestReviewComment
 }
 
 /*
@@ -2349,7 +2286,7 @@ func PullsListRequestedReviewers(ctx context.Context, req *PullsListRequestedRev
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = PullsListRequestedReviewersResponseBody{}
+	resp.Data = components.PullRequestReviewRequest{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2452,13 +2389,6 @@ func (r *PullsListRequestedReviewersReq) Rel(link RelName, resp *PullsListReques
 }
 
 /*
-PullsListRequestedReviewersResponseBody is a response body for PullsListRequestedReviewers
-
-https://developer.github.com/v3/pulls/review_requests/#list-requested-reviewers-for-a-pull-request
-*/
-type PullsListRequestedReviewersResponseBody components.PullRequestReviewRequest
-
-/*
 PullsListRequestedReviewersResponse is a response for PullsListRequestedReviewers
 
 https://developer.github.com/v3/pulls/review_requests/#list-requested-reviewers-for-a-pull-request
@@ -2466,7 +2396,7 @@ https://developer.github.com/v3/pulls/review_requests/#list-requested-reviewers-
 type PullsListRequestedReviewersResponse struct {
 	response
 	request *PullsListRequestedReviewersReq
-	Data    PullsListRequestedReviewersResponseBody
+	Data    components.PullRequestReviewRequest
 }
 
 /*
@@ -3012,7 +2942,7 @@ func PullsMerge(ctx context.Context, req *PullsMergeReq, opt ...RequestOption) (
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = PullsMergeResponseBody{}
+	resp.Data = components.PullRequestMergeResult{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3127,13 +3057,6 @@ type PullsMergeReqBody struct {
 }
 
 /*
-PullsMergeResponseBody is a response body for PullsMerge
-
-https://developer.github.com/v3/pulls/#merge-a-pull-request
-*/
-type PullsMergeResponseBody components.PullRequestMergeResult
-
-/*
 PullsMergeResponse is a response for PullsMerge
 
 https://developer.github.com/v3/pulls/#merge-a-pull-request
@@ -3141,7 +3064,7 @@ https://developer.github.com/v3/pulls/#merge-a-pull-request
 type PullsMergeResponse struct {
 	response
 	request *PullsMergeReq
-	Data    PullsMergeResponseBody
+	Data    components.PullRequestMergeResult
 }
 
 /*
@@ -3300,7 +3223,7 @@ func PullsRequestReviewers(ctx context.Context, req *PullsRequestReviewersReq, o
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = PullsRequestReviewersResponseBody{}
+	resp.Data = components.PullRequestSimple{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3409,13 +3332,6 @@ type PullsRequestReviewersReqBody struct {
 }
 
 /*
-PullsRequestReviewersResponseBody is a response body for PullsRequestReviewers
-
-https://developer.github.com/v3/pulls/review_requests/#request-reviewers-for-a-pull-request
-*/
-type PullsRequestReviewersResponseBody components.PullRequestSimple
-
-/*
 PullsRequestReviewersResponse is a response for PullsRequestReviewers
 
 https://developer.github.com/v3/pulls/review_requests/#request-reviewers-for-a-pull-request
@@ -3423,7 +3339,7 @@ https://developer.github.com/v3/pulls/review_requests/#request-reviewers-for-a-p
 type PullsRequestReviewersResponse struct {
 	response
 	request *PullsRequestReviewersReq
-	Data    PullsRequestReviewersResponseBody
+	Data    components.PullRequestSimple
 }
 
 /*
@@ -3447,7 +3363,7 @@ func PullsSubmitReview(ctx context.Context, req *PullsSubmitReviewReq, opt ...Re
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = PullsSubmitReviewResponseBody{}
+	resp.Data = components.PullRequestReview{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3565,13 +3481,6 @@ type PullsSubmitReviewReqBody struct {
 }
 
 /*
-PullsSubmitReviewResponseBody is a response body for PullsSubmitReview
-
-https://developer.github.com/v3/pulls/reviews/#submit-a-review-for-a-pull-request
-*/
-type PullsSubmitReviewResponseBody components.PullRequestReview
-
-/*
 PullsSubmitReviewResponse is a response for PullsSubmitReview
 
 https://developer.github.com/v3/pulls/reviews/#submit-a-review-for-a-pull-request
@@ -3579,7 +3488,7 @@ https://developer.github.com/v3/pulls/reviews/#submit-a-review-for-a-pull-reques
 type PullsSubmitReviewResponse struct {
 	response
 	request *PullsSubmitReviewReq
-	Data    PullsSubmitReviewResponseBody
+	Data    components.PullRequestReview
 }
 
 /*
@@ -3603,7 +3512,7 @@ func PullsUpdate(ctx context.Context, req *PullsUpdateReq, opt ...RequestOption)
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = PullsUpdateResponseBody{}
+	resp.Data = components.PullRequest{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3742,13 +3651,6 @@ type PullsUpdateReqBody struct {
 }
 
 /*
-PullsUpdateResponseBody is a response body for PullsUpdate
-
-https://developer.github.com/v3/pulls/#update-a-pull-request
-*/
-type PullsUpdateResponseBody components.PullRequest
-
-/*
 PullsUpdateResponse is a response for PullsUpdate
 
 https://developer.github.com/v3/pulls/#update-a-pull-request
@@ -3756,7 +3658,7 @@ https://developer.github.com/v3/pulls/#update-a-pull-request
 type PullsUpdateResponse struct {
 	response
 	request *PullsUpdateReq
-	Data    PullsUpdateResponseBody
+	Data    components.PullRequest
 }
 
 /*
@@ -3948,7 +3850,7 @@ func PullsUpdateReview(ctx context.Context, req *PullsUpdateReviewReq, opt ...Re
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = PullsUpdateReviewResponseBody{}
+	resp.Data = components.PullRequestReview{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -4057,13 +3959,6 @@ type PullsUpdateReviewReqBody struct {
 }
 
 /*
-PullsUpdateReviewResponseBody is a response body for PullsUpdateReview
-
-https://developer.github.com/v3/pulls/reviews/#update-a-review-for-a-pull-request
-*/
-type PullsUpdateReviewResponseBody components.PullRequestReview
-
-/*
 PullsUpdateReviewResponse is a response for PullsUpdateReview
 
 https://developer.github.com/v3/pulls/reviews/#update-a-review-for-a-pull-request
@@ -4071,7 +3966,7 @@ https://developer.github.com/v3/pulls/reviews/#update-a-review-for-a-pull-reques
 type PullsUpdateReviewResponse struct {
 	response
 	request *PullsUpdateReviewReq
-	Data    PullsUpdateReviewResponseBody
+	Data    components.PullRequestReview
 }
 
 /*
@@ -4095,7 +3990,7 @@ func PullsUpdateReviewComment(ctx context.Context, req *PullsUpdateReviewComment
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = PullsUpdateReviewCommentResponseBody{}
+	resp.Data = components.PullRequestReviewComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -4213,13 +4108,6 @@ type PullsUpdateReviewCommentReqBody struct {
 }
 
 /*
-PullsUpdateReviewCommentResponseBody is a response body for PullsUpdateReviewComment
-
-https://developer.github.com/v3/pulls/comments/#update-a-review-comment-for-a-pull-request
-*/
-type PullsUpdateReviewCommentResponseBody components.PullRequestReviewComment
-
-/*
 PullsUpdateReviewCommentResponse is a response for PullsUpdateReviewComment
 
 https://developer.github.com/v3/pulls/comments/#update-a-review-comment-for-a-pull-request
@@ -4227,5 +4115,5 @@ https://developer.github.com/v3/pulls/comments/#update-a-review-comment-for-a-pu
 type PullsUpdateReviewCommentResponse struct {
 	response
 	request *PullsUpdateReviewCommentReq
-	Data    PullsUpdateReviewCommentResponseBody
+	Data    components.PullRequestReviewComment
 }

--- a/zz_pulls_gen.go
+++ b/zz_pulls_gen.go
@@ -1666,7 +1666,7 @@ func PullsList(ctx context.Context, req *PullsListReq, opt ...RequestOption) (*P
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = PullsListResponseBody{}
+	resp.Data = []components.PullRequestSimple{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1822,13 +1822,6 @@ func (r *PullsListReq) Rel(link RelName, resp *PullsListResponse) bool {
 }
 
 /*
-PullsListResponseBody is a response body for PullsList
-
-https://developer.github.com/v3/pulls/#list-pull-requests
-*/
-type PullsListResponseBody []components.PullRequestSimple
-
-/*
 PullsListResponse is a response for PullsList
 
 https://developer.github.com/v3/pulls/#list-pull-requests
@@ -1836,7 +1829,7 @@ https://developer.github.com/v3/pulls/#list-pull-requests
 type PullsListResponse struct {
 	response
 	request *PullsListReq
-	Data    PullsListResponseBody
+	Data    []components.PullRequestSimple
 }
 
 /*
@@ -1860,7 +1853,7 @@ func PullsListCommentsForReview(ctx context.Context, req *PullsListCommentsForRe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = PullsListCommentsForReviewResponseBody{}
+	resp.Data = []components.ReviewComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1966,13 +1959,6 @@ func (r *PullsListCommentsForReviewReq) Rel(link RelName, resp *PullsListComment
 }
 
 /*
-PullsListCommentsForReviewResponseBody is a response body for PullsListCommentsForReview
-
-https://developer.github.com/v3/pulls/reviews/#list-comments-for-a-pull-request-review
-*/
-type PullsListCommentsForReviewResponseBody []components.ReviewComment
-
-/*
 PullsListCommentsForReviewResponse is a response for PullsListCommentsForReview
 
 https://developer.github.com/v3/pulls/reviews/#list-comments-for-a-pull-request-review
@@ -1980,7 +1966,7 @@ https://developer.github.com/v3/pulls/reviews/#list-comments-for-a-pull-request-
 type PullsListCommentsForReviewResponse struct {
 	response
 	request *PullsListCommentsForReviewReq
-	Data    PullsListCommentsForReviewResponseBody
+	Data    []components.ReviewComment
 }
 
 /*
@@ -2004,7 +1990,7 @@ func PullsListCommits(ctx context.Context, req *PullsListCommitsReq, opt ...Requ
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = PullsListCommitsResponseBody{}
+	resp.Data = []components.SimpleCommit{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2107,13 +2093,6 @@ func (r *PullsListCommitsReq) Rel(link RelName, resp *PullsListCommitsResponse) 
 }
 
 /*
-PullsListCommitsResponseBody is a response body for PullsListCommits
-
-https://developer.github.com/v3/pulls/#list-commits-on-a-pull-request
-*/
-type PullsListCommitsResponseBody []components.SimpleCommit
-
-/*
 PullsListCommitsResponse is a response for PullsListCommits
 
 https://developer.github.com/v3/pulls/#list-commits-on-a-pull-request
@@ -2121,7 +2100,7 @@ https://developer.github.com/v3/pulls/#list-commits-on-a-pull-request
 type PullsListCommitsResponse struct {
 	response
 	request *PullsListCommitsReq
-	Data    PullsListCommitsResponseBody
+	Data    []components.SimpleCommit
 }
 
 /*
@@ -2145,7 +2124,7 @@ func PullsListFiles(ctx context.Context, req *PullsListFilesReq, opt ...RequestO
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = PullsListFilesResponseBody{}
+	resp.Data = []components.DiffEntry{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2248,13 +2227,6 @@ func (r *PullsListFilesReq) Rel(link RelName, resp *PullsListFilesResponse) bool
 }
 
 /*
-PullsListFilesResponseBody is a response body for PullsListFiles
-
-https://developer.github.com/v3/pulls/#list-pull-requests-files
-*/
-type PullsListFilesResponseBody []components.DiffEntry
-
-/*
 PullsListFilesResponse is a response for PullsListFiles
 
 https://developer.github.com/v3/pulls/#list-pull-requests-files
@@ -2262,7 +2234,7 @@ https://developer.github.com/v3/pulls/#list-pull-requests-files
 type PullsListFilesResponse struct {
 	response
 	request *PullsListFilesReq
-	Data    PullsListFilesResponseBody
+	Data    []components.DiffEntry
 }
 
 /*
@@ -2420,7 +2392,7 @@ func PullsListReviewComments(ctx context.Context, req *PullsListReviewCommentsRe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = PullsListReviewCommentsResponseBody{}
+	resp.Data = []components.PullRequestReviewComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2573,13 +2545,6 @@ func (r *PullsListReviewCommentsReq) Rel(link RelName, resp *PullsListReviewComm
 }
 
 /*
-PullsListReviewCommentsResponseBody is a response body for PullsListReviewComments
-
-https://developer.github.com/v3/pulls/comments/#list-review-comments-on-a-pull-request
-*/
-type PullsListReviewCommentsResponseBody []components.PullRequestReviewComment
-
-/*
 PullsListReviewCommentsResponse is a response for PullsListReviewComments
 
 https://developer.github.com/v3/pulls/comments/#list-review-comments-on-a-pull-request
@@ -2587,7 +2552,7 @@ https://developer.github.com/v3/pulls/comments/#list-review-comments-on-a-pull-r
 type PullsListReviewCommentsResponse struct {
 	response
 	request *PullsListReviewCommentsReq
-	Data    PullsListReviewCommentsResponseBody
+	Data    []components.PullRequestReviewComment
 }
 
 /*
@@ -2611,7 +2576,7 @@ func PullsListReviewCommentsForRepo(ctx context.Context, req *PullsListReviewCom
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = PullsListReviewCommentsForRepoResponseBody{}
+	resp.Data = []components.PullRequestReviewComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2763,13 +2728,6 @@ func (r *PullsListReviewCommentsForRepoReq) Rel(link RelName, resp *PullsListRev
 }
 
 /*
-PullsListReviewCommentsForRepoResponseBody is a response body for PullsListReviewCommentsForRepo
-
-https://developer.github.com/v3/pulls/comments/#list-review-comments-in-a-repository
-*/
-type PullsListReviewCommentsForRepoResponseBody []components.PullRequestReviewComment
-
-/*
 PullsListReviewCommentsForRepoResponse is a response for PullsListReviewCommentsForRepo
 
 https://developer.github.com/v3/pulls/comments/#list-review-comments-in-a-repository
@@ -2777,7 +2735,7 @@ https://developer.github.com/v3/pulls/comments/#list-review-comments-in-a-reposi
 type PullsListReviewCommentsForRepoResponse struct {
 	response
 	request *PullsListReviewCommentsForRepoReq
-	Data    PullsListReviewCommentsForRepoResponseBody
+	Data    []components.PullRequestReviewComment
 }
 
 /*
@@ -2801,7 +2759,7 @@ func PullsListReviews(ctx context.Context, req *PullsListReviewsReq, opt ...Requ
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = PullsListReviewsResponseBody{}
+	resp.Data = []components.PullRequestReview{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2904,13 +2862,6 @@ func (r *PullsListReviewsReq) Rel(link RelName, resp *PullsListReviewsResponse) 
 }
 
 /*
-PullsListReviewsResponseBody is a response body for PullsListReviews
-
-https://developer.github.com/v3/pulls/reviews/#list-reviews-for-a-pull-request
-*/
-type PullsListReviewsResponseBody []components.PullRequestReview
-
-/*
 PullsListReviewsResponse is a response for PullsListReviews
 
 https://developer.github.com/v3/pulls/reviews/#list-reviews-for-a-pull-request
@@ -2918,7 +2869,7 @@ https://developer.github.com/v3/pulls/reviews/#list-reviews-for-a-pull-request
 type PullsListReviewsResponse struct {
 	response
 	request *PullsListReviewsReq
-	Data    PullsListReviewsResponseBody
+	Data    []components.PullRequestReview
 }
 
 /*

--- a/zz_rate_limit_gen.go
+++ b/zz_rate_limit_gen.go
@@ -31,7 +31,7 @@ func RateLimitGet(ctx context.Context, req *RateLimitGetReq, opt ...RequestOptio
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = RateLimitGetResponseBody{}
+	resp.Data = components.RateLimitOverview{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -119,13 +119,6 @@ func (r *RateLimitGetReq) Rel(link RelName, resp *RateLimitGetResponse) bool {
 }
 
 /*
-RateLimitGetResponseBody is a response body for RateLimitGet
-
-https://developer.github.com/v3/rate_limit/#get-rate-limit-status-for-the-authenticated-user
-*/
-type RateLimitGetResponseBody components.RateLimitOverview
-
-/*
 RateLimitGetResponse is a response for RateLimitGet
 
 https://developer.github.com/v3/rate_limit/#get-rate-limit-status-for-the-authenticated-user
@@ -133,5 +126,5 @@ https://developer.github.com/v3/rate_limit/#get-rate-limit-status-for-the-authen
 type RateLimitGetResponse struct {
 	response
 	request *RateLimitGetReq
-	Data    RateLimitGetResponseBody
+	Data    components.RateLimitOverview
 }

--- a/zz_reactions_gen.go
+++ b/zz_reactions_gen.go
@@ -32,7 +32,7 @@ func ReactionsCreateForCommitComment(ctx context.Context, req *ReactionsCreateFo
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReactionsCreateForCommitCommentResponseBody{}
+	resp.Data = components.Reaction{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -157,13 +157,6 @@ type ReactionsCreateForCommitCommentReqBody struct {
 }
 
 /*
-ReactionsCreateForCommitCommentResponseBody is a response body for ReactionsCreateForCommitComment
-
-https://developer.github.com/v3/reactions/#create-reaction-for-a-commit-comment
-*/
-type ReactionsCreateForCommitCommentResponseBody components.Reaction
-
-/*
 ReactionsCreateForCommitCommentResponse is a response for ReactionsCreateForCommitComment
 
 https://developer.github.com/v3/reactions/#create-reaction-for-a-commit-comment
@@ -171,7 +164,7 @@ https://developer.github.com/v3/reactions/#create-reaction-for-a-commit-comment
 type ReactionsCreateForCommitCommentResponse struct {
 	response
 	request *ReactionsCreateForCommitCommentReq
-	Data    ReactionsCreateForCommitCommentResponseBody
+	Data    components.Reaction
 }
 
 /*
@@ -195,7 +188,7 @@ func ReactionsCreateForIssue(ctx context.Context, req *ReactionsCreateForIssueRe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReactionsCreateForIssueResponseBody{}
+	resp.Data = components.Reaction{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -320,13 +313,6 @@ type ReactionsCreateForIssueReqBody struct {
 }
 
 /*
-ReactionsCreateForIssueResponseBody is a response body for ReactionsCreateForIssue
-
-https://developer.github.com/v3/reactions/#create-reaction-for-an-issue
-*/
-type ReactionsCreateForIssueResponseBody components.Reaction
-
-/*
 ReactionsCreateForIssueResponse is a response for ReactionsCreateForIssue
 
 https://developer.github.com/v3/reactions/#create-reaction-for-an-issue
@@ -334,7 +320,7 @@ https://developer.github.com/v3/reactions/#create-reaction-for-an-issue
 type ReactionsCreateForIssueResponse struct {
 	response
 	request *ReactionsCreateForIssueReq
-	Data    ReactionsCreateForIssueResponseBody
+	Data    components.Reaction
 }
 
 /*
@@ -358,7 +344,7 @@ func ReactionsCreateForIssueComment(ctx context.Context, req *ReactionsCreateFor
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReactionsCreateForIssueCommentResponseBody{}
+	resp.Data = components.Reaction{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -483,13 +469,6 @@ type ReactionsCreateForIssueCommentReqBody struct {
 }
 
 /*
-ReactionsCreateForIssueCommentResponseBody is a response body for ReactionsCreateForIssueComment
-
-https://developer.github.com/v3/reactions/#create-reaction-for-an-issue-comment
-*/
-type ReactionsCreateForIssueCommentResponseBody components.Reaction
-
-/*
 ReactionsCreateForIssueCommentResponse is a response for ReactionsCreateForIssueComment
 
 https://developer.github.com/v3/reactions/#create-reaction-for-an-issue-comment
@@ -497,7 +476,7 @@ https://developer.github.com/v3/reactions/#create-reaction-for-an-issue-comment
 type ReactionsCreateForIssueCommentResponse struct {
 	response
 	request *ReactionsCreateForIssueCommentReq
-	Data    ReactionsCreateForIssueCommentResponseBody
+	Data    components.Reaction
 }
 
 /*
@@ -521,7 +500,7 @@ func ReactionsCreateForPullRequestReviewComment(ctx context.Context, req *Reacti
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReactionsCreateForPullRequestReviewCommentResponseBody{}
+	resp.Data = components.Reaction{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -649,13 +628,6 @@ type ReactionsCreateForPullRequestReviewCommentReqBody struct {
 }
 
 /*
-ReactionsCreateForPullRequestReviewCommentResponseBody is a response body for ReactionsCreateForPullRequestReviewComment
-
-https://developer.github.com/v3/reactions/#create-reaction-for-a-pull-request-review-comment
-*/
-type ReactionsCreateForPullRequestReviewCommentResponseBody components.Reaction
-
-/*
 ReactionsCreateForPullRequestReviewCommentResponse is a response for ReactionsCreateForPullRequestReviewComment
 
 https://developer.github.com/v3/reactions/#create-reaction-for-a-pull-request-review-comment
@@ -663,7 +635,7 @@ https://developer.github.com/v3/reactions/#create-reaction-for-a-pull-request-re
 type ReactionsCreateForPullRequestReviewCommentResponse struct {
 	response
 	request *ReactionsCreateForPullRequestReviewCommentReq
-	Data    ReactionsCreateForPullRequestReviewCommentResponseBody
+	Data    components.Reaction
 }
 
 /*
@@ -687,7 +659,7 @@ func ReactionsCreateForTeamDiscussionCommentInOrg(ctx context.Context, req *Reac
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReactionsCreateForTeamDiscussionCommentInOrgResponseBody{}
+	resp.Data = components.Reaction{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -813,13 +785,6 @@ type ReactionsCreateForTeamDiscussionCommentInOrgReqBody struct {
 }
 
 /*
-ReactionsCreateForTeamDiscussionCommentInOrgResponseBody is a response body for ReactionsCreateForTeamDiscussionCommentInOrg
-
-https://developer.github.com/v3/reactions/#create-reaction-for-a-team-discussion-comment
-*/
-type ReactionsCreateForTeamDiscussionCommentInOrgResponseBody components.Reaction
-
-/*
 ReactionsCreateForTeamDiscussionCommentInOrgResponse is a response for ReactionsCreateForTeamDiscussionCommentInOrg
 
 https://developer.github.com/v3/reactions/#create-reaction-for-a-team-discussion-comment
@@ -827,7 +792,7 @@ https://developer.github.com/v3/reactions/#create-reaction-for-a-team-discussion
 type ReactionsCreateForTeamDiscussionCommentInOrgResponse struct {
 	response
 	request *ReactionsCreateForTeamDiscussionCommentInOrgReq
-	Data    ReactionsCreateForTeamDiscussionCommentInOrgResponseBody
+	Data    components.Reaction
 }
 
 /*
@@ -851,7 +816,7 @@ func ReactionsCreateForTeamDiscussionCommentLegacy(ctx context.Context, req *Rea
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReactionsCreateForTeamDiscussionCommentLegacyResponseBody{}
+	resp.Data = components.Reaction{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -974,13 +939,6 @@ type ReactionsCreateForTeamDiscussionCommentLegacyReqBody struct {
 }
 
 /*
-ReactionsCreateForTeamDiscussionCommentLegacyResponseBody is a response body for ReactionsCreateForTeamDiscussionCommentLegacy
-
-https://developer.github.com/v3/reactions/#create-reaction-for-a-team-discussion-comment-legacy
-*/
-type ReactionsCreateForTeamDiscussionCommentLegacyResponseBody components.Reaction
-
-/*
 ReactionsCreateForTeamDiscussionCommentLegacyResponse is a response for ReactionsCreateForTeamDiscussionCommentLegacy
 
 https://developer.github.com/v3/reactions/#create-reaction-for-a-team-discussion-comment-legacy
@@ -988,7 +946,7 @@ https://developer.github.com/v3/reactions/#create-reaction-for-a-team-discussion
 type ReactionsCreateForTeamDiscussionCommentLegacyResponse struct {
 	response
 	request *ReactionsCreateForTeamDiscussionCommentLegacyReq
-	Data    ReactionsCreateForTeamDiscussionCommentLegacyResponseBody
+	Data    components.Reaction
 }
 
 /*
@@ -1012,7 +970,7 @@ func ReactionsCreateForTeamDiscussionInOrg(ctx context.Context, req *ReactionsCr
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReactionsCreateForTeamDiscussionInOrgResponseBody{}
+	resp.Data = components.Reaction{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1137,13 +1095,6 @@ type ReactionsCreateForTeamDiscussionInOrgReqBody struct {
 }
 
 /*
-ReactionsCreateForTeamDiscussionInOrgResponseBody is a response body for ReactionsCreateForTeamDiscussionInOrg
-
-https://developer.github.com/v3/reactions/#create-reaction-for-a-team-discussion
-*/
-type ReactionsCreateForTeamDiscussionInOrgResponseBody components.Reaction
-
-/*
 ReactionsCreateForTeamDiscussionInOrgResponse is a response for ReactionsCreateForTeamDiscussionInOrg
 
 https://developer.github.com/v3/reactions/#create-reaction-for-a-team-discussion
@@ -1151,7 +1102,7 @@ https://developer.github.com/v3/reactions/#create-reaction-for-a-team-discussion
 type ReactionsCreateForTeamDiscussionInOrgResponse struct {
 	response
 	request *ReactionsCreateForTeamDiscussionInOrgReq
-	Data    ReactionsCreateForTeamDiscussionInOrgResponseBody
+	Data    components.Reaction
 }
 
 /*
@@ -1175,7 +1126,7 @@ func ReactionsCreateForTeamDiscussionLegacy(ctx context.Context, req *ReactionsC
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReactionsCreateForTeamDiscussionLegacyResponseBody{}
+	resp.Data = components.Reaction{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1297,13 +1248,6 @@ type ReactionsCreateForTeamDiscussionLegacyReqBody struct {
 }
 
 /*
-ReactionsCreateForTeamDiscussionLegacyResponseBody is a response body for ReactionsCreateForTeamDiscussionLegacy
-
-https://developer.github.com/v3/reactions/#create-reaction-for-a-team-discussion-legacy
-*/
-type ReactionsCreateForTeamDiscussionLegacyResponseBody components.Reaction
-
-/*
 ReactionsCreateForTeamDiscussionLegacyResponse is a response for ReactionsCreateForTeamDiscussionLegacy
 
 https://developer.github.com/v3/reactions/#create-reaction-for-a-team-discussion-legacy
@@ -1311,7 +1255,7 @@ https://developer.github.com/v3/reactions/#create-reaction-for-a-team-discussion
 type ReactionsCreateForTeamDiscussionLegacyResponse struct {
 	response
 	request *ReactionsCreateForTeamDiscussionLegacyReq
-	Data    ReactionsCreateForTeamDiscussionLegacyResponseBody
+	Data    components.Reaction
 }
 
 /*

--- a/zz_reactions_gen.go
+++ b/zz_reactions_gen.go
@@ -2255,7 +2255,7 @@ func ReactionsListForCommitComment(ctx context.Context, req *ReactionsListForCom
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReactionsListForCommitCommentResponseBody{}
+	resp.Data = []components.Reaction{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2387,13 +2387,6 @@ func (r *ReactionsListForCommitCommentReq) Rel(link RelName, resp *ReactionsList
 }
 
 /*
-ReactionsListForCommitCommentResponseBody is a response body for ReactionsListForCommitComment
-
-https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment
-*/
-type ReactionsListForCommitCommentResponseBody []components.Reaction
-
-/*
 ReactionsListForCommitCommentResponse is a response for ReactionsListForCommitComment
 
 https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment
@@ -2401,7 +2394,7 @@ https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment
 type ReactionsListForCommitCommentResponse struct {
 	response
 	request *ReactionsListForCommitCommentReq
-	Data    ReactionsListForCommitCommentResponseBody
+	Data    []components.Reaction
 }
 
 /*
@@ -2425,7 +2418,7 @@ func ReactionsListForIssue(ctx context.Context, req *ReactionsListForIssueReq, o
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReactionsListForIssueResponseBody{}
+	resp.Data = []components.Reaction{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2557,13 +2550,6 @@ func (r *ReactionsListForIssueReq) Rel(link RelName, resp *ReactionsListForIssue
 }
 
 /*
-ReactionsListForIssueResponseBody is a response body for ReactionsListForIssue
-
-https://developer.github.com/v3/reactions/#list-reactions-for-an-issue
-*/
-type ReactionsListForIssueResponseBody []components.Reaction
-
-/*
 ReactionsListForIssueResponse is a response for ReactionsListForIssue
 
 https://developer.github.com/v3/reactions/#list-reactions-for-an-issue
@@ -2571,7 +2557,7 @@ https://developer.github.com/v3/reactions/#list-reactions-for-an-issue
 type ReactionsListForIssueResponse struct {
 	response
 	request *ReactionsListForIssueReq
-	Data    ReactionsListForIssueResponseBody
+	Data    []components.Reaction
 }
 
 /*
@@ -2595,7 +2581,7 @@ func ReactionsListForIssueComment(ctx context.Context, req *ReactionsListForIssu
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReactionsListForIssueCommentResponseBody{}
+	resp.Data = []components.Reaction{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2727,13 +2713,6 @@ func (r *ReactionsListForIssueCommentReq) Rel(link RelName, resp *ReactionsListF
 }
 
 /*
-ReactionsListForIssueCommentResponseBody is a response body for ReactionsListForIssueComment
-
-https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment
-*/
-type ReactionsListForIssueCommentResponseBody []components.Reaction
-
-/*
 ReactionsListForIssueCommentResponse is a response for ReactionsListForIssueComment
 
 https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment
@@ -2741,7 +2720,7 @@ https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment
 type ReactionsListForIssueCommentResponse struct {
 	response
 	request *ReactionsListForIssueCommentReq
-	Data    ReactionsListForIssueCommentResponseBody
+	Data    []components.Reaction
 }
 
 /*
@@ -2765,7 +2744,7 @@ func ReactionsListForPullRequestReviewComment(ctx context.Context, req *Reaction
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReactionsListForPullRequestReviewCommentResponseBody{}
+	resp.Data = []components.Reaction{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2897,13 +2876,6 @@ func (r *ReactionsListForPullRequestReviewCommentReq) Rel(link RelName, resp *Re
 }
 
 /*
-ReactionsListForPullRequestReviewCommentResponseBody is a response body for ReactionsListForPullRequestReviewComment
-
-https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment
-*/
-type ReactionsListForPullRequestReviewCommentResponseBody []components.Reaction
-
-/*
 ReactionsListForPullRequestReviewCommentResponse is a response for ReactionsListForPullRequestReviewComment
 
 https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment
@@ -2911,7 +2883,7 @@ https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-rev
 type ReactionsListForPullRequestReviewCommentResponse struct {
 	response
 	request *ReactionsListForPullRequestReviewCommentReq
-	Data    ReactionsListForPullRequestReviewCommentResponseBody
+	Data    []components.Reaction
 }
 
 /*
@@ -2935,7 +2907,7 @@ func ReactionsListForTeamDiscussionCommentInOrg(ctx context.Context, req *Reacti
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReactionsListForTeamDiscussionCommentInOrgResponseBody{}
+	resp.Data = []components.Reaction{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3068,13 +3040,6 @@ func (r *ReactionsListForTeamDiscussionCommentInOrgReq) Rel(link RelName, resp *
 }
 
 /*
-ReactionsListForTeamDiscussionCommentInOrgResponseBody is a response body for ReactionsListForTeamDiscussionCommentInOrg
-
-https://developer.github.com/v3/reactions/#list-reactions-for-a-team-discussion-comment
-*/
-type ReactionsListForTeamDiscussionCommentInOrgResponseBody []components.Reaction
-
-/*
 ReactionsListForTeamDiscussionCommentInOrgResponse is a response for ReactionsListForTeamDiscussionCommentInOrg
 
 https://developer.github.com/v3/reactions/#list-reactions-for-a-team-discussion-comment
@@ -3082,7 +3047,7 @@ https://developer.github.com/v3/reactions/#list-reactions-for-a-team-discussion-
 type ReactionsListForTeamDiscussionCommentInOrgResponse struct {
 	response
 	request *ReactionsListForTeamDiscussionCommentInOrgReq
-	Data    ReactionsListForTeamDiscussionCommentInOrgResponseBody
+	Data    []components.Reaction
 }
 
 /*
@@ -3106,7 +3071,7 @@ func ReactionsListForTeamDiscussionCommentLegacy(ctx context.Context, req *React
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReactionsListForTeamDiscussionCommentLegacyResponseBody{}
+	resp.Data = []components.Reaction{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3236,13 +3201,6 @@ func (r *ReactionsListForTeamDiscussionCommentLegacyReq) Rel(link RelName, resp 
 }
 
 /*
-ReactionsListForTeamDiscussionCommentLegacyResponseBody is a response body for ReactionsListForTeamDiscussionCommentLegacy
-
-https://developer.github.com/v3/reactions/#list-reactions-for-a-team-discussion-comment-legacy
-*/
-type ReactionsListForTeamDiscussionCommentLegacyResponseBody []components.Reaction
-
-/*
 ReactionsListForTeamDiscussionCommentLegacyResponse is a response for ReactionsListForTeamDiscussionCommentLegacy
 
 https://developer.github.com/v3/reactions/#list-reactions-for-a-team-discussion-comment-legacy
@@ -3250,7 +3208,7 @@ https://developer.github.com/v3/reactions/#list-reactions-for-a-team-discussion-
 type ReactionsListForTeamDiscussionCommentLegacyResponse struct {
 	response
 	request *ReactionsListForTeamDiscussionCommentLegacyReq
-	Data    ReactionsListForTeamDiscussionCommentLegacyResponseBody
+	Data    []components.Reaction
 }
 
 /*
@@ -3274,7 +3232,7 @@ func ReactionsListForTeamDiscussionInOrg(ctx context.Context, req *ReactionsList
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReactionsListForTeamDiscussionInOrgResponseBody{}
+	resp.Data = []components.Reaction{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3406,13 +3364,6 @@ func (r *ReactionsListForTeamDiscussionInOrgReq) Rel(link RelName, resp *Reactio
 }
 
 /*
-ReactionsListForTeamDiscussionInOrgResponseBody is a response body for ReactionsListForTeamDiscussionInOrg
-
-https://developer.github.com/v3/reactions/#list-reactions-for-a-team-discussion
-*/
-type ReactionsListForTeamDiscussionInOrgResponseBody []components.Reaction
-
-/*
 ReactionsListForTeamDiscussionInOrgResponse is a response for ReactionsListForTeamDiscussionInOrg
 
 https://developer.github.com/v3/reactions/#list-reactions-for-a-team-discussion
@@ -3420,7 +3371,7 @@ https://developer.github.com/v3/reactions/#list-reactions-for-a-team-discussion
 type ReactionsListForTeamDiscussionInOrgResponse struct {
 	response
 	request *ReactionsListForTeamDiscussionInOrgReq
-	Data    ReactionsListForTeamDiscussionInOrgResponseBody
+	Data    []components.Reaction
 }
 
 /*
@@ -3444,7 +3395,7 @@ func ReactionsListForTeamDiscussionLegacy(ctx context.Context, req *ReactionsLis
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReactionsListForTeamDiscussionLegacyResponseBody{}
+	resp.Data = []components.Reaction{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3573,13 +3524,6 @@ func (r *ReactionsListForTeamDiscussionLegacyReq) Rel(link RelName, resp *Reacti
 }
 
 /*
-ReactionsListForTeamDiscussionLegacyResponseBody is a response body for ReactionsListForTeamDiscussionLegacy
-
-https://developer.github.com/v3/reactions/#list-reactions-for-a-team-discussion-legacy
-*/
-type ReactionsListForTeamDiscussionLegacyResponseBody []components.Reaction
-
-/*
 ReactionsListForTeamDiscussionLegacyResponse is a response for ReactionsListForTeamDiscussionLegacy
 
 https://developer.github.com/v3/reactions/#list-reactions-for-a-team-discussion-legacy
@@ -3587,5 +3531,5 @@ https://developer.github.com/v3/reactions/#list-reactions-for-a-team-discussion-
 type ReactionsListForTeamDiscussionLegacyResponse struct {
 	response
 	request *ReactionsListForTeamDiscussionLegacyReq
-	Data    ReactionsListForTeamDiscussionLegacyResponseBody
+	Data    []components.Reaction
 }

--- a/zz_repos_gen.go
+++ b/zz_repos_gen.go
@@ -296,7 +296,7 @@ func ReposAddCollaborator(ctx context.Context, req *ReposAddCollaboratorReq, opt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposAddCollaboratorResponseBody{}
+	resp.Data = components.RepositoryInvitation{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -413,13 +413,6 @@ type ReposAddCollaboratorReqBody struct {
 }
 
 /*
-ReposAddCollaboratorResponseBody is a response body for ReposAddCollaborator
-
-https://developer.github.com/v3/repos/collaborators/#add-a-repository-collaborator
-*/
-type ReposAddCollaboratorResponseBody components.RepositoryInvitation
-
-/*
 ReposAddCollaboratorResponse is a response for ReposAddCollaborator
 
 https://developer.github.com/v3/repos/collaborators/#add-a-repository-collaborator
@@ -427,7 +420,7 @@ https://developer.github.com/v3/repos/collaborators/#add-a-repository-collaborat
 type ReposAddCollaboratorResponse struct {
 	response
 	request *ReposAddCollaboratorReq
-	Data    ReposAddCollaboratorResponseBody
+	Data    components.RepositoryInvitation
 }
 
 /*
@@ -1139,7 +1132,7 @@ func ReposCompareCommits(ctx context.Context, req *ReposCompareCommitsReq, opt .
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposCompareCommitsResponseBody{}
+	resp.Data = components.CommitComparison{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1235,13 +1228,6 @@ func (r *ReposCompareCommitsReq) Rel(link RelName, resp *ReposCompareCommitsResp
 }
 
 /*
-ReposCompareCommitsResponseBody is a response body for ReposCompareCommits
-
-https://developer.github.com/v3/repos/commits/#compare-two-commits
-*/
-type ReposCompareCommitsResponseBody components.CommitComparison
-
-/*
 ReposCompareCommitsResponse is a response for ReposCompareCommits
 
 https://developer.github.com/v3/repos/commits/#compare-two-commits
@@ -1249,7 +1235,7 @@ https://developer.github.com/v3/repos/commits/#compare-two-commits
 type ReposCompareCommitsResponse struct {
 	response
 	request *ReposCompareCommitsReq
-	Data    ReposCompareCommitsResponseBody
+	Data    components.CommitComparison
 }
 
 /*
@@ -1273,7 +1259,7 @@ func ReposCreateCommitComment(ctx context.Context, req *ReposCreateCommitComment
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposCreateCommitCommentResponseBody{}
+	resp.Data = components.CommitComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1390,13 +1376,6 @@ type ReposCreateCommitCommentReqBody struct {
 }
 
 /*
-ReposCreateCommitCommentResponseBody is a response body for ReposCreateCommitComment
-
-https://developer.github.com/v3/repos/comments/#create-a-commit-comment
-*/
-type ReposCreateCommitCommentResponseBody components.CommitComment
-
-/*
 ReposCreateCommitCommentResponse is a response for ReposCreateCommitComment
 
 https://developer.github.com/v3/repos/comments/#create-a-commit-comment
@@ -1404,7 +1383,7 @@ https://developer.github.com/v3/repos/comments/#create-a-commit-comment
 type ReposCreateCommitCommentResponse struct {
 	response
 	request *ReposCreateCommitCommentReq
-	Data    ReposCreateCommitCommentResponseBody
+	Data    components.CommitComment
 }
 
 /*
@@ -1428,7 +1407,7 @@ func ReposCreateCommitSignatureProtection(ctx context.Context, req *ReposCreateC
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposCreateCommitSignatureProtectionResponseBody{}
+	resp.Data = components.ProtectedBranchAdminEnforced{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1536,13 +1515,6 @@ func (r *ReposCreateCommitSignatureProtectionReq) Rel(link RelName, resp *ReposC
 }
 
 /*
-ReposCreateCommitSignatureProtectionResponseBody is a response body for ReposCreateCommitSignatureProtection
-
-https://developer.github.com/v3/repos/branches/#create-commit-signature-protection
-*/
-type ReposCreateCommitSignatureProtectionResponseBody components.ProtectedBranchAdminEnforced
-
-/*
 ReposCreateCommitSignatureProtectionResponse is a response for ReposCreateCommitSignatureProtection
 
 https://developer.github.com/v3/repos/branches/#create-commit-signature-protection
@@ -1550,7 +1522,7 @@ https://developer.github.com/v3/repos/branches/#create-commit-signature-protecti
 type ReposCreateCommitSignatureProtectionResponse struct {
 	response
 	request *ReposCreateCommitSignatureProtectionReq
-	Data    ReposCreateCommitSignatureProtectionResponseBody
+	Data    components.ProtectedBranchAdminEnforced
 }
 
 /*
@@ -1574,7 +1546,7 @@ func ReposCreateCommitStatus(ctx context.Context, req *ReposCreateCommitStatusRe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposCreateCommitStatusResponseBody{}
+	resp.Data = components.Status{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1697,13 +1669,6 @@ type ReposCreateCommitStatusReqBody struct {
 }
 
 /*
-ReposCreateCommitStatusResponseBody is a response body for ReposCreateCommitStatus
-
-https://developer.github.com/v3/repos/statuses/#create-a-commit-status
-*/
-type ReposCreateCommitStatusResponseBody components.Status
-
-/*
 ReposCreateCommitStatusResponse is a response for ReposCreateCommitStatus
 
 https://developer.github.com/v3/repos/statuses/#create-a-commit-status
@@ -1711,7 +1676,7 @@ https://developer.github.com/v3/repos/statuses/#create-a-commit-status
 type ReposCreateCommitStatusResponse struct {
 	response
 	request *ReposCreateCommitStatusReq
-	Data    ReposCreateCommitStatusResponseBody
+	Data    components.Status
 }
 
 /*
@@ -1735,7 +1700,7 @@ func ReposCreateDeployKey(ctx context.Context, req *ReposCreateDeployKeyReq, opt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposCreateDeployKeyResponseBody{}
+	resp.Data = components.DeployKey{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1856,13 +1821,6 @@ type ReposCreateDeployKeyReqBody struct {
 }
 
 /*
-ReposCreateDeployKeyResponseBody is a response body for ReposCreateDeployKey
-
-https://developer.github.com/v3/repos/keys/#create-a-deploy-key
-*/
-type ReposCreateDeployKeyResponseBody components.DeployKey
-
-/*
 ReposCreateDeployKeyResponse is a response for ReposCreateDeployKey
 
 https://developer.github.com/v3/repos/keys/#create-a-deploy-key
@@ -1870,7 +1828,7 @@ https://developer.github.com/v3/repos/keys/#create-a-deploy-key
 type ReposCreateDeployKeyResponse struct {
 	response
 	request *ReposCreateDeployKeyReq
-	Data    ReposCreateDeployKeyResponseBody
+	Data    components.DeployKey
 }
 
 /*
@@ -1894,7 +1852,7 @@ func ReposCreateDeployment(ctx context.Context, req *ReposCreateDeploymentReq, o
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposCreateDeploymentResponseBody{}
+	resp.Data = components.Deployment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2057,13 +2015,6 @@ type ReposCreateDeploymentReqBody struct {
 }
 
 /*
-ReposCreateDeploymentResponseBody is a response body for ReposCreateDeployment
-
-https://developer.github.com/v3/repos/deployments/#create-a-deployment
-*/
-type ReposCreateDeploymentResponseBody components.Deployment
-
-/*
 ReposCreateDeploymentResponse is a response for ReposCreateDeployment
 
 https://developer.github.com/v3/repos/deployments/#create-a-deployment
@@ -2071,7 +2022,7 @@ https://developer.github.com/v3/repos/deployments/#create-a-deployment
 type ReposCreateDeploymentResponse struct {
 	response
 	request *ReposCreateDeploymentReq
-	Data    ReposCreateDeploymentResponseBody
+	Data    components.Deployment
 }
 
 /*
@@ -2095,7 +2046,7 @@ func ReposCreateDeploymentStatus(ctx context.Context, req *ReposCreateDeployment
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposCreateDeploymentStatusResponseBody{}
+	resp.Data = components.DeploymentStatus{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2301,13 +2252,6 @@ type ReposCreateDeploymentStatusReqBody struct {
 }
 
 /*
-ReposCreateDeploymentStatusResponseBody is a response body for ReposCreateDeploymentStatus
-
-https://developer.github.com/v3/repos/deployments/#create-a-deployment-status
-*/
-type ReposCreateDeploymentStatusResponseBody components.DeploymentStatus
-
-/*
 ReposCreateDeploymentStatusResponse is a response for ReposCreateDeploymentStatus
 
 https://developer.github.com/v3/repos/deployments/#create-a-deployment-status
@@ -2315,7 +2259,7 @@ https://developer.github.com/v3/repos/deployments/#create-a-deployment-status
 type ReposCreateDeploymentStatusResponse struct {
 	response
 	request *ReposCreateDeploymentStatusReq
-	Data    ReposCreateDeploymentStatusResponseBody
+	Data    components.DeploymentStatus
 }
 
 /*
@@ -2473,7 +2417,7 @@ func ReposCreateForAuthenticatedUser(ctx context.Context, req *ReposCreateForAut
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposCreateForAuthenticatedUserResponseBody{}
+	resp.Data = components.Repository{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2655,13 +2599,6 @@ type ReposCreateForAuthenticatedUserReqBody struct {
 }
 
 /*
-ReposCreateForAuthenticatedUserResponseBody is a response body for ReposCreateForAuthenticatedUser
-
-https://developer.github.com/v3/repos/#create-a-repository-for-the-authenticated-user
-*/
-type ReposCreateForAuthenticatedUserResponseBody components.Repository
-
-/*
 ReposCreateForAuthenticatedUserResponse is a response for ReposCreateForAuthenticatedUser
 
 https://developer.github.com/v3/repos/#create-a-repository-for-the-authenticated-user
@@ -2669,7 +2606,7 @@ https://developer.github.com/v3/repos/#create-a-repository-for-the-authenticated
 type ReposCreateForAuthenticatedUserResponse struct {
 	response
 	request *ReposCreateForAuthenticatedUserReq
-	Data    ReposCreateForAuthenticatedUserResponseBody
+	Data    components.Repository
 }
 
 /*
@@ -2693,7 +2630,7 @@ func ReposCreateFork(ctx context.Context, req *ReposCreateForkReq, opt ...Reques
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposCreateForkResponseBody{}
+	resp.Data = components.Repository{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2798,13 +2735,6 @@ type ReposCreateForkReqBody struct {
 }
 
 /*
-ReposCreateForkResponseBody is a response body for ReposCreateFork
-
-https://developer.github.com/v3/repos/forks/#create-a-fork
-*/
-type ReposCreateForkResponseBody components.Repository
-
-/*
 ReposCreateForkResponse is a response for ReposCreateFork
 
 https://developer.github.com/v3/repos/forks/#create-a-fork
@@ -2812,7 +2742,7 @@ https://developer.github.com/v3/repos/forks/#create-a-fork
 type ReposCreateForkResponse struct {
 	response
 	request *ReposCreateForkReq
-	Data    ReposCreateForkResponseBody
+	Data    components.Repository
 }
 
 /*
@@ -2836,7 +2766,7 @@ func ReposCreateInOrg(ctx context.Context, req *ReposCreateInOrgReq, opt ...Requ
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposCreateInOrgResponseBody{}
+	resp.Data = components.Repository{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3048,13 +2978,6 @@ type ReposCreateInOrgReqBody struct {
 }
 
 /*
-ReposCreateInOrgResponseBody is a response body for ReposCreateInOrg
-
-https://developer.github.com/v3/repos/#create-an-organization-repository
-*/
-type ReposCreateInOrgResponseBody components.Repository
-
-/*
 ReposCreateInOrgResponse is a response for ReposCreateInOrg
 
 https://developer.github.com/v3/repos/#create-an-organization-repository
@@ -3062,7 +2985,7 @@ https://developer.github.com/v3/repos/#create-an-organization-repository
 type ReposCreateInOrgResponse struct {
 	response
 	request *ReposCreateInOrgReq
-	Data    ReposCreateInOrgResponseBody
+	Data    components.Repository
 }
 
 /*
@@ -3086,7 +3009,7 @@ func ReposCreateOrUpdateFileContents(ctx context.Context, req *ReposCreateOrUpda
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposCreateOrUpdateFileContentsResponseBody{}
+	resp.Data = components.FileCommit{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3231,13 +3154,6 @@ type ReposCreateOrUpdateFileContentsReqBody struct {
 }
 
 /*
-ReposCreateOrUpdateFileContentsResponseBody is a response body for ReposCreateOrUpdateFileContents
-
-https://developer.github.com/v3/repos/contents/#create-or-update-file-contents
-*/
-type ReposCreateOrUpdateFileContentsResponseBody components.FileCommit
-
-/*
 ReposCreateOrUpdateFileContentsResponse is a response for ReposCreateOrUpdateFileContents
 
 https://developer.github.com/v3/repos/contents/#create-or-update-file-contents
@@ -3245,7 +3161,7 @@ https://developer.github.com/v3/repos/contents/#create-or-update-file-contents
 type ReposCreateOrUpdateFileContentsResponse struct {
 	response
 	request *ReposCreateOrUpdateFileContentsReq
-	Data    ReposCreateOrUpdateFileContentsResponseBody
+	Data    components.FileCommit
 }
 
 /*
@@ -3269,7 +3185,7 @@ func ReposCreatePagesSite(ctx context.Context, req *ReposCreatePagesSiteReq, opt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposCreatePagesSiteResponseBody{}
+	resp.Data = components.Page{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3405,13 +3321,6 @@ type ReposCreatePagesSiteReqBody struct {
 }
 
 /*
-ReposCreatePagesSiteResponseBody is a response body for ReposCreatePagesSite
-
-https://developer.github.com/v3/repos/pages/#create-a-github-pages-site
-*/
-type ReposCreatePagesSiteResponseBody components.Page
-
-/*
 ReposCreatePagesSiteResponse is a response for ReposCreatePagesSite
 
 https://developer.github.com/v3/repos/pages/#create-a-github-pages-site
@@ -3419,7 +3328,7 @@ https://developer.github.com/v3/repos/pages/#create-a-github-pages-site
 type ReposCreatePagesSiteResponse struct {
 	response
 	request *ReposCreatePagesSiteReq
-	Data    ReposCreatePagesSiteResponseBody
+	Data    components.Page
 }
 
 /*
@@ -3443,7 +3352,7 @@ func ReposCreateRelease(ctx context.Context, req *ReposCreateReleaseReq, opt ...
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposCreateReleaseResponseBody{}
+	resp.Data = components.Release{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3567,13 +3476,6 @@ type ReposCreateReleaseReqBody struct {
 }
 
 /*
-ReposCreateReleaseResponseBody is a response body for ReposCreateRelease
-
-https://developer.github.com/v3/repos/releases/#create-a-release
-*/
-type ReposCreateReleaseResponseBody components.Release
-
-/*
 ReposCreateReleaseResponse is a response for ReposCreateRelease
 
 https://developer.github.com/v3/repos/releases/#create-a-release
@@ -3581,7 +3483,7 @@ https://developer.github.com/v3/repos/releases/#create-a-release
 type ReposCreateReleaseResponse struct {
 	response
 	request *ReposCreateReleaseReq
-	Data    ReposCreateReleaseResponseBody
+	Data    components.Release
 }
 
 /*
@@ -3605,7 +3507,7 @@ func ReposCreateUsingTemplate(ctx context.Context, req *ReposCreateUsingTemplate
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposCreateUsingTemplateResponseBody{}
+	resp.Data = components.Repository{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3742,13 +3644,6 @@ type ReposCreateUsingTemplateReqBody struct {
 }
 
 /*
-ReposCreateUsingTemplateResponseBody is a response body for ReposCreateUsingTemplate
-
-https://developer.github.com/v3/repos/#create-a-repository-using-a-template
-*/
-type ReposCreateUsingTemplateResponseBody components.Repository
-
-/*
 ReposCreateUsingTemplateResponse is a response for ReposCreateUsingTemplate
 
 https://developer.github.com/v3/repos/#create-a-repository-using-a-template
@@ -3756,7 +3651,7 @@ https://developer.github.com/v3/repos/#create-a-repository-using-a-template
 type ReposCreateUsingTemplateResponse struct {
 	response
 	request *ReposCreateUsingTemplateReq
-	Data    ReposCreateUsingTemplateResponseBody
+	Data    components.Repository
 }
 
 /*
@@ -3780,7 +3675,7 @@ func ReposCreateWebhook(ctx context.Context, req *ReposCreateWebhookReq, opt ...
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposCreateWebhookResponseBody{}
+	resp.Data = components.Hook{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3926,13 +3821,6 @@ type ReposCreateWebhookReqBody struct {
 }
 
 /*
-ReposCreateWebhookResponseBody is a response body for ReposCreateWebhook
-
-https://developer.github.com/v3/repos/hooks/#create-a-repository-webhook
-*/
-type ReposCreateWebhookResponseBody components.Hook
-
-/*
 ReposCreateWebhookResponse is a response for ReposCreateWebhook
 
 https://developer.github.com/v3/repos/hooks/#create-a-repository-webhook
@@ -3940,7 +3828,7 @@ https://developer.github.com/v3/repos/hooks/#create-a-repository-webhook
 type ReposCreateWebhookResponse struct {
 	response
 	request *ReposCreateWebhookReq
-	Data    ReposCreateWebhookResponseBody
+	Data    components.Hook
 }
 
 /*
@@ -5087,7 +4975,7 @@ func ReposDeleteFile(ctx context.Context, req *ReposDeleteFileReq, opt ...Reques
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposDeleteFileResponseBody{}
+	resp.Data = components.FileCommit{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -5227,13 +5115,6 @@ type ReposDeleteFileReqBody struct {
 }
 
 /*
-ReposDeleteFileResponseBody is a response body for ReposDeleteFile
-
-https://developer.github.com/v3/repos/contents/#delete-a-file
-*/
-type ReposDeleteFileResponseBody components.FileCommit
-
-/*
 ReposDeleteFileResponse is a response for ReposDeleteFile
 
 https://developer.github.com/v3/repos/contents/#delete-a-file
@@ -5241,7 +5122,7 @@ https://developer.github.com/v3/repos/contents/#delete-a-file
 type ReposDeleteFileResponse struct {
 	response
 	request *ReposDeleteFileReq
-	Data    ReposDeleteFileResponseBody
+	Data    components.FileCommit
 }
 
 /*
@@ -6789,7 +6670,7 @@ func ReposGet(ctx context.Context, req *ReposGetReq, opt ...RequestOption) (*Rep
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetResponseBody{}
+	resp.Data = components.FullRepository{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -6905,13 +6786,6 @@ func (r *ReposGetReq) Rel(link RelName, resp *ReposGetResponse) bool {
 }
 
 /*
-ReposGetResponseBody is a response body for ReposGet
-
-https://developer.github.com/v3/repos/#get-a-repository
-*/
-type ReposGetResponseBody components.FullRepository
-
-/*
 ReposGetResponse is a response for ReposGet
 
 https://developer.github.com/v3/repos/#get-a-repository
@@ -6919,7 +6793,7 @@ https://developer.github.com/v3/repos/#get-a-repository
 type ReposGetResponse struct {
 	response
 	request *ReposGetReq
-	Data    ReposGetResponseBody
+	Data    components.FullRepository
 }
 
 /*
@@ -6943,7 +6817,7 @@ func ReposGetAccessRestrictions(ctx context.Context, req *ReposGetAccessRestrict
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetAccessRestrictionsResponseBody{}
+	resp.Data = components.BranchRestrictionPolicy{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -7036,13 +6910,6 @@ func (r *ReposGetAccessRestrictionsReq) Rel(link RelName, resp *ReposGetAccessRe
 }
 
 /*
-ReposGetAccessRestrictionsResponseBody is a response body for ReposGetAccessRestrictions
-
-https://developer.github.com/v3/repos/branches/#get-access-restrictions
-*/
-type ReposGetAccessRestrictionsResponseBody components.BranchRestrictionPolicy
-
-/*
 ReposGetAccessRestrictionsResponse is a response for ReposGetAccessRestrictions
 
 https://developer.github.com/v3/repos/branches/#get-access-restrictions
@@ -7050,7 +6917,7 @@ https://developer.github.com/v3/repos/branches/#get-access-restrictions
 type ReposGetAccessRestrictionsResponse struct {
 	response
 	request *ReposGetAccessRestrictionsReq
-	Data    ReposGetAccessRestrictionsResponseBody
+	Data    components.BranchRestrictionPolicy
 }
 
 /*
@@ -7074,7 +6941,7 @@ func ReposGetAdminBranchProtection(ctx context.Context, req *ReposGetAdminBranch
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetAdminBranchProtectionResponseBody{}
+	resp.Data = components.ProtectedBranchAdminEnforced{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -7167,13 +7034,6 @@ func (r *ReposGetAdminBranchProtectionReq) Rel(link RelName, resp *ReposGetAdmin
 }
 
 /*
-ReposGetAdminBranchProtectionResponseBody is a response body for ReposGetAdminBranchProtection
-
-https://developer.github.com/v3/repos/branches/#get-admin-branch-protection
-*/
-type ReposGetAdminBranchProtectionResponseBody components.ProtectedBranchAdminEnforced
-
-/*
 ReposGetAdminBranchProtectionResponse is a response for ReposGetAdminBranchProtection
 
 https://developer.github.com/v3/repos/branches/#get-admin-branch-protection
@@ -7181,7 +7041,7 @@ https://developer.github.com/v3/repos/branches/#get-admin-branch-protection
 type ReposGetAdminBranchProtectionResponse struct {
 	response
 	request *ReposGetAdminBranchProtectionReq
-	Data    ReposGetAdminBranchProtectionResponseBody
+	Data    components.ProtectedBranchAdminEnforced
 }
 
 /*
@@ -7336,7 +7196,7 @@ func ReposGetAllTopics(ctx context.Context, req *ReposGetAllTopicsReq, opt ...Re
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetAllTopicsResponseBody{}
+	resp.Data = components.Topic{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -7439,13 +7299,6 @@ func (r *ReposGetAllTopicsReq) Rel(link RelName, resp *ReposGetAllTopicsResponse
 }
 
 /*
-ReposGetAllTopicsResponseBody is a response body for ReposGetAllTopics
-
-https://developer.github.com/v3/repos/#get-all-repository-topics
-*/
-type ReposGetAllTopicsResponseBody components.Topic
-
-/*
 ReposGetAllTopicsResponse is a response for ReposGetAllTopics
 
 https://developer.github.com/v3/repos/#get-all-repository-topics
@@ -7453,7 +7306,7 @@ https://developer.github.com/v3/repos/#get-all-repository-topics
 type ReposGetAllTopicsResponse struct {
 	response
 	request *ReposGetAllTopicsReq
-	Data    ReposGetAllTopicsResponseBody
+	Data    components.Topic
 }
 
 /*
@@ -7608,7 +7461,7 @@ func ReposGetBranch(ctx context.Context, req *ReposGetBranchReq, opt ...RequestO
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetBranchResponseBody{}
+	resp.Data = components.BranchWithProtection{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -7701,13 +7554,6 @@ func (r *ReposGetBranchReq) Rel(link RelName, resp *ReposGetBranchResponse) bool
 }
 
 /*
-ReposGetBranchResponseBody is a response body for ReposGetBranch
-
-https://developer.github.com/v3/repos/branches/#get-a-branch
-*/
-type ReposGetBranchResponseBody components.BranchWithProtection
-
-/*
 ReposGetBranchResponse is a response for ReposGetBranch
 
 https://developer.github.com/v3/repos/branches/#get-a-branch
@@ -7715,7 +7561,7 @@ https://developer.github.com/v3/repos/branches/#get-a-branch
 type ReposGetBranchResponse struct {
 	response
 	request *ReposGetBranchReq
-	Data    ReposGetBranchResponseBody
+	Data    components.BranchWithProtection
 }
 
 /*
@@ -7739,7 +7585,7 @@ func ReposGetBranchProtection(ctx context.Context, req *ReposGetBranchProtection
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetBranchProtectionResponseBody{}
+	resp.Data = components.BranchProtection{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -7845,13 +7691,6 @@ func (r *ReposGetBranchProtectionReq) Rel(link RelName, resp *ReposGetBranchProt
 }
 
 /*
-ReposGetBranchProtectionResponseBody is a response body for ReposGetBranchProtection
-
-https://developer.github.com/v3/repos/branches/#get-branch-protection
-*/
-type ReposGetBranchProtectionResponseBody components.BranchProtection
-
-/*
 ReposGetBranchProtectionResponse is a response for ReposGetBranchProtection
 
 https://developer.github.com/v3/repos/branches/#get-branch-protection
@@ -7859,7 +7698,7 @@ https://developer.github.com/v3/repos/branches/#get-branch-protection
 type ReposGetBranchProtectionResponse struct {
 	response
 	request *ReposGetBranchProtectionReq
-	Data    ReposGetBranchProtectionResponseBody
+	Data    components.BranchProtection
 }
 
 /*
@@ -7883,7 +7722,7 @@ func ReposGetClones(ctx context.Context, req *ReposGetClonesReq, opt ...RequestO
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetClonesResponseBody{}
+	resp.Data = components.CloneTraffic{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -7979,13 +7818,6 @@ func (r *ReposGetClonesReq) Rel(link RelName, resp *ReposGetClonesResponse) bool
 }
 
 /*
-ReposGetClonesResponseBody is a response body for ReposGetClones
-
-https://developer.github.com/v3/repos/traffic/#get-repository-clones
-*/
-type ReposGetClonesResponseBody components.CloneTraffic
-
-/*
 ReposGetClonesResponse is a response for ReposGetClones
 
 https://developer.github.com/v3/repos/traffic/#get-repository-clones
@@ -7993,7 +7825,7 @@ https://developer.github.com/v3/repos/traffic/#get-repository-clones
 type ReposGetClonesResponse struct {
 	response
 	request *ReposGetClonesReq
-	Data    ReposGetClonesResponseBody
+	Data    components.CloneTraffic
 }
 
 /*
@@ -8145,7 +7977,7 @@ func ReposGetCollaboratorPermissionLevel(ctx context.Context, req *ReposGetColla
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetCollaboratorPermissionLevelResponseBody{}
+	resp.Data = components.RepositoryCollaboratorPermission{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -8236,13 +8068,6 @@ func (r *ReposGetCollaboratorPermissionLevelReq) Rel(link RelName, resp *ReposGe
 }
 
 /*
-ReposGetCollaboratorPermissionLevelResponseBody is a response body for ReposGetCollaboratorPermissionLevel
-
-https://developer.github.com/v3/repos/collaborators/#get-repository-permissions-for-a-user
-*/
-type ReposGetCollaboratorPermissionLevelResponseBody components.RepositoryCollaboratorPermission
-
-/*
 ReposGetCollaboratorPermissionLevelResponse is a response for ReposGetCollaboratorPermissionLevel
 
 https://developer.github.com/v3/repos/collaborators/#get-repository-permissions-for-a-user
@@ -8250,7 +8075,7 @@ https://developer.github.com/v3/repos/collaborators/#get-repository-permissions-
 type ReposGetCollaboratorPermissionLevelResponse struct {
 	response
 	request *ReposGetCollaboratorPermissionLevelReq
-	Data    ReposGetCollaboratorPermissionLevelResponseBody
+	Data    components.RepositoryCollaboratorPermission
 }
 
 /*
@@ -8274,7 +8099,7 @@ func ReposGetCombinedStatusForRef(ctx context.Context, req *ReposGetCombinedStat
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetCombinedStatusForRefResponseBody{}
+	resp.Data = components.CombinedCommitStatus{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -8367,13 +8192,6 @@ func (r *ReposGetCombinedStatusForRefReq) Rel(link RelName, resp *ReposGetCombin
 }
 
 /*
-ReposGetCombinedStatusForRefResponseBody is a response body for ReposGetCombinedStatusForRef
-
-https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-reference
-*/
-type ReposGetCombinedStatusForRefResponseBody components.CombinedCommitStatus
-
-/*
 ReposGetCombinedStatusForRefResponse is a response for ReposGetCombinedStatusForRef
 
 https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-reference
@@ -8381,7 +8199,7 @@ https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-sp
 type ReposGetCombinedStatusForRefResponse struct {
 	response
 	request *ReposGetCombinedStatusForRefReq
-	Data    ReposGetCombinedStatusForRefResponseBody
+	Data    components.CombinedCommitStatus
 }
 
 /*
@@ -8405,7 +8223,7 @@ func ReposGetCommit(ctx context.Context, req *ReposGetCommitReq, opt ...RequestO
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetCommitResponseBody{}
+	resp.Data = components.Commit{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -8498,13 +8316,6 @@ func (r *ReposGetCommitReq) Rel(link RelName, resp *ReposGetCommitResponse) bool
 }
 
 /*
-ReposGetCommitResponseBody is a response body for ReposGetCommit
-
-https://developer.github.com/v3/repos/commits/#get-a-commit
-*/
-type ReposGetCommitResponseBody components.Commit
-
-/*
 ReposGetCommitResponse is a response for ReposGetCommit
 
 https://developer.github.com/v3/repos/commits/#get-a-commit
@@ -8512,7 +8323,7 @@ https://developer.github.com/v3/repos/commits/#get-a-commit
 type ReposGetCommitResponse struct {
 	response
 	request *ReposGetCommitReq
-	Data    ReposGetCommitResponseBody
+	Data    components.Commit
 }
 
 /*
@@ -8664,7 +8475,7 @@ func ReposGetCommitComment(ctx context.Context, req *ReposGetCommitCommentReq, o
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetCommitCommentResponseBody{}
+	resp.Data = components.CommitComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -8771,13 +8582,6 @@ func (r *ReposGetCommitCommentReq) Rel(link RelName, resp *ReposGetCommitComment
 }
 
 /*
-ReposGetCommitCommentResponseBody is a response body for ReposGetCommitComment
-
-https://developer.github.com/v3/repos/comments/#get-a-commit-comment
-*/
-type ReposGetCommitCommentResponseBody components.CommitComment
-
-/*
 ReposGetCommitCommentResponse is a response for ReposGetCommitComment
 
 https://developer.github.com/v3/repos/comments/#get-a-commit-comment
@@ -8785,7 +8589,7 @@ https://developer.github.com/v3/repos/comments/#get-a-commit-comment
 type ReposGetCommitCommentResponse struct {
 	response
 	request *ReposGetCommitCommentReq
-	Data    ReposGetCommitCommentResponseBody
+	Data    components.CommitComment
 }
 
 /*
@@ -8809,7 +8613,7 @@ func ReposGetCommitSignatureProtection(ctx context.Context, req *ReposGetCommitS
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetCommitSignatureProtectionResponseBody{}
+	resp.Data = components.ProtectedBranchAdminEnforced{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -8917,13 +8721,6 @@ func (r *ReposGetCommitSignatureProtectionReq) Rel(link RelName, resp *ReposGetC
 }
 
 /*
-ReposGetCommitSignatureProtectionResponseBody is a response body for ReposGetCommitSignatureProtection
-
-https://developer.github.com/v3/repos/branches/#get-commit-signature-protection
-*/
-type ReposGetCommitSignatureProtectionResponseBody components.ProtectedBranchAdminEnforced
-
-/*
 ReposGetCommitSignatureProtectionResponse is a response for ReposGetCommitSignatureProtection
 
 https://developer.github.com/v3/repos/branches/#get-commit-signature-protection
@@ -8931,7 +8728,7 @@ https://developer.github.com/v3/repos/branches/#get-commit-signature-protection
 type ReposGetCommitSignatureProtectionResponse struct {
 	response
 	request *ReposGetCommitSignatureProtectionReq
-	Data    ReposGetCommitSignatureProtectionResponseBody
+	Data    components.ProtectedBranchAdminEnforced
 }
 
 /*
@@ -8955,7 +8752,7 @@ func ReposGetCommunityProfileMetrics(ctx context.Context, req *ReposGetCommunity
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetCommunityProfileMetricsResponseBody{}
+	resp.Data = components.CommunityProfile{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -9058,13 +8855,6 @@ func (r *ReposGetCommunityProfileMetricsReq) Rel(link RelName, resp *ReposGetCom
 }
 
 /*
-ReposGetCommunityProfileMetricsResponseBody is a response body for ReposGetCommunityProfileMetrics
-
-https://developer.github.com/v3/repos/community/#get-community-profile-metrics
-*/
-type ReposGetCommunityProfileMetricsResponseBody components.CommunityProfile
-
-/*
 ReposGetCommunityProfileMetricsResponse is a response for ReposGetCommunityProfileMetrics
 
 https://developer.github.com/v3/repos/community/#get-community-profile-metrics
@@ -9072,7 +8862,7 @@ https://developer.github.com/v3/repos/community/#get-community-profile-metrics
 type ReposGetCommunityProfileMetricsResponse struct {
 	response
 	request *ReposGetCommunityProfileMetricsReq
-	Data    ReposGetCommunityProfileMetricsResponseBody
+	Data    components.CommunityProfile
 }
 
 /*
@@ -9448,7 +9238,7 @@ func ReposGetDeployKey(ctx context.Context, req *ReposGetDeployKeyReq, opt ...Re
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetDeployKeyResponseBody{}
+	resp.Data = components.DeployKey{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -9541,13 +9331,6 @@ func (r *ReposGetDeployKeyReq) Rel(link RelName, resp *ReposGetDeployKeyResponse
 }
 
 /*
-ReposGetDeployKeyResponseBody is a response body for ReposGetDeployKey
-
-https://developer.github.com/v3/repos/keys/#get-a-deploy-key
-*/
-type ReposGetDeployKeyResponseBody components.DeployKey
-
-/*
 ReposGetDeployKeyResponse is a response for ReposGetDeployKey
 
 https://developer.github.com/v3/repos/keys/#get-a-deploy-key
@@ -9555,7 +9338,7 @@ https://developer.github.com/v3/repos/keys/#get-a-deploy-key
 type ReposGetDeployKeyResponse struct {
 	response
 	request *ReposGetDeployKeyReq
-	Data    ReposGetDeployKeyResponseBody
+	Data    components.DeployKey
 }
 
 /*
@@ -9579,7 +9362,7 @@ func ReposGetDeployment(ctx context.Context, req *ReposGetDeploymentReq, opt ...
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetDeploymentResponseBody{}
+	resp.Data = components.Deployment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -9696,13 +9479,6 @@ func (r *ReposGetDeploymentReq) Rel(link RelName, resp *ReposGetDeploymentRespon
 }
 
 /*
-ReposGetDeploymentResponseBody is a response body for ReposGetDeployment
-
-https://developer.github.com/v3/repos/deployments/#get-a-deployment
-*/
-type ReposGetDeploymentResponseBody components.Deployment
-
-/*
 ReposGetDeploymentResponse is a response for ReposGetDeployment
 
 https://developer.github.com/v3/repos/deployments/#get-a-deployment
@@ -9710,7 +9486,7 @@ https://developer.github.com/v3/repos/deployments/#get-a-deployment
 type ReposGetDeploymentResponse struct {
 	response
 	request *ReposGetDeploymentReq
-	Data    ReposGetDeploymentResponseBody
+	Data    components.Deployment
 }
 
 /*
@@ -9734,7 +9510,7 @@ func ReposGetDeploymentStatus(ctx context.Context, req *ReposGetDeploymentStatus
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetDeploymentStatusResponseBody{}
+	resp.Data = components.DeploymentStatus{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -9868,13 +9644,6 @@ func (r *ReposGetDeploymentStatusReq) Rel(link RelName, resp *ReposGetDeployment
 }
 
 /*
-ReposGetDeploymentStatusResponseBody is a response body for ReposGetDeploymentStatus
-
-https://developer.github.com/v3/repos/deployments/#get-a-deployment-status
-*/
-type ReposGetDeploymentStatusResponseBody components.DeploymentStatus
-
-/*
 ReposGetDeploymentStatusResponse is a response for ReposGetDeploymentStatus
 
 https://developer.github.com/v3/repos/deployments/#get-a-deployment-status
@@ -9882,7 +9651,7 @@ https://developer.github.com/v3/repos/deployments/#get-a-deployment-status
 type ReposGetDeploymentStatusResponse struct {
 	response
 	request *ReposGetDeploymentStatusReq
-	Data    ReposGetDeploymentStatusResponseBody
+	Data    components.DeploymentStatus
 }
 
 /*
@@ -9906,7 +9675,7 @@ func ReposGetLatestPagesBuild(ctx context.Context, req *ReposGetLatestPagesBuild
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetLatestPagesBuildResponseBody{}
+	resp.Data = components.PageBuild{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -9996,13 +9765,6 @@ func (r *ReposGetLatestPagesBuildReq) Rel(link RelName, resp *ReposGetLatestPage
 }
 
 /*
-ReposGetLatestPagesBuildResponseBody is a response body for ReposGetLatestPagesBuild
-
-https://developer.github.com/v3/repos/pages/#get-latest-pages-build
-*/
-type ReposGetLatestPagesBuildResponseBody components.PageBuild
-
-/*
 ReposGetLatestPagesBuildResponse is a response for ReposGetLatestPagesBuild
 
 https://developer.github.com/v3/repos/pages/#get-latest-pages-build
@@ -10010,7 +9772,7 @@ https://developer.github.com/v3/repos/pages/#get-latest-pages-build
 type ReposGetLatestPagesBuildResponse struct {
 	response
 	request *ReposGetLatestPagesBuildReq
-	Data    ReposGetLatestPagesBuildResponseBody
+	Data    components.PageBuild
 }
 
 /*
@@ -10034,7 +9796,7 @@ func ReposGetLatestRelease(ctx context.Context, req *ReposGetLatestReleaseReq, o
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetLatestReleaseResponseBody{}
+	resp.Data = components.Release{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -10124,13 +9886,6 @@ func (r *ReposGetLatestReleaseReq) Rel(link RelName, resp *ReposGetLatestRelease
 }
 
 /*
-ReposGetLatestReleaseResponseBody is a response body for ReposGetLatestRelease
-
-https://developer.github.com/v3/repos/releases/#get-the-latest-release
-*/
-type ReposGetLatestReleaseResponseBody components.Release
-
-/*
 ReposGetLatestReleaseResponse is a response for ReposGetLatestRelease
 
 https://developer.github.com/v3/repos/releases/#get-the-latest-release
@@ -10138,7 +9893,7 @@ https://developer.github.com/v3/repos/releases/#get-the-latest-release
 type ReposGetLatestReleaseResponse struct {
 	response
 	request *ReposGetLatestReleaseReq
-	Data    ReposGetLatestReleaseResponseBody
+	Data    components.Release
 }
 
 /*
@@ -10162,7 +9917,7 @@ func ReposGetPages(ctx context.Context, req *ReposGetPagesReq, opt ...RequestOpt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetPagesResponseBody{}
+	resp.Data = components.Page{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -10252,13 +10007,6 @@ func (r *ReposGetPagesReq) Rel(link RelName, resp *ReposGetPagesResponse) bool {
 }
 
 /*
-ReposGetPagesResponseBody is a response body for ReposGetPages
-
-https://developer.github.com/v3/repos/pages/#get-a-github-pages-site
-*/
-type ReposGetPagesResponseBody components.Page
-
-/*
 ReposGetPagesResponse is a response for ReposGetPages
 
 https://developer.github.com/v3/repos/pages/#get-a-github-pages-site
@@ -10266,7 +10014,7 @@ https://developer.github.com/v3/repos/pages/#get-a-github-pages-site
 type ReposGetPagesResponse struct {
 	response
 	request *ReposGetPagesReq
-	Data    ReposGetPagesResponseBody
+	Data    components.Page
 }
 
 /*
@@ -10290,7 +10038,7 @@ func ReposGetPagesBuild(ctx context.Context, req *ReposGetPagesBuildReq, opt ...
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetPagesBuildResponseBody{}
+	resp.Data = components.PageBuild{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -10383,13 +10131,6 @@ func (r *ReposGetPagesBuildReq) Rel(link RelName, resp *ReposGetPagesBuildRespon
 }
 
 /*
-ReposGetPagesBuildResponseBody is a response body for ReposGetPagesBuild
-
-https://developer.github.com/v3/repos/pages/#get-github-pages-build
-*/
-type ReposGetPagesBuildResponseBody components.PageBuild
-
-/*
 ReposGetPagesBuildResponse is a response for ReposGetPagesBuild
 
 https://developer.github.com/v3/repos/pages/#get-github-pages-build
@@ -10397,7 +10138,7 @@ https://developer.github.com/v3/repos/pages/#get-github-pages-build
 type ReposGetPagesBuildResponse struct {
 	response
 	request *ReposGetPagesBuildReq
-	Data    ReposGetPagesBuildResponseBody
+	Data    components.PageBuild
 }
 
 /*
@@ -10421,7 +10162,7 @@ func ReposGetParticipationStats(ctx context.Context, req *ReposGetParticipationS
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetParticipationStatsResponseBody{}
+	resp.Data = components.ParticipationStats{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -10511,13 +10252,6 @@ func (r *ReposGetParticipationStatsReq) Rel(link RelName, resp *ReposGetParticip
 }
 
 /*
-ReposGetParticipationStatsResponseBody is a response body for ReposGetParticipationStats
-
-https://developer.github.com/v3/repos/statistics/#get-the-weekly-commit-count
-*/
-type ReposGetParticipationStatsResponseBody components.ParticipationStats
-
-/*
 ReposGetParticipationStatsResponse is a response for ReposGetParticipationStats
 
 https://developer.github.com/v3/repos/statistics/#get-the-weekly-commit-count
@@ -10525,7 +10259,7 @@ https://developer.github.com/v3/repos/statistics/#get-the-weekly-commit-count
 type ReposGetParticipationStatsResponse struct {
 	response
 	request *ReposGetParticipationStatsReq
-	Data    ReposGetParticipationStatsResponseBody
+	Data    components.ParticipationStats
 }
 
 /*
@@ -10549,7 +10283,7 @@ func ReposGetPullRequestReviewProtection(ctx context.Context, req *ReposGetPullR
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetPullRequestReviewProtectionResponseBody{}
+	resp.Data = components.ProtectedBranchPullRequestReview{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -10655,13 +10389,6 @@ func (r *ReposGetPullRequestReviewProtectionReq) Rel(link RelName, resp *ReposGe
 }
 
 /*
-ReposGetPullRequestReviewProtectionResponseBody is a response body for ReposGetPullRequestReviewProtection
-
-https://developer.github.com/v3/repos/branches/#get-pull-request-review-protection
-*/
-type ReposGetPullRequestReviewProtectionResponseBody components.ProtectedBranchPullRequestReview
-
-/*
 ReposGetPullRequestReviewProtectionResponse is a response for ReposGetPullRequestReviewProtection
 
 https://developer.github.com/v3/repos/branches/#get-pull-request-review-protection
@@ -10669,7 +10396,7 @@ https://developer.github.com/v3/repos/branches/#get-pull-request-review-protecti
 type ReposGetPullRequestReviewProtectionResponse struct {
 	response
 	request *ReposGetPullRequestReviewProtectionReq
-	Data    ReposGetPullRequestReviewProtectionResponseBody
+	Data    components.ProtectedBranchPullRequestReview
 }
 
 /*
@@ -10821,7 +10548,7 @@ func ReposGetReadme(ctx context.Context, req *ReposGetReadmeReq, opt ...RequestO
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetReadmeResponseBody{}
+	resp.Data = components.ContentFile{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -10920,13 +10647,6 @@ func (r *ReposGetReadmeReq) Rel(link RelName, resp *ReposGetReadmeResponse) bool
 }
 
 /*
-ReposGetReadmeResponseBody is a response body for ReposGetReadme
-
-https://developer.github.com/v3/repos/contents/#get-a-repository-readme
-*/
-type ReposGetReadmeResponseBody components.ContentFile
-
-/*
 ReposGetReadmeResponse is a response for ReposGetReadme
 
 https://developer.github.com/v3/repos/contents/#get-a-repository-readme
@@ -10934,7 +10654,7 @@ https://developer.github.com/v3/repos/contents/#get-a-repository-readme
 type ReposGetReadmeResponse struct {
 	response
 	request *ReposGetReadmeReq
-	Data    ReposGetReadmeResponseBody
+	Data    components.ContentFile
 }
 
 /*
@@ -10958,7 +10678,7 @@ func ReposGetRelease(ctx context.Context, req *ReposGetReleaseReq, opt ...Reques
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetReleaseResponseBody{}
+	resp.Data = components.Release{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -11051,13 +10771,6 @@ func (r *ReposGetReleaseReq) Rel(link RelName, resp *ReposGetReleaseResponse) bo
 }
 
 /*
-ReposGetReleaseResponseBody is a response body for ReposGetRelease
-
-https://developer.github.com/v3/repos/releases/#get-a-release
-*/
-type ReposGetReleaseResponseBody components.Release
-
-/*
 ReposGetReleaseResponse is a response for ReposGetRelease
 
 https://developer.github.com/v3/repos/releases/#get-a-release
@@ -11065,7 +10778,7 @@ https://developer.github.com/v3/repos/releases/#get-a-release
 type ReposGetReleaseResponse struct {
 	response
 	request *ReposGetReleaseReq
-	Data    ReposGetReleaseResponseBody
+	Data    components.Release
 }
 
 /*
@@ -11089,7 +10802,7 @@ func ReposGetReleaseAsset(ctx context.Context, req *ReposGetReleaseAssetReq, opt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetReleaseAssetResponseBody{}
+	resp.Data = components.ReleaseAsset{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -11182,13 +10895,6 @@ func (r *ReposGetReleaseAssetReq) Rel(link RelName, resp *ReposGetReleaseAssetRe
 }
 
 /*
-ReposGetReleaseAssetResponseBody is a response body for ReposGetReleaseAsset
-
-https://developer.github.com/v3/repos/releases/#get-a-release-asset
-*/
-type ReposGetReleaseAssetResponseBody components.ReleaseAsset
-
-/*
 ReposGetReleaseAssetResponse is a response for ReposGetReleaseAsset
 
 https://developer.github.com/v3/repos/releases/#get-a-release-asset
@@ -11196,7 +10902,7 @@ https://developer.github.com/v3/repos/releases/#get-a-release-asset
 type ReposGetReleaseAssetResponse struct {
 	response
 	request *ReposGetReleaseAssetReq
-	Data    ReposGetReleaseAssetResponseBody
+	Data    components.ReleaseAsset
 }
 
 /*
@@ -11220,7 +10926,7 @@ func ReposGetReleaseByTag(ctx context.Context, req *ReposGetReleaseByTagReq, opt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetReleaseByTagResponseBody{}
+	resp.Data = components.Release{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -11313,13 +11019,6 @@ func (r *ReposGetReleaseByTagReq) Rel(link RelName, resp *ReposGetReleaseByTagRe
 }
 
 /*
-ReposGetReleaseByTagResponseBody is a response body for ReposGetReleaseByTag
-
-https://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name
-*/
-type ReposGetReleaseByTagResponseBody components.Release
-
-/*
 ReposGetReleaseByTagResponse is a response for ReposGetReleaseByTag
 
 https://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name
@@ -11327,7 +11026,7 @@ https://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name
 type ReposGetReleaseByTagResponse struct {
 	response
 	request *ReposGetReleaseByTagReq
-	Data    ReposGetReleaseByTagResponseBody
+	Data    components.Release
 }
 
 /*
@@ -11351,7 +11050,7 @@ func ReposGetStatusChecksProtection(ctx context.Context, req *ReposGetStatusChec
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetStatusChecksProtectionResponseBody{}
+	resp.Data = components.StatusCheckPolicy{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -11444,13 +11143,6 @@ func (r *ReposGetStatusChecksProtectionReq) Rel(link RelName, resp *ReposGetStat
 }
 
 /*
-ReposGetStatusChecksProtectionResponseBody is a response body for ReposGetStatusChecksProtection
-
-https://developer.github.com/v3/repos/branches/#get-status-checks-protection
-*/
-type ReposGetStatusChecksProtectionResponseBody components.StatusCheckPolicy
-
-/*
 ReposGetStatusChecksProtectionResponse is a response for ReposGetStatusChecksProtection
 
 https://developer.github.com/v3/repos/branches/#get-status-checks-protection
@@ -11458,7 +11150,7 @@ https://developer.github.com/v3/repos/branches/#get-status-checks-protection
 type ReposGetStatusChecksProtectionResponse struct {
 	response
 	request *ReposGetStatusChecksProtectionReq
-	Data    ReposGetStatusChecksProtectionResponseBody
+	Data    components.StatusCheckPolicy
 }
 
 /*
@@ -12000,7 +11692,7 @@ func ReposGetViews(ctx context.Context, req *ReposGetViewsReq, opt ...RequestOpt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetViewsResponseBody{}
+	resp.Data = components.ViewTraffic{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -12096,13 +11788,6 @@ func (r *ReposGetViewsReq) Rel(link RelName, resp *ReposGetViewsResponse) bool {
 }
 
 /*
-ReposGetViewsResponseBody is a response body for ReposGetViews
-
-https://developer.github.com/v3/repos/traffic/#get-page-views
-*/
-type ReposGetViewsResponseBody components.ViewTraffic
-
-/*
 ReposGetViewsResponse is a response for ReposGetViews
 
 https://developer.github.com/v3/repos/traffic/#get-page-views
@@ -12110,7 +11795,7 @@ https://developer.github.com/v3/repos/traffic/#get-page-views
 type ReposGetViewsResponse struct {
 	response
 	request *ReposGetViewsReq
-	Data    ReposGetViewsResponseBody
+	Data    components.ViewTraffic
 }
 
 /*
@@ -12134,7 +11819,7 @@ func ReposGetWebhook(ctx context.Context, req *ReposGetWebhookReq, opt ...Reques
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetWebhookResponseBody{}
+	resp.Data = components.Hook{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -12225,13 +11910,6 @@ func (r *ReposGetWebhookReq) Rel(link RelName, resp *ReposGetWebhookResponse) bo
 }
 
 /*
-ReposGetWebhookResponseBody is a response body for ReposGetWebhook
-
-https://developer.github.com/v3/repos/hooks/#get-a-repository-webhook
-*/
-type ReposGetWebhookResponseBody components.Hook
-
-/*
 ReposGetWebhookResponse is a response for ReposGetWebhook
 
 https://developer.github.com/v3/repos/hooks/#get-a-repository-webhook
@@ -12239,7 +11917,7 @@ https://developer.github.com/v3/repos/hooks/#get-a-repository-webhook
 type ReposGetWebhookResponse struct {
 	response
 	request *ReposGetWebhookReq
-	Data    ReposGetWebhookResponseBody
+	Data    components.Hook
 }
 
 /*
@@ -14982,7 +14660,7 @@ func ReposListLanguages(ctx context.Context, req *ReposListLanguagesReq, opt ...
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposListLanguagesResponseBody{}
+	resp.Data = components.Language{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -15072,13 +14750,6 @@ func (r *ReposListLanguagesReq) Rel(link RelName, resp *ReposListLanguagesRespon
 }
 
 /*
-ReposListLanguagesResponseBody is a response body for ReposListLanguages
-
-https://developer.github.com/v3/repos/#list-repository-languages
-*/
-type ReposListLanguagesResponseBody components.Language
-
-/*
 ReposListLanguagesResponse is a response for ReposListLanguages
 
 https://developer.github.com/v3/repos/#list-repository-languages
@@ -15086,7 +14757,7 @@ https://developer.github.com/v3/repos/#list-repository-languages
 type ReposListLanguagesResponse struct {
 	response
 	request *ReposListLanguagesReq
-	Data    ReposListLanguagesResponseBody
+	Data    components.Language
 }
 
 /*
@@ -16257,7 +15928,7 @@ func ReposMerge(ctx context.Context, req *ReposMergeReq, opt ...RequestOption) (
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposMergeResponseBody{}
+	resp.Data = components.Commit{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -16368,13 +16039,6 @@ type ReposMergeReqBody struct {
 }
 
 /*
-ReposMergeResponseBody is a response body for ReposMerge
-
-https://developer.github.com/v3/repos/merging/#merge-a-branch
-*/
-type ReposMergeResponseBody components.Commit
-
-/*
 ReposMergeResponse is a response for ReposMerge
 
 https://developer.github.com/v3/repos/merging/#merge-a-branch
@@ -16382,7 +16046,7 @@ https://developer.github.com/v3/repos/merging/#merge-a-branch
 type ReposMergeResponse struct {
 	response
 	request *ReposMergeReq
-	Data    ReposMergeResponseBody
+	Data    components.Commit
 }
 
 /*
@@ -17341,7 +17005,7 @@ func ReposReplaceAllTopics(ctx context.Context, req *ReposReplaceAllTopicsReq, o
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposReplaceAllTopicsResponseBody{}
+	resp.Data = components.Topic{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -17464,13 +17128,6 @@ type ReposReplaceAllTopicsReqBody struct {
 }
 
 /*
-ReposReplaceAllTopicsResponseBody is a response body for ReposReplaceAllTopics
-
-https://developer.github.com/v3/repos/#replace-all-repository-topics
-*/
-type ReposReplaceAllTopicsResponseBody components.Topic
-
-/*
 ReposReplaceAllTopicsResponse is a response for ReposReplaceAllTopics
 
 https://developer.github.com/v3/repos/#replace-all-repository-topics
@@ -17478,7 +17135,7 @@ https://developer.github.com/v3/repos/#replace-all-repository-topics
 type ReposReplaceAllTopicsResponse struct {
 	response
 	request *ReposReplaceAllTopicsReq
-	Data    ReposReplaceAllTopicsResponseBody
+	Data    components.Topic
 }
 
 /*
@@ -17502,7 +17159,7 @@ func ReposRequestPagesBuild(ctx context.Context, req *ReposRequestPagesBuildReq,
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposRequestPagesBuildResponseBody{}
+	resp.Data = components.PageBuildStatus{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -17592,13 +17249,6 @@ func (r *ReposRequestPagesBuildReq) Rel(link RelName, resp *ReposRequestPagesBui
 }
 
 /*
-ReposRequestPagesBuildResponseBody is a response body for ReposRequestPagesBuild
-
-https://developer.github.com/v3/repos/pages/#request-a-github-pages-build
-*/
-type ReposRequestPagesBuildResponseBody components.PageBuildStatus
-
-/*
 ReposRequestPagesBuildResponse is a response for ReposRequestPagesBuild
 
 https://developer.github.com/v3/repos/pages/#request-a-github-pages-build
@@ -17606,7 +17256,7 @@ https://developer.github.com/v3/repos/pages/#request-a-github-pages-build
 type ReposRequestPagesBuildResponse struct {
 	response
 	request *ReposRequestPagesBuildReq
-	Data    ReposRequestPagesBuildResponseBody
+	Data    components.PageBuildStatus
 }
 
 /*
@@ -17630,7 +17280,7 @@ func ReposSetAdminBranchProtection(ctx context.Context, req *ReposSetAdminBranch
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposSetAdminBranchProtectionResponseBody{}
+	resp.Data = components.ProtectedBranchAdminEnforced{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -17723,13 +17373,6 @@ func (r *ReposSetAdminBranchProtectionReq) Rel(link RelName, resp *ReposSetAdmin
 }
 
 /*
-ReposSetAdminBranchProtectionResponseBody is a response body for ReposSetAdminBranchProtection
-
-https://developer.github.com/v3/repos/branches/#set-admin-branch-protection
-*/
-type ReposSetAdminBranchProtectionResponseBody components.ProtectedBranchAdminEnforced
-
-/*
 ReposSetAdminBranchProtectionResponse is a response for ReposSetAdminBranchProtection
 
 https://developer.github.com/v3/repos/branches/#set-admin-branch-protection
@@ -17737,7 +17380,7 @@ https://developer.github.com/v3/repos/branches/#set-admin-branch-protection
 type ReposSetAdminBranchProtectionResponse struct {
 	response
 	request *ReposSetAdminBranchProtectionReq
-	Data    ReposSetAdminBranchProtectionResponseBody
+	Data    components.ProtectedBranchAdminEnforced
 }
 
 /*
@@ -18454,7 +18097,7 @@ func ReposTransfer(ctx context.Context, req *ReposTransferReq, opt ...RequestOpt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposTransferResponseBody{}
+	resp.Data = components.Repository{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -18562,13 +18205,6 @@ type ReposTransferReqBody struct {
 }
 
 /*
-ReposTransferResponseBody is a response body for ReposTransfer
-
-https://developer.github.com/v3/repos/#transfer-a-repository
-*/
-type ReposTransferResponseBody components.Repository
-
-/*
 ReposTransferResponse is a response for ReposTransfer
 
 https://developer.github.com/v3/repos/#transfer-a-repository
@@ -18576,7 +18212,7 @@ https://developer.github.com/v3/repos/#transfer-a-repository
 type ReposTransferResponse struct {
 	response
 	request *ReposTransferReq
-	Data    ReposTransferResponseBody
+	Data    components.Repository
 }
 
 /*
@@ -18600,7 +18236,7 @@ func ReposUpdate(ctx context.Context, req *ReposUpdateReq, opt ...RequestOption)
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposUpdateResponseBody{}
+	resp.Data = components.FullRepository{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -18803,13 +18439,6 @@ type ReposUpdateReqBody struct {
 }
 
 /*
-ReposUpdateResponseBody is a response body for ReposUpdate
-
-https://developer.github.com/v3/repos/#update-a-repository
-*/
-type ReposUpdateResponseBody components.FullRepository
-
-/*
 ReposUpdateResponse is a response for ReposUpdate
 
 https://developer.github.com/v3/repos/#update-a-repository
@@ -18817,7 +18446,7 @@ https://developer.github.com/v3/repos/#update-a-repository
 type ReposUpdateResponse struct {
 	response
 	request *ReposUpdateReq
-	Data    ReposUpdateResponseBody
+	Data    components.FullRepository
 }
 
 /*
@@ -18841,7 +18470,7 @@ func ReposUpdateBranchProtection(ctx context.Context, req *ReposUpdateBranchProt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposUpdateBranchProtectionResponseBody{}
+	resp.Data = components.ProtectedBranch{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -19062,13 +18691,6 @@ type ReposUpdateBranchProtectionReqBody struct {
 }
 
 /*
-ReposUpdateBranchProtectionResponseBody is a response body for ReposUpdateBranchProtection
-
-https://developer.github.com/v3/repos/branches/#update-branch-protection
-*/
-type ReposUpdateBranchProtectionResponseBody components.ProtectedBranch
-
-/*
 ReposUpdateBranchProtectionResponse is a response for ReposUpdateBranchProtection
 
 https://developer.github.com/v3/repos/branches/#update-branch-protection
@@ -19076,7 +18698,7 @@ https://developer.github.com/v3/repos/branches/#update-branch-protection
 type ReposUpdateBranchProtectionResponse struct {
 	response
 	request *ReposUpdateBranchProtectionReq
-	Data    ReposUpdateBranchProtectionResponseBody
+	Data    components.ProtectedBranch
 }
 
 /*
@@ -19100,7 +18722,7 @@ func ReposUpdateCommitComment(ctx context.Context, req *ReposUpdateCommitComment
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposUpdateCommitCommentResponseBody{}
+	resp.Data = components.CommitComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -19208,13 +18830,6 @@ type ReposUpdateCommitCommentReqBody struct {
 }
 
 /*
-ReposUpdateCommitCommentResponseBody is a response body for ReposUpdateCommitComment
-
-https://developer.github.com/v3/repos/comments/#update-a-commit-comment
-*/
-type ReposUpdateCommitCommentResponseBody components.CommitComment
-
-/*
 ReposUpdateCommitCommentResponse is a response for ReposUpdateCommitComment
 
 https://developer.github.com/v3/repos/comments/#update-a-commit-comment
@@ -19222,7 +18837,7 @@ https://developer.github.com/v3/repos/comments/#update-a-commit-comment
 type ReposUpdateCommitCommentResponse struct {
 	response
 	request *ReposUpdateCommitCommentReq
-	Data    ReposUpdateCommitCommentResponseBody
+	Data    components.CommitComment
 }
 
 /*
@@ -19383,7 +18998,7 @@ func ReposUpdateInvitation(ctx context.Context, req *ReposUpdateInvitationReq, o
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposUpdateInvitationResponseBody{}
+	resp.Data = components.RepositoryInvitation{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -19494,13 +19109,6 @@ type ReposUpdateInvitationReqBody struct {
 }
 
 /*
-ReposUpdateInvitationResponseBody is a response body for ReposUpdateInvitation
-
-https://developer.github.com/v3/repos/invitations/#update-a-repository-invitation
-*/
-type ReposUpdateInvitationResponseBody components.RepositoryInvitation
-
-/*
 ReposUpdateInvitationResponse is a response for ReposUpdateInvitation
 
 https://developer.github.com/v3/repos/invitations/#update-a-repository-invitation
@@ -19508,7 +19116,7 @@ https://developer.github.com/v3/repos/invitations/#update-a-repository-invitatio
 type ReposUpdateInvitationResponse struct {
 	response
 	request *ReposUpdateInvitationReq
-	Data    ReposUpdateInvitationResponseBody
+	Data    components.RepositoryInvitation
 }
 
 /*
@@ -19532,7 +19140,7 @@ func ReposUpdatePullRequestReviewProtection(ctx context.Context, req *ReposUpdat
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposUpdatePullRequestReviewProtectionResponseBody{}
+	resp.Data = components.ProtectedBranchPullRequestReview{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -19677,13 +19285,6 @@ type ReposUpdatePullRequestReviewProtectionReqBody struct {
 }
 
 /*
-ReposUpdatePullRequestReviewProtectionResponseBody is a response body for ReposUpdatePullRequestReviewProtection
-
-https://developer.github.com/v3/repos/branches/#update-pull-request-review-protection
-*/
-type ReposUpdatePullRequestReviewProtectionResponseBody components.ProtectedBranchPullRequestReview
-
-/*
 ReposUpdatePullRequestReviewProtectionResponse is a response for ReposUpdatePullRequestReviewProtection
 
 https://developer.github.com/v3/repos/branches/#update-pull-request-review-protection
@@ -19691,7 +19292,7 @@ https://developer.github.com/v3/repos/branches/#update-pull-request-review-prote
 type ReposUpdatePullRequestReviewProtectionResponse struct {
 	response
 	request *ReposUpdatePullRequestReviewProtectionReq
-	Data    ReposUpdatePullRequestReviewProtectionResponseBody
+	Data    components.ProtectedBranchPullRequestReview
 }
 
 /*
@@ -19715,7 +19316,7 @@ func ReposUpdateRelease(ctx context.Context, req *ReposUpdateReleaseReq, opt ...
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposUpdateReleaseResponseBody{}
+	resp.Data = components.Release{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -19842,13 +19443,6 @@ type ReposUpdateReleaseReqBody struct {
 }
 
 /*
-ReposUpdateReleaseResponseBody is a response body for ReposUpdateRelease
-
-https://developer.github.com/v3/repos/releases/#update-a-release
-*/
-type ReposUpdateReleaseResponseBody components.Release
-
-/*
 ReposUpdateReleaseResponse is a response for ReposUpdateRelease
 
 https://developer.github.com/v3/repos/releases/#update-a-release
@@ -19856,7 +19450,7 @@ https://developer.github.com/v3/repos/releases/#update-a-release
 type ReposUpdateReleaseResponse struct {
 	response
 	request *ReposUpdateReleaseReq
-	Data    ReposUpdateReleaseResponseBody
+	Data    components.Release
 }
 
 /*
@@ -19880,7 +19474,7 @@ func ReposUpdateReleaseAsset(ctx context.Context, req *ReposUpdateReleaseAssetRe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposUpdateReleaseAssetResponseBody{}
+	resp.Data = components.ReleaseAsset{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -19992,13 +19586,6 @@ type ReposUpdateReleaseAssetReqBody struct {
 }
 
 /*
-ReposUpdateReleaseAssetResponseBody is a response body for ReposUpdateReleaseAsset
-
-https://developer.github.com/v3/repos/releases/#update-a-release-asset
-*/
-type ReposUpdateReleaseAssetResponseBody components.ReleaseAsset
-
-/*
 ReposUpdateReleaseAssetResponse is a response for ReposUpdateReleaseAsset
 
 https://developer.github.com/v3/repos/releases/#update-a-release-asset
@@ -20006,7 +19593,7 @@ https://developer.github.com/v3/repos/releases/#update-a-release-asset
 type ReposUpdateReleaseAssetResponse struct {
 	response
 	request *ReposUpdateReleaseAssetReq
-	Data    ReposUpdateReleaseAssetResponseBody
+	Data    components.ReleaseAsset
 }
 
 /*
@@ -20030,7 +19617,7 @@ func ReposUpdateStatusCheckProtection(ctx context.Context, req *ReposUpdateStatu
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposUpdateStatusCheckProtectionResponseBody{}
+	resp.Data = components.StatusCheckPolicy{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -20141,13 +19728,6 @@ type ReposUpdateStatusCheckProtectionReqBody struct {
 }
 
 /*
-ReposUpdateStatusCheckProtectionResponseBody is a response body for ReposUpdateStatusCheckProtection
-
-https://developer.github.com/v3/repos/branches/#update-status-check-potection
-*/
-type ReposUpdateStatusCheckProtectionResponseBody components.StatusCheckPolicy
-
-/*
 ReposUpdateStatusCheckProtectionResponse is a response for ReposUpdateStatusCheckProtection
 
 https://developer.github.com/v3/repos/branches/#update-status-check-potection
@@ -20155,7 +19735,7 @@ https://developer.github.com/v3/repos/branches/#update-status-check-potection
 type ReposUpdateStatusCheckProtectionResponse struct {
 	response
 	request *ReposUpdateStatusCheckProtectionReq
-	Data    ReposUpdateStatusCheckProtectionResponseBody
+	Data    components.StatusCheckPolicy
 }
 
 /*
@@ -20179,7 +19759,7 @@ func ReposUpdateWebhook(ctx context.Context, req *ReposUpdateWebhookReq, opt ...
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposUpdateWebhookResponseBody{}
+	resp.Data = components.Hook{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -20332,13 +19912,6 @@ type ReposUpdateWebhookReqBody struct {
 }
 
 /*
-ReposUpdateWebhookResponseBody is a response body for ReposUpdateWebhook
-
-https://developer.github.com/v3/repos/hooks/#update-a-repository-webhook
-*/
-type ReposUpdateWebhookResponseBody components.Hook
-
-/*
 ReposUpdateWebhookResponse is a response for ReposUpdateWebhook
 
 https://developer.github.com/v3/repos/hooks/#update-a-repository-webhook
@@ -20346,7 +19919,7 @@ https://developer.github.com/v3/repos/hooks/#update-a-repository-webhook
 type ReposUpdateWebhookResponse struct {
 	response
 	request *ReposUpdateWebhookReq
-	Data    ReposUpdateWebhookResponseBody
+	Data    components.Hook
 }
 
 /*
@@ -20370,7 +19943,7 @@ func ReposUploadReleaseAsset(ctx context.Context, req *ReposUploadReleaseAssetRe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposUploadReleaseAssetResponseBody{}
+	resp.Data = components.ReleaseAsset{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -20485,13 +20058,6 @@ func (r *ReposUploadReleaseAssetReq) Rel(link RelName, resp *ReposUploadReleaseA
 }
 
 /*
-ReposUploadReleaseAssetResponseBody is a response body for ReposUploadReleaseAsset
-
-https://developer.github.com/v3/repos/releases/#upload-a-release-asset
-*/
-type ReposUploadReleaseAssetResponseBody components.ReleaseAsset
-
-/*
 ReposUploadReleaseAssetResponse is a response for ReposUploadReleaseAsset
 
 https://developer.github.com/v3/repos/releases/#upload-a-release-asset
@@ -20499,5 +20065,5 @@ https://developer.github.com/v3/repos/releases/#upload-a-release-asset
 type ReposUploadReleaseAssetResponse struct {
 	response
 	request *ReposUploadReleaseAssetReq
-	Data    ReposUploadReleaseAssetResponseBody
+	Data    components.ReleaseAsset
 }

--- a/zz_repos_gen.go
+++ b/zz_repos_gen.go
@@ -154,7 +154,7 @@ func ReposAddAppAccessRestrictions(ctx context.Context, req *ReposAddAppAccessRe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposAddAppAccessRestrictionsResponseBody{}
+	resp.Data = []components.Integration{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -258,13 +258,6 @@ https://developer.github.com/v3/repos/branches/#add-app-access-restrictions
 type ReposAddAppAccessRestrictionsReqBody []string
 
 /*
-ReposAddAppAccessRestrictionsResponseBody is a response body for ReposAddAppAccessRestrictions
-
-https://developer.github.com/v3/repos/branches/#add-app-access-restrictions
-*/
-type ReposAddAppAccessRestrictionsResponseBody []components.Integration
-
-/*
 ReposAddAppAccessRestrictionsResponse is a response for ReposAddAppAccessRestrictions
 
 https://developer.github.com/v3/repos/branches/#add-app-access-restrictions
@@ -272,7 +265,7 @@ https://developer.github.com/v3/repos/branches/#add-app-access-restrictions
 type ReposAddAppAccessRestrictionsResponse struct {
 	response
 	request *ReposAddAppAccessRestrictionsReq
-	Data    ReposAddAppAccessRestrictionsResponseBody
+	Data    []components.Integration
 }
 
 /*
@@ -586,7 +579,7 @@ func ReposAddTeamAccessRestrictions(ctx context.Context, req *ReposAddTeamAccess
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposAddTeamAccessRestrictionsResponseBody{}
+	resp.Data = []components.Team{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -690,13 +683,6 @@ https://developer.github.com/v3/repos/branches/#add-team-access-restrictions
 type ReposAddTeamAccessRestrictionsReqBody []string
 
 /*
-ReposAddTeamAccessRestrictionsResponseBody is a response body for ReposAddTeamAccessRestrictions
-
-https://developer.github.com/v3/repos/branches/#add-team-access-restrictions
-*/
-type ReposAddTeamAccessRestrictionsResponseBody []components.Team
-
-/*
 ReposAddTeamAccessRestrictionsResponse is a response for ReposAddTeamAccessRestrictions
 
 https://developer.github.com/v3/repos/branches/#add-team-access-restrictions
@@ -704,7 +690,7 @@ https://developer.github.com/v3/repos/branches/#add-team-access-restrictions
 type ReposAddTeamAccessRestrictionsResponse struct {
 	response
 	request *ReposAddTeamAccessRestrictionsReq
-	Data    ReposAddTeamAccessRestrictionsResponseBody
+	Data    []components.Team
 }
 
 /*
@@ -728,7 +714,7 @@ func ReposAddUserAccessRestrictions(ctx context.Context, req *ReposAddUserAccess
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposAddUserAccessRestrictionsResponseBody{}
+	resp.Data = []components.SimpleUser{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -832,13 +818,6 @@ https://developer.github.com/v3/repos/branches/#add-user-access-restrictions
 type ReposAddUserAccessRestrictionsReqBody []string
 
 /*
-ReposAddUserAccessRestrictionsResponseBody is a response body for ReposAddUserAccessRestrictions
-
-https://developer.github.com/v3/repos/branches/#add-user-access-restrictions
-*/
-type ReposAddUserAccessRestrictionsResponseBody []components.SimpleUser
-
-/*
 ReposAddUserAccessRestrictionsResponse is a response for ReposAddUserAccessRestrictions
 
 https://developer.github.com/v3/repos/branches/#add-user-access-restrictions
@@ -846,7 +825,7 @@ https://developer.github.com/v3/repos/branches/#add-user-access-restrictions
 type ReposAddUserAccessRestrictionsResponse struct {
 	response
 	request *ReposAddUserAccessRestrictionsReq
-	Data    ReposAddUserAccessRestrictionsResponseBody
+	Data    []components.SimpleUser
 }
 
 /*
@@ -7330,7 +7309,7 @@ func ReposGetAppsWithAccessToProtectedBranch(ctx context.Context, req *ReposGetA
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetAppsWithAccessToProtectedBranchResponseBody{}
+	resp.Data = []components.Integration{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -7423,13 +7402,6 @@ func (r *ReposGetAppsWithAccessToProtectedBranchReq) Rel(link RelName, resp *Rep
 }
 
 /*
-ReposGetAppsWithAccessToProtectedBranchResponseBody is a response body for ReposGetAppsWithAccessToProtectedBranch
-
-https://developer.github.com/v3/repos/branches/#list-apps-with-access-to-the-protected-branch
-*/
-type ReposGetAppsWithAccessToProtectedBranchResponseBody []components.Integration
-
-/*
 ReposGetAppsWithAccessToProtectedBranchResponse is a response for ReposGetAppsWithAccessToProtectedBranch
 
 https://developer.github.com/v3/repos/branches/#list-apps-with-access-to-the-protected-branch
@@ -7437,7 +7409,7 @@ https://developer.github.com/v3/repos/branches/#list-apps-with-access-to-the-pro
 type ReposGetAppsWithAccessToProtectedBranchResponse struct {
 	response
 	request *ReposGetAppsWithAccessToProtectedBranchReq
-	Data    ReposGetAppsWithAccessToProtectedBranchResponseBody
+	Data    []components.Integration
 }
 
 /*
@@ -7849,7 +7821,7 @@ func ReposGetCodeFrequencyStats(ctx context.Context, req *ReposGetCodeFrequencyS
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetCodeFrequencyStatsResponseBody{}
+	resp.Data = []components.CodeFrequencyStat{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -7939,13 +7911,6 @@ func (r *ReposGetCodeFrequencyStatsReq) Rel(link RelName, resp *ReposGetCodeFreq
 }
 
 /*
-ReposGetCodeFrequencyStatsResponseBody is a response body for ReposGetCodeFrequencyStats
-
-https://developer.github.com/v3/repos/statistics/#get-the-weekly-commit-activity
-*/
-type ReposGetCodeFrequencyStatsResponseBody []components.CodeFrequencyStat
-
-/*
 ReposGetCodeFrequencyStatsResponse is a response for ReposGetCodeFrequencyStats
 
 https://developer.github.com/v3/repos/statistics/#get-the-weekly-commit-activity
@@ -7953,7 +7918,7 @@ https://developer.github.com/v3/repos/statistics/#get-the-weekly-commit-activity
 type ReposGetCodeFrequencyStatsResponse struct {
 	response
 	request *ReposGetCodeFrequencyStatsReq
-	Data    ReposGetCodeFrequencyStatsResponseBody
+	Data    []components.CodeFrequencyStat
 }
 
 /*
@@ -8347,7 +8312,7 @@ func ReposGetCommitActivityStats(ctx context.Context, req *ReposGetCommitActivit
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetCommitActivityStatsResponseBody{}
+	resp.Data = []components.CommitActivity{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -8437,13 +8402,6 @@ func (r *ReposGetCommitActivityStatsReq) Rel(link RelName, resp *ReposGetCommitA
 }
 
 /*
-ReposGetCommitActivityStatsResponseBody is a response body for ReposGetCommitActivityStats
-
-https://developer.github.com/v3/repos/statistics/#get-the-last-year-of-commit-activity
-*/
-type ReposGetCommitActivityStatsResponseBody []components.CommitActivity
-
-/*
 ReposGetCommitActivityStatsResponse is a response for ReposGetCommitActivityStats
 
 https://developer.github.com/v3/repos/statistics/#get-the-last-year-of-commit-activity
@@ -8451,7 +8409,7 @@ https://developer.github.com/v3/repos/statistics/#get-the-last-year-of-commit-ac
 type ReposGetCommitActivityStatsResponse struct {
 	response
 	request *ReposGetCommitActivityStatsReq
-	Data    ReposGetCommitActivityStatsResponseBody
+	Data    []components.CommitActivity
 }
 
 /*
@@ -9110,7 +9068,7 @@ func ReposGetContributorsStats(ctx context.Context, req *ReposGetContributorsSta
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetContributorsStatsResponseBody{}
+	resp.Data = []components.ContributorActivity{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -9200,13 +9158,6 @@ func (r *ReposGetContributorsStatsReq) Rel(link RelName, resp *ReposGetContribut
 }
 
 /*
-ReposGetContributorsStatsResponseBody is a response body for ReposGetContributorsStats
-
-https://developer.github.com/v3/repos/statistics/#get-all-contributor-commit-activity
-*/
-type ReposGetContributorsStatsResponseBody []components.ContributorActivity
-
-/*
 ReposGetContributorsStatsResponse is a response for ReposGetContributorsStats
 
 https://developer.github.com/v3/repos/statistics/#get-all-contributor-commit-activity
@@ -9214,7 +9165,7 @@ https://developer.github.com/v3/repos/statistics/#get-all-contributor-commit-act
 type ReposGetContributorsStatsResponse struct {
 	response
 	request *ReposGetContributorsStatsReq
-	Data    ReposGetContributorsStatsResponseBody
+	Data    []components.ContributorActivity
 }
 
 /*
@@ -10420,7 +10371,7 @@ func ReposGetPunchCardStats(ctx context.Context, req *ReposGetPunchCardStatsReq,
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetPunchCardStatsResponseBody{}
+	resp.Data = []components.CodeFrequencyStat{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -10510,13 +10461,6 @@ func (r *ReposGetPunchCardStatsReq) Rel(link RelName, resp *ReposGetPunchCardSta
 }
 
 /*
-ReposGetPunchCardStatsResponseBody is a response body for ReposGetPunchCardStats
-
-https://developer.github.com/v3/repos/statistics/#get-the-hourly-commit-count-for-each-day
-*/
-type ReposGetPunchCardStatsResponseBody []components.CodeFrequencyStat
-
-/*
 ReposGetPunchCardStatsResponse is a response for ReposGetPunchCardStats
 
 https://developer.github.com/v3/repos/statistics/#get-the-hourly-commit-count-for-each-day
@@ -10524,7 +10468,7 @@ https://developer.github.com/v3/repos/statistics/#get-the-hourly-commit-count-fo
 type ReposGetPunchCardStatsResponse struct {
 	response
 	request *ReposGetPunchCardStatsReq
-	Data    ReposGetPunchCardStatsResponseBody
+	Data    []components.CodeFrequencyStat
 }
 
 /*
@@ -11174,7 +11118,7 @@ func ReposGetTeamsWithAccessToProtectedBranch(ctx context.Context, req *ReposGet
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetTeamsWithAccessToProtectedBranchResponseBody{}
+	resp.Data = []components.Team{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -11267,13 +11211,6 @@ func (r *ReposGetTeamsWithAccessToProtectedBranchReq) Rel(link RelName, resp *Re
 }
 
 /*
-ReposGetTeamsWithAccessToProtectedBranchResponseBody is a response body for ReposGetTeamsWithAccessToProtectedBranch
-
-https://developer.github.com/v3/repos/branches/#list-teams-with-access-to-the-protected-branch
-*/
-type ReposGetTeamsWithAccessToProtectedBranchResponseBody []components.Team
-
-/*
 ReposGetTeamsWithAccessToProtectedBranchResponse is a response for ReposGetTeamsWithAccessToProtectedBranch
 
 https://developer.github.com/v3/repos/branches/#list-teams-with-access-to-the-protected-branch
@@ -11281,7 +11218,7 @@ https://developer.github.com/v3/repos/branches/#list-teams-with-access-to-the-pr
 type ReposGetTeamsWithAccessToProtectedBranchResponse struct {
 	response
 	request *ReposGetTeamsWithAccessToProtectedBranchReq
-	Data    ReposGetTeamsWithAccessToProtectedBranchResponseBody
+	Data    []components.Team
 }
 
 /*
@@ -11305,7 +11242,7 @@ func ReposGetTopPaths(ctx context.Context, req *ReposGetTopPathsReq, opt ...Requ
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetTopPathsResponseBody{}
+	resp.Data = []components.ContentTraffic{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -11395,13 +11332,6 @@ func (r *ReposGetTopPathsReq) Rel(link RelName, resp *ReposGetTopPathsResponse) 
 }
 
 /*
-ReposGetTopPathsResponseBody is a response body for ReposGetTopPaths
-
-https://developer.github.com/v3/repos/traffic/#get-top-referral-paths
-*/
-type ReposGetTopPathsResponseBody []components.ContentTraffic
-
-/*
 ReposGetTopPathsResponse is a response for ReposGetTopPaths
 
 https://developer.github.com/v3/repos/traffic/#get-top-referral-paths
@@ -11409,7 +11339,7 @@ https://developer.github.com/v3/repos/traffic/#get-top-referral-paths
 type ReposGetTopPathsResponse struct {
 	response
 	request *ReposGetTopPathsReq
-	Data    ReposGetTopPathsResponseBody
+	Data    []components.ContentTraffic
 }
 
 /*
@@ -11433,7 +11363,7 @@ func ReposGetTopReferrers(ctx context.Context, req *ReposGetTopReferrersReq, opt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetTopReferrersResponseBody{}
+	resp.Data = []components.ReferrerTraffic{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -11523,13 +11453,6 @@ func (r *ReposGetTopReferrersReq) Rel(link RelName, resp *ReposGetTopReferrersRe
 }
 
 /*
-ReposGetTopReferrersResponseBody is a response body for ReposGetTopReferrers
-
-https://developer.github.com/v3/repos/traffic/#get-top-referral-sources
-*/
-type ReposGetTopReferrersResponseBody []components.ReferrerTraffic
-
-/*
 ReposGetTopReferrersResponse is a response for ReposGetTopReferrers
 
 https://developer.github.com/v3/repos/traffic/#get-top-referral-sources
@@ -11537,7 +11460,7 @@ https://developer.github.com/v3/repos/traffic/#get-top-referral-sources
 type ReposGetTopReferrersResponse struct {
 	response
 	request *ReposGetTopReferrersReq
-	Data    ReposGetTopReferrersResponseBody
+	Data    []components.ReferrerTraffic
 }
 
 /*
@@ -11561,7 +11484,7 @@ func ReposGetUsersWithAccessToProtectedBranch(ctx context.Context, req *ReposGet
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposGetUsersWithAccessToProtectedBranchResponseBody{}
+	resp.Data = []components.SimpleUser{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -11654,13 +11577,6 @@ func (r *ReposGetUsersWithAccessToProtectedBranchReq) Rel(link RelName, resp *Re
 }
 
 /*
-ReposGetUsersWithAccessToProtectedBranchResponseBody is a response body for ReposGetUsersWithAccessToProtectedBranch
-
-https://developer.github.com/v3/repos/branches/#list-users-with-access-to-the-protected-branch
-*/
-type ReposGetUsersWithAccessToProtectedBranchResponseBody []components.SimpleUser
-
-/*
 ReposGetUsersWithAccessToProtectedBranchResponse is a response for ReposGetUsersWithAccessToProtectedBranch
 
 https://developer.github.com/v3/repos/branches/#list-users-with-access-to-the-protected-branch
@@ -11668,7 +11584,7 @@ https://developer.github.com/v3/repos/branches/#list-users-with-access-to-the-pr
 type ReposGetUsersWithAccessToProtectedBranchResponse struct {
 	response
 	request *ReposGetUsersWithAccessToProtectedBranchReq
-	Data    ReposGetUsersWithAccessToProtectedBranchResponseBody
+	Data    []components.SimpleUser
 }
 
 /*
@@ -11941,7 +11857,7 @@ func ReposListBranches(ctx context.Context, req *ReposListBranchesReq, opt ...Re
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposListBranchesResponseBody{}
+	resp.Data = []components.ShortBranch{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -12052,13 +11968,6 @@ func (r *ReposListBranchesReq) Rel(link RelName, resp *ReposListBranchesResponse
 }
 
 /*
-ReposListBranchesResponseBody is a response body for ReposListBranches
-
-https://developer.github.com/v3/repos/branches/#list-branches
-*/
-type ReposListBranchesResponseBody []components.ShortBranch
-
-/*
 ReposListBranchesResponse is a response for ReposListBranches
 
 https://developer.github.com/v3/repos/branches/#list-branches
@@ -12066,7 +11975,7 @@ https://developer.github.com/v3/repos/branches/#list-branches
 type ReposListBranchesResponse struct {
 	response
 	request *ReposListBranchesReq
-	Data    ReposListBranchesResponseBody
+	Data    []components.ShortBranch
 }
 
 /*
@@ -12090,7 +11999,7 @@ func ReposListBranchesForHeadCommit(ctx context.Context, req *ReposListBranchesF
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposListBranchesForHeadCommitResponseBody{}
+	resp.Data = []components.BranchShort{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -12198,13 +12107,6 @@ func (r *ReposListBranchesForHeadCommitReq) Rel(link RelName, resp *ReposListBra
 }
 
 /*
-ReposListBranchesForHeadCommitResponseBody is a response body for ReposListBranchesForHeadCommit
-
-https://developer.github.com/v3/repos/commits/#list-branches-for-head-commit
-*/
-type ReposListBranchesForHeadCommitResponseBody []components.BranchShort
-
-/*
 ReposListBranchesForHeadCommitResponse is a response for ReposListBranchesForHeadCommit
 
 https://developer.github.com/v3/repos/commits/#list-branches-for-head-commit
@@ -12212,7 +12114,7 @@ https://developer.github.com/v3/repos/commits/#list-branches-for-head-commit
 type ReposListBranchesForHeadCommitResponse struct {
 	response
 	request *ReposListBranchesForHeadCommitReq
-	Data    ReposListBranchesForHeadCommitResponseBody
+	Data    []components.BranchShort
 }
 
 /*
@@ -12236,7 +12138,7 @@ func ReposListCollaborators(ctx context.Context, req *ReposListCollaboratorsReq,
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposListCollaboratorsResponseBody{}
+	resp.Data = []components.Collaborator{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -12350,13 +12252,6 @@ func (r *ReposListCollaboratorsReq) Rel(link RelName, resp *ReposListCollaborato
 }
 
 /*
-ReposListCollaboratorsResponseBody is a response body for ReposListCollaborators
-
-https://developer.github.com/v3/repos/collaborators/#list-repository-collaborators
-*/
-type ReposListCollaboratorsResponseBody []components.Collaborator
-
-/*
 ReposListCollaboratorsResponse is a response for ReposListCollaborators
 
 https://developer.github.com/v3/repos/collaborators/#list-repository-collaborators
@@ -12364,7 +12259,7 @@ https://developer.github.com/v3/repos/collaborators/#list-repository-collaborato
 type ReposListCollaboratorsResponse struct {
 	response
 	request *ReposListCollaboratorsReq
-	Data    ReposListCollaboratorsResponseBody
+	Data    []components.Collaborator
 }
 
 /*
@@ -12388,7 +12283,7 @@ func ReposListCommentsForCommit(ctx context.Context, req *ReposListCommentsForCo
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposListCommentsForCommitResponseBody{}
+	resp.Data = []components.CommitComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -12507,13 +12402,6 @@ func (r *ReposListCommentsForCommitReq) Rel(link RelName, resp *ReposListComment
 }
 
 /*
-ReposListCommentsForCommitResponseBody is a response body for ReposListCommentsForCommit
-
-https://developer.github.com/v3/repos/comments/#list-commit-comments
-*/
-type ReposListCommentsForCommitResponseBody []components.CommitComment
-
-/*
 ReposListCommentsForCommitResponse is a response for ReposListCommentsForCommit
 
 https://developer.github.com/v3/repos/comments/#list-commit-comments
@@ -12521,7 +12409,7 @@ https://developer.github.com/v3/repos/comments/#list-commit-comments
 type ReposListCommentsForCommitResponse struct {
 	response
 	request *ReposListCommentsForCommitReq
-	Data    ReposListCommentsForCommitResponseBody
+	Data    []components.CommitComment
 }
 
 /*
@@ -12545,7 +12433,7 @@ func ReposListCommitCommentsForRepo(ctx context.Context, req *ReposListCommitCom
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposListCommitCommentsForRepoResponseBody{}
+	resp.Data = []components.CommitComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -12661,13 +12549,6 @@ func (r *ReposListCommitCommentsForRepoReq) Rel(link RelName, resp *ReposListCom
 }
 
 /*
-ReposListCommitCommentsForRepoResponseBody is a response body for ReposListCommitCommentsForRepo
-
-https://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository
-*/
-type ReposListCommitCommentsForRepoResponseBody []components.CommitComment
-
-/*
 ReposListCommitCommentsForRepoResponse is a response for ReposListCommitCommentsForRepo
 
 https://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository
@@ -12675,7 +12556,7 @@ https://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repos
 type ReposListCommitCommentsForRepoResponse struct {
 	response
 	request *ReposListCommitCommentsForRepoReq
-	Data    ReposListCommitCommentsForRepoResponseBody
+	Data    []components.CommitComment
 }
 
 /*
@@ -12699,7 +12580,7 @@ func ReposListCommitStatusesForRef(ctx context.Context, req *ReposListCommitStat
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposListCommitStatusesForRefResponseBody{}
+	resp.Data = []components.Status{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -12804,13 +12685,6 @@ func (r *ReposListCommitStatusesForRefReq) Rel(link RelName, resp *ReposListComm
 }
 
 /*
-ReposListCommitStatusesForRefResponseBody is a response body for ReposListCommitStatusesForRef
-
-https://developer.github.com/v3/repos/statuses/#list-commit-statuses-for-a-reference
-*/
-type ReposListCommitStatusesForRefResponseBody []components.Status
-
-/*
 ReposListCommitStatusesForRefResponse is a response for ReposListCommitStatusesForRef
 
 https://developer.github.com/v3/repos/statuses/#list-commit-statuses-for-a-reference
@@ -12818,7 +12692,7 @@ https://developer.github.com/v3/repos/statuses/#list-commit-statuses-for-a-refer
 type ReposListCommitStatusesForRefResponse struct {
 	response
 	request *ReposListCommitStatusesForRefReq
-	Data    ReposListCommitStatusesForRefResponseBody
+	Data    []components.Status
 }
 
 /*
@@ -12842,7 +12716,7 @@ func ReposListCommits(ctx context.Context, req *ReposListCommitsReq, opt ...Requ
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposListCommitsResponseBody{}
+	resp.Data = []components.SimpleCommit{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -12984,13 +12858,6 @@ func (r *ReposListCommitsReq) Rel(link RelName, resp *ReposListCommitsResponse) 
 }
 
 /*
-ReposListCommitsResponseBody is a response body for ReposListCommits
-
-https://developer.github.com/v3/repos/commits/#list-commits
-*/
-type ReposListCommitsResponseBody []components.SimpleCommit
-
-/*
 ReposListCommitsResponse is a response for ReposListCommits
 
 https://developer.github.com/v3/repos/commits/#list-commits
@@ -12998,7 +12865,7 @@ https://developer.github.com/v3/repos/commits/#list-commits
 type ReposListCommitsResponse struct {
 	response
 	request *ReposListCommitsReq
-	Data    ReposListCommitsResponseBody
+	Data    []components.SimpleCommit
 }
 
 /*
@@ -13022,7 +12889,7 @@ func ReposListContributors(ctx context.Context, req *ReposListContributorsReq, o
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposListContributorsResponseBody{}
+	resp.Data = []components.Contributor{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -13130,13 +12997,6 @@ func (r *ReposListContributorsReq) Rel(link RelName, resp *ReposListContributors
 }
 
 /*
-ReposListContributorsResponseBody is a response body for ReposListContributors
-
-https://developer.github.com/v3/repos/#list-repository-contributors
-*/
-type ReposListContributorsResponseBody []components.Contributor
-
-/*
 ReposListContributorsResponse is a response for ReposListContributors
 
 https://developer.github.com/v3/repos/#list-repository-contributors
@@ -13144,7 +13004,7 @@ https://developer.github.com/v3/repos/#list-repository-contributors
 type ReposListContributorsResponse struct {
 	response
 	request *ReposListContributorsReq
-	Data    ReposListContributorsResponseBody
+	Data    []components.Contributor
 }
 
 /*
@@ -13168,7 +13028,7 @@ func ReposListDeployKeys(ctx context.Context, req *ReposListDeployKeysReq, opt .
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposListDeployKeysResponseBody{}
+	resp.Data = []components.DeployKey{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -13270,13 +13130,6 @@ func (r *ReposListDeployKeysReq) Rel(link RelName, resp *ReposListDeployKeysResp
 }
 
 /*
-ReposListDeployKeysResponseBody is a response body for ReposListDeployKeys
-
-https://developer.github.com/v3/repos/keys/#list-deploy-keys
-*/
-type ReposListDeployKeysResponseBody []components.DeployKey
-
-/*
 ReposListDeployKeysResponse is a response for ReposListDeployKeys
 
 https://developer.github.com/v3/repos/keys/#list-deploy-keys
@@ -13284,7 +13137,7 @@ https://developer.github.com/v3/repos/keys/#list-deploy-keys
 type ReposListDeployKeysResponse struct {
 	response
 	request *ReposListDeployKeysReq
-	Data    ReposListDeployKeysResponseBody
+	Data    []components.DeployKey
 }
 
 /*
@@ -13308,7 +13161,7 @@ func ReposListDeploymentStatuses(ctx context.Context, req *ReposListDeploymentSt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposListDeploymentStatusesResponseBody{}
+	resp.Data = []components.DeploymentStatus{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -13443,13 +13296,6 @@ func (r *ReposListDeploymentStatusesReq) Rel(link RelName, resp *ReposListDeploy
 }
 
 /*
-ReposListDeploymentStatusesResponseBody is a response body for ReposListDeploymentStatuses
-
-https://developer.github.com/v3/repos/deployments/#list-deployment-statuses
-*/
-type ReposListDeploymentStatusesResponseBody []components.DeploymentStatus
-
-/*
 ReposListDeploymentStatusesResponse is a response for ReposListDeploymentStatuses
 
 https://developer.github.com/v3/repos/deployments/#list-deployment-statuses
@@ -13457,7 +13303,7 @@ https://developer.github.com/v3/repos/deployments/#list-deployment-statuses
 type ReposListDeploymentStatusesResponse struct {
 	response
 	request *ReposListDeploymentStatusesReq
-	Data    ReposListDeploymentStatusesResponseBody
+	Data    []components.DeploymentStatus
 }
 
 /*
@@ -13481,7 +13327,7 @@ func ReposListDeployments(ctx context.Context, req *ReposListDeploymentsReq, opt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposListDeploymentsResponseBody{}
+	resp.Data = []components.Deployment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -13624,13 +13470,6 @@ func (r *ReposListDeploymentsReq) Rel(link RelName, resp *ReposListDeploymentsRe
 }
 
 /*
-ReposListDeploymentsResponseBody is a response body for ReposListDeployments
-
-https://developer.github.com/v3/repos/deployments/#list-deployments
-*/
-type ReposListDeploymentsResponseBody []components.Deployment
-
-/*
 ReposListDeploymentsResponse is a response for ReposListDeployments
 
 https://developer.github.com/v3/repos/deployments/#list-deployments
@@ -13638,7 +13477,7 @@ https://developer.github.com/v3/repos/deployments/#list-deployments
 type ReposListDeploymentsResponse struct {
 	response
 	request *ReposListDeploymentsReq
-	Data    ReposListDeploymentsResponseBody
+	Data    []components.Deployment
 }
 
 /*
@@ -13662,7 +13501,7 @@ func ReposListForAuthenticatedUser(ctx context.Context, req *ReposListForAuthent
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposListForAuthenticatedUserResponseBody{}
+	resp.Data = []components.Repository{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -13829,13 +13668,6 @@ func (r *ReposListForAuthenticatedUserReq) Rel(link RelName, resp *ReposListForA
 }
 
 /*
-ReposListForAuthenticatedUserResponseBody is a response body for ReposListForAuthenticatedUser
-
-https://developer.github.com/v3/repos/#list-repositories-for-the-authenticated-user
-*/
-type ReposListForAuthenticatedUserResponseBody []components.Repository
-
-/*
 ReposListForAuthenticatedUserResponse is a response for ReposListForAuthenticatedUser
 
 https://developer.github.com/v3/repos/#list-repositories-for-the-authenticated-user
@@ -13843,7 +13675,7 @@ https://developer.github.com/v3/repos/#list-repositories-for-the-authenticated-u
 type ReposListForAuthenticatedUserResponse struct {
 	response
 	request *ReposListForAuthenticatedUserReq
-	Data    ReposListForAuthenticatedUserResponseBody
+	Data    []components.Repository
 }
 
 /*
@@ -13867,7 +13699,7 @@ func ReposListForOrg(ctx context.Context, req *ReposListForOrgReq, opt ...Reques
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposListForOrgResponseBody{}
+	resp.Data = []components.MinimalRepository{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -14023,13 +13855,6 @@ func (r *ReposListForOrgReq) Rel(link RelName, resp *ReposListForOrgResponse) bo
 }
 
 /*
-ReposListForOrgResponseBody is a response body for ReposListForOrg
-
-https://developer.github.com/v3/repos/#list-organization-repositories
-*/
-type ReposListForOrgResponseBody []components.MinimalRepository
-
-/*
 ReposListForOrgResponse is a response for ReposListForOrg
 
 https://developer.github.com/v3/repos/#list-organization-repositories
@@ -14037,7 +13862,7 @@ https://developer.github.com/v3/repos/#list-organization-repositories
 type ReposListForOrgResponse struct {
 	response
 	request *ReposListForOrgReq
-	Data    ReposListForOrgResponseBody
+	Data    []components.MinimalRepository
 }
 
 /*
@@ -14061,7 +13886,7 @@ func ReposListForUser(ctx context.Context, req *ReposListForUserReq, opt ...Requ
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposListForUserResponseBody{}
+	resp.Data = []components.MinimalRepository{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -14198,13 +14023,6 @@ func (r *ReposListForUserReq) Rel(link RelName, resp *ReposListForUserResponse) 
 }
 
 /*
-ReposListForUserResponseBody is a response body for ReposListForUser
-
-https://developer.github.com/v3/repos/#list-repositories-for-a-user
-*/
-type ReposListForUserResponseBody []components.MinimalRepository
-
-/*
 ReposListForUserResponse is a response for ReposListForUser
 
 https://developer.github.com/v3/repos/#list-repositories-for-a-user
@@ -14212,7 +14030,7 @@ https://developer.github.com/v3/repos/#list-repositories-for-a-user
 type ReposListForUserResponse struct {
 	response
 	request *ReposListForUserReq
-	Data    ReposListForUserResponseBody
+	Data    []components.MinimalRepository
 }
 
 /*
@@ -14236,7 +14054,7 @@ func ReposListForks(ctx context.Context, req *ReposListForksReq, opt ...RequestO
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposListForksResponseBody{}
+	resp.Data = []components.MinimalRepository{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -14344,13 +14162,6 @@ func (r *ReposListForksReq) Rel(link RelName, resp *ReposListForksResponse) bool
 }
 
 /*
-ReposListForksResponseBody is a response body for ReposListForks
-
-https://developer.github.com/v3/repos/forks/#list-forks
-*/
-type ReposListForksResponseBody []components.MinimalRepository
-
-/*
 ReposListForksResponse is a response for ReposListForks
 
 https://developer.github.com/v3/repos/forks/#list-forks
@@ -14358,7 +14169,7 @@ https://developer.github.com/v3/repos/forks/#list-forks
 type ReposListForksResponse struct {
 	response
 	request *ReposListForksReq
-	Data    ReposListForksResponseBody
+	Data    []components.MinimalRepository
 }
 
 /*
@@ -14382,7 +14193,7 @@ func ReposListInvitations(ctx context.Context, req *ReposListInvitationsReq, opt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposListInvitationsResponseBody{}
+	resp.Data = []components.RepositoryInvitation{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -14484,13 +14295,6 @@ func (r *ReposListInvitationsReq) Rel(link RelName, resp *ReposListInvitationsRe
 }
 
 /*
-ReposListInvitationsResponseBody is a response body for ReposListInvitations
-
-https://developer.github.com/v3/repos/invitations/#list-repository-invitations
-*/
-type ReposListInvitationsResponseBody []components.RepositoryInvitation
-
-/*
 ReposListInvitationsResponse is a response for ReposListInvitations
 
 https://developer.github.com/v3/repos/invitations/#list-repository-invitations
@@ -14498,7 +14302,7 @@ https://developer.github.com/v3/repos/invitations/#list-repository-invitations
 type ReposListInvitationsResponse struct {
 	response
 	request *ReposListInvitationsReq
-	Data    ReposListInvitationsResponseBody
+	Data    []components.RepositoryInvitation
 }
 
 /*
@@ -14522,7 +14326,7 @@ func ReposListInvitationsForAuthenticatedUser(ctx context.Context, req *ReposLis
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposListInvitationsForAuthenticatedUserResponseBody{}
+	resp.Data = []components.RepositoryInvitation{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -14622,13 +14426,6 @@ func (r *ReposListInvitationsForAuthenticatedUserReq) Rel(link RelName, resp *Re
 }
 
 /*
-ReposListInvitationsForAuthenticatedUserResponseBody is a response body for ReposListInvitationsForAuthenticatedUser
-
-https://developer.github.com/v3/repos/invitations/#list-repository-invitations-for-the-authenticated-user
-*/
-type ReposListInvitationsForAuthenticatedUserResponseBody []components.RepositoryInvitation
-
-/*
 ReposListInvitationsForAuthenticatedUserResponse is a response for ReposListInvitationsForAuthenticatedUser
 
 https://developer.github.com/v3/repos/invitations/#list-repository-invitations-for-the-authenticated-user
@@ -14636,7 +14433,7 @@ https://developer.github.com/v3/repos/invitations/#list-repository-invitations-f
 type ReposListInvitationsForAuthenticatedUserResponse struct {
 	response
 	request *ReposListInvitationsForAuthenticatedUserReq
-	Data    ReposListInvitationsForAuthenticatedUserResponseBody
+	Data    []components.RepositoryInvitation
 }
 
 /*
@@ -14781,7 +14578,7 @@ func ReposListPagesBuilds(ctx context.Context, req *ReposListPagesBuildsReq, opt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposListPagesBuildsResponseBody{}
+	resp.Data = []components.PageBuild{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -14883,13 +14680,6 @@ func (r *ReposListPagesBuildsReq) Rel(link RelName, resp *ReposListPagesBuildsRe
 }
 
 /*
-ReposListPagesBuildsResponseBody is a response body for ReposListPagesBuilds
-
-https://developer.github.com/v3/repos/pages/#list-github-pages-builds
-*/
-type ReposListPagesBuildsResponseBody []components.PageBuild
-
-/*
 ReposListPagesBuildsResponse is a response for ReposListPagesBuilds
 
 https://developer.github.com/v3/repos/pages/#list-github-pages-builds
@@ -14897,7 +14687,7 @@ https://developer.github.com/v3/repos/pages/#list-github-pages-builds
 type ReposListPagesBuildsResponse struct {
 	response
 	request *ReposListPagesBuildsReq
-	Data    ReposListPagesBuildsResponseBody
+	Data    []components.PageBuild
 }
 
 /*
@@ -14921,7 +14711,7 @@ func ReposListPublic(ctx context.Context, req *ReposListPublicReq, opt ...Reques
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposListPublicResponseBody{}
+	resp.Data = []components.MinimalRepository{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -15029,13 +14819,6 @@ func (r *ReposListPublicReq) Rel(link RelName, resp *ReposListPublicResponse) bo
 }
 
 /*
-ReposListPublicResponseBody is a response body for ReposListPublic
-
-https://developer.github.com/v3/repos/#list-public-repositories
-*/
-type ReposListPublicResponseBody []components.MinimalRepository
-
-/*
 ReposListPublicResponse is a response for ReposListPublic
 
 https://developer.github.com/v3/repos/#list-public-repositories
@@ -15043,7 +14826,7 @@ https://developer.github.com/v3/repos/#list-public-repositories
 type ReposListPublicResponse struct {
 	response
 	request *ReposListPublicReq
-	Data    ReposListPublicResponseBody
+	Data    []components.MinimalRepository
 }
 
 /*
@@ -15067,7 +14850,7 @@ func ReposListPullRequestsAssociatedWithCommit(ctx context.Context, req *ReposLi
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposListPullRequestsAssociatedWithCommitResponseBody{}
+	resp.Data = []components.PullRequestSimple{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -15187,13 +14970,6 @@ func (r *ReposListPullRequestsAssociatedWithCommitReq) Rel(link RelName, resp *R
 }
 
 /*
-ReposListPullRequestsAssociatedWithCommitResponseBody is a response body for ReposListPullRequestsAssociatedWithCommit
-
-https://developer.github.com/v3/repos/commits/#list-pull-requests-associated-with-a-commit
-*/
-type ReposListPullRequestsAssociatedWithCommitResponseBody []components.PullRequestSimple
-
-/*
 ReposListPullRequestsAssociatedWithCommitResponse is a response for ReposListPullRequestsAssociatedWithCommit
 
 https://developer.github.com/v3/repos/commits/#list-pull-requests-associated-with-a-commit
@@ -15201,7 +14977,7 @@ https://developer.github.com/v3/repos/commits/#list-pull-requests-associated-wit
 type ReposListPullRequestsAssociatedWithCommitResponse struct {
 	response
 	request *ReposListPullRequestsAssociatedWithCommitReq
-	Data    ReposListPullRequestsAssociatedWithCommitResponseBody
+	Data    []components.PullRequestSimple
 }
 
 /*
@@ -15225,7 +15001,7 @@ func ReposListReleaseAssets(ctx context.Context, req *ReposListReleaseAssetsReq,
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposListReleaseAssetsResponseBody{}
+	resp.Data = []components.ReleaseAsset{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -15330,13 +15106,6 @@ func (r *ReposListReleaseAssetsReq) Rel(link RelName, resp *ReposListReleaseAsse
 }
 
 /*
-ReposListReleaseAssetsResponseBody is a response body for ReposListReleaseAssets
-
-https://developer.github.com/v3/repos/releases/#list-release-assets
-*/
-type ReposListReleaseAssetsResponseBody []components.ReleaseAsset
-
-/*
 ReposListReleaseAssetsResponse is a response for ReposListReleaseAssets
 
 https://developer.github.com/v3/repos/releases/#list-release-assets
@@ -15344,7 +15113,7 @@ https://developer.github.com/v3/repos/releases/#list-release-assets
 type ReposListReleaseAssetsResponse struct {
 	response
 	request *ReposListReleaseAssetsReq
-	Data    ReposListReleaseAssetsResponseBody
+	Data    []components.ReleaseAsset
 }
 
 /*
@@ -15368,7 +15137,7 @@ func ReposListReleases(ctx context.Context, req *ReposListReleasesReq, opt ...Re
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposListReleasesResponseBody{}
+	resp.Data = []components.Release{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -15470,13 +15239,6 @@ func (r *ReposListReleasesReq) Rel(link RelName, resp *ReposListReleasesResponse
 }
 
 /*
-ReposListReleasesResponseBody is a response body for ReposListReleases
-
-https://developer.github.com/v3/repos/releases/#list-releases
-*/
-type ReposListReleasesResponseBody []components.Release
-
-/*
 ReposListReleasesResponse is a response for ReposListReleases
 
 https://developer.github.com/v3/repos/releases/#list-releases
@@ -15484,7 +15246,7 @@ https://developer.github.com/v3/repos/releases/#list-releases
 type ReposListReleasesResponse struct {
 	response
 	request *ReposListReleasesReq
-	Data    ReposListReleasesResponseBody
+	Data    []components.Release
 }
 
 /*
@@ -15508,7 +15270,7 @@ func ReposListTags(ctx context.Context, req *ReposListTagsReq, opt ...RequestOpt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposListTagsResponseBody{}
+	resp.Data = []components.Tag{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -15610,13 +15372,6 @@ func (r *ReposListTagsReq) Rel(link RelName, resp *ReposListTagsResponse) bool {
 }
 
 /*
-ReposListTagsResponseBody is a response body for ReposListTags
-
-https://developer.github.com/v3/repos/#list-repository-tags
-*/
-type ReposListTagsResponseBody []components.Tag
-
-/*
 ReposListTagsResponse is a response for ReposListTags
 
 https://developer.github.com/v3/repos/#list-repository-tags
@@ -15624,7 +15379,7 @@ https://developer.github.com/v3/repos/#list-repository-tags
 type ReposListTagsResponse struct {
 	response
 	request *ReposListTagsReq
-	Data    ReposListTagsResponseBody
+	Data    []components.Tag
 }
 
 /*
@@ -15648,7 +15403,7 @@ func ReposListTeams(ctx context.Context, req *ReposListTeamsReq, opt ...RequestO
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposListTeamsResponseBody{}
+	resp.Data = []components.Team{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -15750,13 +15505,6 @@ func (r *ReposListTeamsReq) Rel(link RelName, resp *ReposListTeamsResponse) bool
 }
 
 /*
-ReposListTeamsResponseBody is a response body for ReposListTeams
-
-https://developer.github.com/v3/repos/#list-repository-teams
-*/
-type ReposListTeamsResponseBody []components.Team
-
-/*
 ReposListTeamsResponse is a response for ReposListTeams
 
 https://developer.github.com/v3/repos/#list-repository-teams
@@ -15764,7 +15512,7 @@ https://developer.github.com/v3/repos/#list-repository-teams
 type ReposListTeamsResponse struct {
 	response
 	request *ReposListTeamsReq
-	Data    ReposListTeamsResponseBody
+	Data    []components.Team
 }
 
 /*
@@ -15788,7 +15536,7 @@ func ReposListWebhooks(ctx context.Context, req *ReposListWebhooksReq, opt ...Re
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposListWebhooksResponseBody{}
+	resp.Data = []components.Hook{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -15890,13 +15638,6 @@ func (r *ReposListWebhooksReq) Rel(link RelName, resp *ReposListWebhooksResponse
 }
 
 /*
-ReposListWebhooksResponseBody is a response body for ReposListWebhooks
-
-https://developer.github.com/v3/repos/hooks/#list-repository-webhooks
-*/
-type ReposListWebhooksResponseBody []components.Hook
-
-/*
 ReposListWebhooksResponse is a response for ReposListWebhooks
 
 https://developer.github.com/v3/repos/hooks/#list-repository-webhooks
@@ -15904,7 +15645,7 @@ https://developer.github.com/v3/repos/hooks/#list-repository-webhooks
 type ReposListWebhooksResponse struct {
 	response
 	request *ReposListWebhooksReq
-	Data    ReposListWebhooksResponseBody
+	Data    []components.Hook
 }
 
 /*
@@ -16195,7 +15936,7 @@ func ReposRemoveAppAccessRestrictions(ctx context.Context, req *ReposRemoveAppAc
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposRemoveAppAccessRestrictionsResponseBody{}
+	resp.Data = []components.Integration{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -16299,13 +16040,6 @@ https://developer.github.com/v3/repos/branches/#remove-app-access-restrictions
 type ReposRemoveAppAccessRestrictionsReqBody []string
 
 /*
-ReposRemoveAppAccessRestrictionsResponseBody is a response body for ReposRemoveAppAccessRestrictions
-
-https://developer.github.com/v3/repos/branches/#remove-app-access-restrictions
-*/
-type ReposRemoveAppAccessRestrictionsResponseBody []components.Integration
-
-/*
 ReposRemoveAppAccessRestrictionsResponse is a response for ReposRemoveAppAccessRestrictions
 
 https://developer.github.com/v3/repos/branches/#remove-app-access-restrictions
@@ -16313,7 +16047,7 @@ https://developer.github.com/v3/repos/branches/#remove-app-access-restrictions
 type ReposRemoveAppAccessRestrictionsResponse struct {
 	response
 	request *ReposRemoveAppAccessRestrictionsReq
-	Data    ReposRemoveAppAccessRestrictionsResponseBody
+	Data    []components.Integration
 }
 
 /*
@@ -16721,7 +16455,7 @@ func ReposRemoveTeamAccessRestrictions(ctx context.Context, req *ReposRemoveTeam
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposRemoveTeamAccessRestrictionsResponseBody{}
+	resp.Data = []components.Team{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -16825,13 +16559,6 @@ https://developer.github.com/v3/repos/branches/#remove-team-access-restrictions
 type ReposRemoveTeamAccessRestrictionsReqBody []string
 
 /*
-ReposRemoveTeamAccessRestrictionsResponseBody is a response body for ReposRemoveTeamAccessRestrictions
-
-https://developer.github.com/v3/repos/branches/#remove-team-access-restrictions
-*/
-type ReposRemoveTeamAccessRestrictionsResponseBody []components.Team
-
-/*
 ReposRemoveTeamAccessRestrictionsResponse is a response for ReposRemoveTeamAccessRestrictions
 
 https://developer.github.com/v3/repos/branches/#remove-team-access-restrictions
@@ -16839,7 +16566,7 @@ https://developer.github.com/v3/repos/branches/#remove-team-access-restrictions
 type ReposRemoveTeamAccessRestrictionsResponse struct {
 	response
 	request *ReposRemoveTeamAccessRestrictionsReq
-	Data    ReposRemoveTeamAccessRestrictionsResponseBody
+	Data    []components.Team
 }
 
 /*
@@ -16863,7 +16590,7 @@ func ReposRemoveUserAccessRestrictions(ctx context.Context, req *ReposRemoveUser
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposRemoveUserAccessRestrictionsResponseBody{}
+	resp.Data = []components.SimpleUser{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -16967,13 +16694,6 @@ https://developer.github.com/v3/repos/branches/#remove-user-access-restrictions
 type ReposRemoveUserAccessRestrictionsReqBody []string
 
 /*
-ReposRemoveUserAccessRestrictionsResponseBody is a response body for ReposRemoveUserAccessRestrictions
-
-https://developer.github.com/v3/repos/branches/#remove-user-access-restrictions
-*/
-type ReposRemoveUserAccessRestrictionsResponseBody []components.SimpleUser
-
-/*
 ReposRemoveUserAccessRestrictionsResponse is a response for ReposRemoveUserAccessRestrictions
 
 https://developer.github.com/v3/repos/branches/#remove-user-access-restrictions
@@ -16981,7 +16701,7 @@ https://developer.github.com/v3/repos/branches/#remove-user-access-restrictions
 type ReposRemoveUserAccessRestrictionsResponse struct {
 	response
 	request *ReposRemoveUserAccessRestrictionsReq
-	Data    ReposRemoveUserAccessRestrictionsResponseBody
+	Data    []components.SimpleUser
 }
 
 /*
@@ -17404,7 +17124,7 @@ func ReposSetAppAccessRestrictions(ctx context.Context, req *ReposSetAppAccessRe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposSetAppAccessRestrictionsResponseBody{}
+	resp.Data = []components.Integration{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -17508,13 +17228,6 @@ https://developer.github.com/v3/repos/branches/#set-app-access-restrictions
 type ReposSetAppAccessRestrictionsReqBody []string
 
 /*
-ReposSetAppAccessRestrictionsResponseBody is a response body for ReposSetAppAccessRestrictions
-
-https://developer.github.com/v3/repos/branches/#set-app-access-restrictions
-*/
-type ReposSetAppAccessRestrictionsResponseBody []components.Integration
-
-/*
 ReposSetAppAccessRestrictionsResponse is a response for ReposSetAppAccessRestrictions
 
 https://developer.github.com/v3/repos/branches/#set-app-access-restrictions
@@ -17522,7 +17235,7 @@ https://developer.github.com/v3/repos/branches/#set-app-access-restrictions
 type ReposSetAppAccessRestrictionsResponse struct {
 	response
 	request *ReposSetAppAccessRestrictionsReq
-	Data    ReposSetAppAccessRestrictionsResponseBody
+	Data    []components.Integration
 }
 
 /*
@@ -17688,7 +17401,7 @@ func ReposSetTeamAccessRestrictions(ctx context.Context, req *ReposSetTeamAccess
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposSetTeamAccessRestrictionsResponseBody{}
+	resp.Data = []components.Team{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -17792,13 +17505,6 @@ https://developer.github.com/v3/repos/branches/#set-team-access-restrictions
 type ReposSetTeamAccessRestrictionsReqBody []string
 
 /*
-ReposSetTeamAccessRestrictionsResponseBody is a response body for ReposSetTeamAccessRestrictions
-
-https://developer.github.com/v3/repos/branches/#set-team-access-restrictions
-*/
-type ReposSetTeamAccessRestrictionsResponseBody []components.Team
-
-/*
 ReposSetTeamAccessRestrictionsResponse is a response for ReposSetTeamAccessRestrictions
 
 https://developer.github.com/v3/repos/branches/#set-team-access-restrictions
@@ -17806,7 +17512,7 @@ https://developer.github.com/v3/repos/branches/#set-team-access-restrictions
 type ReposSetTeamAccessRestrictionsResponse struct {
 	response
 	request *ReposSetTeamAccessRestrictionsReq
-	Data    ReposSetTeamAccessRestrictionsResponseBody
+	Data    []components.Team
 }
 
 /*
@@ -17830,7 +17536,7 @@ func ReposSetUserAccessRestrictions(ctx context.Context, req *ReposSetUserAccess
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ReposSetUserAccessRestrictionsResponseBody{}
+	resp.Data = []components.SimpleUser{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -17934,13 +17640,6 @@ https://developer.github.com/v3/repos/branches/#set-user-access-restrictions
 type ReposSetUserAccessRestrictionsReqBody []string
 
 /*
-ReposSetUserAccessRestrictionsResponseBody is a response body for ReposSetUserAccessRestrictions
-
-https://developer.github.com/v3/repos/branches/#set-user-access-restrictions
-*/
-type ReposSetUserAccessRestrictionsResponseBody []components.SimpleUser
-
-/*
 ReposSetUserAccessRestrictionsResponse is a response for ReposSetUserAccessRestrictions
 
 https://developer.github.com/v3/repos/branches/#set-user-access-restrictions
@@ -17948,7 +17647,7 @@ https://developer.github.com/v3/repos/branches/#set-user-access-restrictions
 type ReposSetUserAccessRestrictionsResponse struct {
 	response
 	request *ReposSetUserAccessRestrictionsReq
-	Data    ReposSetUserAccessRestrictionsResponseBody
+	Data    []components.SimpleUser
 }
 
 /*

--- a/zz_scim_gen.go
+++ b/zz_scim_gen.go
@@ -153,7 +153,7 @@ func ScimGetProvisioningInformationForUser(ctx context.Context, req *ScimGetProv
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ScimGetProvisioningInformationForUserResponseBody{}
+	resp.Data = components.ScimUser{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -245,13 +245,6 @@ func (r *ScimGetProvisioningInformationForUserReq) Rel(link RelName, resp *ScimG
 }
 
 /*
-ScimGetProvisioningInformationForUserResponseBody is a response body for ScimGetProvisioningInformationForUser
-
-https://developer.github.com/v3/scim/#get-scim-provisioning-information-for-a-user
-*/
-type ScimGetProvisioningInformationForUserResponseBody components.ScimUser
-
-/*
 ScimGetProvisioningInformationForUserResponse is a response for ScimGetProvisioningInformationForUser
 
 https://developer.github.com/v3/scim/#get-scim-provisioning-information-for-a-user
@@ -259,7 +252,7 @@ https://developer.github.com/v3/scim/#get-scim-provisioning-information-for-a-us
 type ScimGetProvisioningInformationForUserResponse struct {
 	response
 	request *ScimGetProvisioningInformationForUserReq
-	Data    ScimGetProvisioningInformationForUserResponseBody
+	Data    components.ScimUser
 }
 
 /*
@@ -283,7 +276,7 @@ func ScimListProvisionedIdentities(ctx context.Context, req *ScimListProvisioned
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ScimListProvisionedIdentitiesResponseBody{}
+	resp.Data = components.ScimUserList{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -402,13 +395,6 @@ func (r *ScimListProvisionedIdentitiesReq) Rel(link RelName, resp *ScimListProvi
 }
 
 /*
-ScimListProvisionedIdentitiesResponseBody is a response body for ScimListProvisionedIdentities
-
-https://developer.github.com/v3/scim/#list-scim-provisioned-identities
-*/
-type ScimListProvisionedIdentitiesResponseBody components.ScimUserList
-
-/*
 ScimListProvisionedIdentitiesResponse is a response for ScimListProvisionedIdentities
 
 https://developer.github.com/v3/scim/#list-scim-provisioned-identities
@@ -416,7 +402,7 @@ https://developer.github.com/v3/scim/#list-scim-provisioned-identities
 type ScimListProvisionedIdentitiesResponse struct {
 	response
 	request *ScimListProvisionedIdentitiesReq
-	Data    ScimListProvisionedIdentitiesResponseBody
+	Data    components.ScimUserList
 }
 
 /*
@@ -440,7 +426,7 @@ func ScimProvisionAndInviteUser(ctx context.Context, req *ScimProvisionAndInvite
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ScimProvisionAndInviteUserResponseBody{}
+	resp.Data = components.ScimUser{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -566,13 +552,6 @@ type ScimProvisionAndInviteUserReqBody struct {
 }
 
 /*
-ScimProvisionAndInviteUserResponseBody is a response body for ScimProvisionAndInviteUser
-
-https://developer.github.com/v3/scim/#provision-and-invite-a-scim-user
-*/
-type ScimProvisionAndInviteUserResponseBody components.ScimUser
-
-/*
 ScimProvisionAndInviteUserResponse is a response for ScimProvisionAndInviteUser
 
 https://developer.github.com/v3/scim/#provision-and-invite-a-scim-user
@@ -580,7 +559,7 @@ https://developer.github.com/v3/scim/#provision-and-invite-a-scim-user
 type ScimProvisionAndInviteUserResponse struct {
 	response
 	request *ScimProvisionAndInviteUserReq
-	Data    ScimProvisionAndInviteUserResponseBody
+	Data    components.ScimUser
 }
 
 /*
@@ -604,7 +583,7 @@ func ScimSetInformationForProvisionedUser(ctx context.Context, req *ScimSetInfor
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ScimSetInformationForProvisionedUserResponseBody{}
+	resp.Data = components.ScimUser{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -733,13 +712,6 @@ type ScimSetInformationForProvisionedUserReqBody struct {
 }
 
 /*
-ScimSetInformationForProvisionedUserResponseBody is a response body for ScimSetInformationForProvisionedUser
-
-https://developer.github.com/v3/scim/#set-scim-information-for-a-provisioned-user
-*/
-type ScimSetInformationForProvisionedUserResponseBody components.ScimUser
-
-/*
 ScimSetInformationForProvisionedUserResponse is a response for ScimSetInformationForProvisionedUser
 
 https://developer.github.com/v3/scim/#set-scim-information-for-a-provisioned-user
@@ -747,7 +719,7 @@ https://developer.github.com/v3/scim/#set-scim-information-for-a-provisioned-use
 type ScimSetInformationForProvisionedUserResponse struct {
 	response
 	request *ScimSetInformationForProvisionedUserReq
-	Data    ScimSetInformationForProvisionedUserResponseBody
+	Data    components.ScimUser
 }
 
 /*
@@ -771,7 +743,7 @@ func ScimUpdateAttributeForUser(ctx context.Context, req *ScimUpdateAttributeFor
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = ScimUpdateAttributeForUserResponseBody{}
+	resp.Data = components.ScimUser{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -895,13 +867,6 @@ type ScimUpdateAttributeForUserReqBody struct {
 }
 
 /*
-ScimUpdateAttributeForUserResponseBody is a response body for ScimUpdateAttributeForUser
-
-https://developer.github.com/v3/scim/#update-an-attribute-for-a-scim-user
-*/
-type ScimUpdateAttributeForUserResponseBody components.ScimUser
-
-/*
 ScimUpdateAttributeForUserResponse is a response for ScimUpdateAttributeForUser
 
 https://developer.github.com/v3/scim/#update-an-attribute-for-a-scim-user
@@ -909,5 +874,5 @@ https://developer.github.com/v3/scim/#update-an-attribute-for-a-scim-user
 type ScimUpdateAttributeForUserResponse struct {
 	response
 	request *ScimUpdateAttributeForUserReq
-	Data    ScimUpdateAttributeForUserResponseBody
+	Data    components.ScimUser
 }

--- a/zz_teams_gen.go
+++ b/zz_teams_gen.go
@@ -4555,7 +4555,7 @@ func TeamsList(ctx context.Context, req *TeamsListReq, opt ...RequestOption) (*T
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsListResponseBody{}
+	resp.Data = []components.Team{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -4656,13 +4656,6 @@ func (r *TeamsListReq) Rel(link RelName, resp *TeamsListResponse) bool {
 }
 
 /*
-TeamsListResponseBody is a response body for TeamsList
-
-https://developer.github.com/v3/teams/#list-teams
-*/
-type TeamsListResponseBody []components.Team
-
-/*
 TeamsListResponse is a response for TeamsList
 
 https://developer.github.com/v3/teams/#list-teams
@@ -4670,7 +4663,7 @@ https://developer.github.com/v3/teams/#list-teams
 type TeamsListResponse struct {
 	response
 	request *TeamsListReq
-	Data    TeamsListResponseBody
+	Data    []components.Team
 }
 
 /*
@@ -4694,7 +4687,7 @@ func TeamsListChildInOrg(ctx context.Context, req *TeamsListChildInOrgReq, opt .
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsListChildInOrgResponseBody{}
+	resp.Data = []components.Team{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -4798,13 +4791,6 @@ func (r *TeamsListChildInOrgReq) Rel(link RelName, resp *TeamsListChildInOrgResp
 }
 
 /*
-TeamsListChildInOrgResponseBody is a response body for TeamsListChildInOrg
-
-https://developer.github.com/v3/teams/#list-child-teams
-*/
-type TeamsListChildInOrgResponseBody []components.Team
-
-/*
 TeamsListChildInOrgResponse is a response for TeamsListChildInOrg
 
 https://developer.github.com/v3/teams/#list-child-teams
@@ -4812,7 +4798,7 @@ https://developer.github.com/v3/teams/#list-child-teams
 type TeamsListChildInOrgResponse struct {
 	response
 	request *TeamsListChildInOrgReq
-	Data    TeamsListChildInOrgResponseBody
+	Data    []components.Team
 }
 
 /*
@@ -4836,7 +4822,7 @@ func TeamsListChildLegacy(ctx context.Context, req *TeamsListChildLegacyReq, opt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsListChildLegacyResponseBody{}
+	resp.Data = []components.Team{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -4937,13 +4923,6 @@ func (r *TeamsListChildLegacyReq) Rel(link RelName, resp *TeamsListChildLegacyRe
 }
 
 /*
-TeamsListChildLegacyResponseBody is a response body for TeamsListChildLegacy
-
-https://developer.github.com/v3/teams/#list-child-teams-legacy
-*/
-type TeamsListChildLegacyResponseBody []components.Team
-
-/*
 TeamsListChildLegacyResponse is a response for TeamsListChildLegacy
 
 https://developer.github.com/v3/teams/#list-child-teams-legacy
@@ -4951,7 +4930,7 @@ https://developer.github.com/v3/teams/#list-child-teams-legacy
 type TeamsListChildLegacyResponse struct {
 	response
 	request *TeamsListChildLegacyReq
-	Data    TeamsListChildLegacyResponseBody
+	Data    []components.Team
 }
 
 /*
@@ -4975,7 +4954,7 @@ func TeamsListDiscussionCommentsInOrg(ctx context.Context, req *TeamsListDiscuss
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsListDiscussionCommentsInOrgResponseBody{}
+	resp.Data = []components.TeamDiscussionComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -5100,13 +5079,6 @@ func (r *TeamsListDiscussionCommentsInOrgReq) Rel(link RelName, resp *TeamsListD
 }
 
 /*
-TeamsListDiscussionCommentsInOrgResponseBody is a response body for TeamsListDiscussionCommentsInOrg
-
-https://developer.github.com/v3/teams/discussion_comments/#list-discussion-comments
-*/
-type TeamsListDiscussionCommentsInOrgResponseBody []components.TeamDiscussionComment
-
-/*
 TeamsListDiscussionCommentsInOrgResponse is a response for TeamsListDiscussionCommentsInOrg
 
 https://developer.github.com/v3/teams/discussion_comments/#list-discussion-comments
@@ -5114,7 +5086,7 @@ https://developer.github.com/v3/teams/discussion_comments/#list-discussion-comme
 type TeamsListDiscussionCommentsInOrgResponse struct {
 	response
 	request *TeamsListDiscussionCommentsInOrgReq
-	Data    TeamsListDiscussionCommentsInOrgResponseBody
+	Data    []components.TeamDiscussionComment
 }
 
 /*
@@ -5138,7 +5110,7 @@ func TeamsListDiscussionCommentsLegacy(ctx context.Context, req *TeamsListDiscus
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsListDiscussionCommentsLegacyResponseBody{}
+	resp.Data = []components.TeamDiscussionComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -5260,13 +5232,6 @@ func (r *TeamsListDiscussionCommentsLegacyReq) Rel(link RelName, resp *TeamsList
 }
 
 /*
-TeamsListDiscussionCommentsLegacyResponseBody is a response body for TeamsListDiscussionCommentsLegacy
-
-https://developer.github.com/v3/teams/discussion_comments/#list-discussion-comments-legacy
-*/
-type TeamsListDiscussionCommentsLegacyResponseBody []components.TeamDiscussionComment
-
-/*
 TeamsListDiscussionCommentsLegacyResponse is a response for TeamsListDiscussionCommentsLegacy
 
 https://developer.github.com/v3/teams/discussion_comments/#list-discussion-comments-legacy
@@ -5274,7 +5239,7 @@ https://developer.github.com/v3/teams/discussion_comments/#list-discussion-comme
 type TeamsListDiscussionCommentsLegacyResponse struct {
 	response
 	request *TeamsListDiscussionCommentsLegacyReq
-	Data    TeamsListDiscussionCommentsLegacyResponseBody
+	Data    []components.TeamDiscussionComment
 }
 
 /*
@@ -5298,7 +5263,7 @@ func TeamsListDiscussionsInOrg(ctx context.Context, req *TeamsListDiscussionsInO
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsListDiscussionsInOrgResponseBody{}
+	resp.Data = []components.TeamDiscussion{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -5422,13 +5387,6 @@ func (r *TeamsListDiscussionsInOrgReq) Rel(link RelName, resp *TeamsListDiscussi
 }
 
 /*
-TeamsListDiscussionsInOrgResponseBody is a response body for TeamsListDiscussionsInOrg
-
-https://developer.github.com/v3/teams/discussions/#list-discussions
-*/
-type TeamsListDiscussionsInOrgResponseBody []components.TeamDiscussion
-
-/*
 TeamsListDiscussionsInOrgResponse is a response for TeamsListDiscussionsInOrg
 
 https://developer.github.com/v3/teams/discussions/#list-discussions
@@ -5436,7 +5394,7 @@ https://developer.github.com/v3/teams/discussions/#list-discussions
 type TeamsListDiscussionsInOrgResponse struct {
 	response
 	request *TeamsListDiscussionsInOrgReq
-	Data    TeamsListDiscussionsInOrgResponseBody
+	Data    []components.TeamDiscussion
 }
 
 /*
@@ -5460,7 +5418,7 @@ func TeamsListDiscussionsLegacy(ctx context.Context, req *TeamsListDiscussionsLe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsListDiscussionsLegacyResponseBody{}
+	resp.Data = []components.TeamDiscussion{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -5581,13 +5539,6 @@ func (r *TeamsListDiscussionsLegacyReq) Rel(link RelName, resp *TeamsListDiscuss
 }
 
 /*
-TeamsListDiscussionsLegacyResponseBody is a response body for TeamsListDiscussionsLegacy
-
-https://developer.github.com/v3/teams/discussions/#list-discussions-legacy
-*/
-type TeamsListDiscussionsLegacyResponseBody []components.TeamDiscussion
-
-/*
 TeamsListDiscussionsLegacyResponse is a response for TeamsListDiscussionsLegacy
 
 https://developer.github.com/v3/teams/discussions/#list-discussions-legacy
@@ -5595,7 +5546,7 @@ https://developer.github.com/v3/teams/discussions/#list-discussions-legacy
 type TeamsListDiscussionsLegacyResponse struct {
 	response
 	request *TeamsListDiscussionsLegacyReq
-	Data    TeamsListDiscussionsLegacyResponseBody
+	Data    []components.TeamDiscussion
 }
 
 /*
@@ -5619,7 +5570,7 @@ func TeamsListForAuthenticatedUser(ctx context.Context, req *TeamsListForAuthent
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsListForAuthenticatedUserResponseBody{}
+	resp.Data = []components.TeamFull{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -5719,13 +5670,6 @@ func (r *TeamsListForAuthenticatedUserReq) Rel(link RelName, resp *TeamsListForA
 }
 
 /*
-TeamsListForAuthenticatedUserResponseBody is a response body for TeamsListForAuthenticatedUser
-
-https://developer.github.com/v3/teams/#list-teams-for-the-authenticated-user
-*/
-type TeamsListForAuthenticatedUserResponseBody []components.TeamFull
-
-/*
 TeamsListForAuthenticatedUserResponse is a response for TeamsListForAuthenticatedUser
 
 https://developer.github.com/v3/teams/#list-teams-for-the-authenticated-user
@@ -5733,7 +5677,7 @@ https://developer.github.com/v3/teams/#list-teams-for-the-authenticated-user
 type TeamsListForAuthenticatedUserResponse struct {
 	response
 	request *TeamsListForAuthenticatedUserReq
-	Data    TeamsListForAuthenticatedUserResponseBody
+	Data    []components.TeamFull
 }
 
 /*
@@ -6132,7 +6076,7 @@ func TeamsListMembersInOrg(ctx context.Context, req *TeamsListMembersInOrgReq, o
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsListMembersInOrgResponseBody{}
+	resp.Data = []components.SimpleUser{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -6247,13 +6191,6 @@ func (r *TeamsListMembersInOrgReq) Rel(link RelName, resp *TeamsListMembersInOrg
 }
 
 /*
-TeamsListMembersInOrgResponseBody is a response body for TeamsListMembersInOrg
-
-https://developer.github.com/v3/teams/members/#list-team-members
-*/
-type TeamsListMembersInOrgResponseBody []components.SimpleUser
-
-/*
 TeamsListMembersInOrgResponse is a response for TeamsListMembersInOrg
 
 https://developer.github.com/v3/teams/members/#list-team-members
@@ -6261,7 +6198,7 @@ https://developer.github.com/v3/teams/members/#list-team-members
 type TeamsListMembersInOrgResponse struct {
 	response
 	request *TeamsListMembersInOrgReq
-	Data    TeamsListMembersInOrgResponseBody
+	Data    []components.SimpleUser
 }
 
 /*
@@ -6285,7 +6222,7 @@ func TeamsListMembersLegacy(ctx context.Context, req *TeamsListMembersLegacyReq,
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsListMembersLegacyResponseBody{}
+	resp.Data = []components.SimpleUser{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -6397,13 +6334,6 @@ func (r *TeamsListMembersLegacyReq) Rel(link RelName, resp *TeamsListMembersLega
 }
 
 /*
-TeamsListMembersLegacyResponseBody is a response body for TeamsListMembersLegacy
-
-https://developer.github.com/v3/teams/members/#list-team-members-legacy
-*/
-type TeamsListMembersLegacyResponseBody []components.SimpleUser
-
-/*
 TeamsListMembersLegacyResponse is a response for TeamsListMembersLegacy
 
 https://developer.github.com/v3/teams/members/#list-team-members-legacy
@@ -6411,7 +6341,7 @@ https://developer.github.com/v3/teams/members/#list-team-members-legacy
 type TeamsListMembersLegacyResponse struct {
 	response
 	request *TeamsListMembersLegacyReq
-	Data    TeamsListMembersLegacyResponseBody
+	Data    []components.SimpleUser
 }
 
 /*
@@ -6435,7 +6365,7 @@ func TeamsListPendingInvitationsInOrg(ctx context.Context, req *TeamsListPending
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsListPendingInvitationsInOrgResponseBody{}
+	resp.Data = []components.OrganizationInvitation{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -6539,13 +6469,6 @@ func (r *TeamsListPendingInvitationsInOrgReq) Rel(link RelName, resp *TeamsListP
 }
 
 /*
-TeamsListPendingInvitationsInOrgResponseBody is a response body for TeamsListPendingInvitationsInOrg
-
-https://developer.github.com/v3/teams/members/#list-pending-team-invitations
-*/
-type TeamsListPendingInvitationsInOrgResponseBody []components.OrganizationInvitation
-
-/*
 TeamsListPendingInvitationsInOrgResponse is a response for TeamsListPendingInvitationsInOrg
 
 https://developer.github.com/v3/teams/members/#list-pending-team-invitations
@@ -6553,7 +6476,7 @@ https://developer.github.com/v3/teams/members/#list-pending-team-invitations
 type TeamsListPendingInvitationsInOrgResponse struct {
 	response
 	request *TeamsListPendingInvitationsInOrgReq
-	Data    TeamsListPendingInvitationsInOrgResponseBody
+	Data    []components.OrganizationInvitation
 }
 
 /*
@@ -6577,7 +6500,7 @@ func TeamsListPendingInvitationsLegacy(ctx context.Context, req *TeamsListPendin
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsListPendingInvitationsLegacyResponseBody{}
+	resp.Data = []components.OrganizationInvitation{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -6678,13 +6601,6 @@ func (r *TeamsListPendingInvitationsLegacyReq) Rel(link RelName, resp *TeamsList
 }
 
 /*
-TeamsListPendingInvitationsLegacyResponseBody is a response body for TeamsListPendingInvitationsLegacy
-
-https://developer.github.com/v3/teams/members/#list-pending-team-invitations-legacy
-*/
-type TeamsListPendingInvitationsLegacyResponseBody []components.OrganizationInvitation
-
-/*
 TeamsListPendingInvitationsLegacyResponse is a response for TeamsListPendingInvitationsLegacy
 
 https://developer.github.com/v3/teams/members/#list-pending-team-invitations-legacy
@@ -6692,7 +6608,7 @@ https://developer.github.com/v3/teams/members/#list-pending-team-invitations-leg
 type TeamsListPendingInvitationsLegacyResponse struct {
 	response
 	request *TeamsListPendingInvitationsLegacyReq
-	Data    TeamsListPendingInvitationsLegacyResponseBody
+	Data    []components.OrganizationInvitation
 }
 
 /*
@@ -6716,7 +6632,7 @@ func TeamsListProjectsInOrg(ctx context.Context, req *TeamsListProjectsInOrgReq,
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsListProjectsInOrgResponseBody{}
+	resp.Data = []components.TeamProject{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -6835,13 +6751,6 @@ func (r *TeamsListProjectsInOrgReq) Rel(link RelName, resp *TeamsListProjectsInO
 }
 
 /*
-TeamsListProjectsInOrgResponseBody is a response body for TeamsListProjectsInOrg
-
-https://developer.github.com/v3/teams/#list-team-projects
-*/
-type TeamsListProjectsInOrgResponseBody []components.TeamProject
-
-/*
 TeamsListProjectsInOrgResponse is a response for TeamsListProjectsInOrg
 
 https://developer.github.com/v3/teams/#list-team-projects
@@ -6849,7 +6758,7 @@ https://developer.github.com/v3/teams/#list-team-projects
 type TeamsListProjectsInOrgResponse struct {
 	response
 	request *TeamsListProjectsInOrgReq
-	Data    TeamsListProjectsInOrgResponseBody
+	Data    []components.TeamProject
 }
 
 /*
@@ -6873,7 +6782,7 @@ func TeamsListProjectsLegacy(ctx context.Context, req *TeamsListProjectsLegacyRe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsListProjectsLegacyResponseBody{}
+	resp.Data = []components.TeamProject{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -6989,13 +6898,6 @@ func (r *TeamsListProjectsLegacyReq) Rel(link RelName, resp *TeamsListProjectsLe
 }
 
 /*
-TeamsListProjectsLegacyResponseBody is a response body for TeamsListProjectsLegacy
-
-https://developer.github.com/v3/teams/#list-team-projects-legacy
-*/
-type TeamsListProjectsLegacyResponseBody []components.TeamProject
-
-/*
 TeamsListProjectsLegacyResponse is a response for TeamsListProjectsLegacy
 
 https://developer.github.com/v3/teams/#list-team-projects-legacy
@@ -7003,7 +6905,7 @@ https://developer.github.com/v3/teams/#list-team-projects-legacy
 type TeamsListProjectsLegacyResponse struct {
 	response
 	request *TeamsListProjectsLegacyReq
-	Data    TeamsListProjectsLegacyResponseBody
+	Data    []components.TeamProject
 }
 
 /*
@@ -7027,7 +6929,7 @@ func TeamsListReposInOrg(ctx context.Context, req *TeamsListReposInOrgReq, opt .
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsListReposInOrgResponseBody{}
+	resp.Data = []components.MinimalRepository{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -7131,13 +7033,6 @@ func (r *TeamsListReposInOrgReq) Rel(link RelName, resp *TeamsListReposInOrgResp
 }
 
 /*
-TeamsListReposInOrgResponseBody is a response body for TeamsListReposInOrg
-
-https://developer.github.com/v3/teams/#list-team-repositories
-*/
-type TeamsListReposInOrgResponseBody []components.MinimalRepository
-
-/*
 TeamsListReposInOrgResponse is a response for TeamsListReposInOrg
 
 https://developer.github.com/v3/teams/#list-team-repositories
@@ -7145,7 +7040,7 @@ https://developer.github.com/v3/teams/#list-team-repositories
 type TeamsListReposInOrgResponse struct {
 	response
 	request *TeamsListReposInOrgReq
-	Data    TeamsListReposInOrgResponseBody
+	Data    []components.MinimalRepository
 }
 
 /*
@@ -7169,7 +7064,7 @@ func TeamsListReposLegacy(ctx context.Context, req *TeamsListReposLegacyReq, opt
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsListReposLegacyResponseBody{}
+	resp.Data = []components.MinimalRepository{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -7270,13 +7165,6 @@ func (r *TeamsListReposLegacyReq) Rel(link RelName, resp *TeamsListReposLegacyRe
 }
 
 /*
-TeamsListReposLegacyResponseBody is a response body for TeamsListReposLegacy
-
-https://developer.github.com/v3/teams/#list-team-repositories-legacy
-*/
-type TeamsListReposLegacyResponseBody []components.MinimalRepository
-
-/*
 TeamsListReposLegacyResponse is a response for TeamsListReposLegacy
 
 https://developer.github.com/v3/teams/#list-team-repositories-legacy
@@ -7284,7 +7172,7 @@ https://developer.github.com/v3/teams/#list-team-repositories-legacy
 type TeamsListReposLegacyResponse struct {
 	response
 	request *TeamsListReposLegacyReq
-	Data    TeamsListReposLegacyResponseBody
+	Data    []components.MinimalRepository
 }
 
 /*

--- a/zz_teams_gen.go
+++ b/zz_teams_gen.go
@@ -151,7 +151,7 @@ func TeamsAddOrUpdateMembershipForUserInOrg(ctx context.Context, req *TeamsAddOr
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsAddOrUpdateMembershipForUserInOrgResponseBody{}
+	resp.Data = components.TeamMembership{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -265,13 +265,6 @@ type TeamsAddOrUpdateMembershipForUserInOrgReqBody struct {
 }
 
 /*
-TeamsAddOrUpdateMembershipForUserInOrgResponseBody is a response body for TeamsAddOrUpdateMembershipForUserInOrg
-
-https://developer.github.com/v3/teams/members/#add-or-update-team-membership-for-a-user
-*/
-type TeamsAddOrUpdateMembershipForUserInOrgResponseBody components.TeamMembership
-
-/*
 TeamsAddOrUpdateMembershipForUserInOrgResponse is a response for TeamsAddOrUpdateMembershipForUserInOrg
 
 https://developer.github.com/v3/teams/members/#add-or-update-team-membership-for-a-user
@@ -279,7 +272,7 @@ https://developer.github.com/v3/teams/members/#add-or-update-team-membership-for
 type TeamsAddOrUpdateMembershipForUserInOrgResponse struct {
 	response
 	request *TeamsAddOrUpdateMembershipForUserInOrgReq
-	Data    TeamsAddOrUpdateMembershipForUserInOrgResponseBody
+	Data    components.TeamMembership
 }
 
 /*
@@ -303,7 +296,7 @@ func TeamsAddOrUpdateMembershipForUserLegacy(ctx context.Context, req *TeamsAddO
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsAddOrUpdateMembershipForUserLegacyResponseBody{}
+	resp.Data = components.TeamMembership{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -414,13 +407,6 @@ type TeamsAddOrUpdateMembershipForUserLegacyReqBody struct {
 }
 
 /*
-TeamsAddOrUpdateMembershipForUserLegacyResponseBody is a response body for TeamsAddOrUpdateMembershipForUserLegacy
-
-https://developer.github.com/v3/teams/members/#add-or-update-team-membership-for-a-user-legacy
-*/
-type TeamsAddOrUpdateMembershipForUserLegacyResponseBody components.TeamMembership
-
-/*
 TeamsAddOrUpdateMembershipForUserLegacyResponse is a response for TeamsAddOrUpdateMembershipForUserLegacy
 
 https://developer.github.com/v3/teams/members/#add-or-update-team-membership-for-a-user-legacy
@@ -428,7 +414,7 @@ https://developer.github.com/v3/teams/members/#add-or-update-team-membership-for
 type TeamsAddOrUpdateMembershipForUserLegacyResponse struct {
 	response
 	request *TeamsAddOrUpdateMembershipForUserLegacyReq
-	Data    TeamsAddOrUpdateMembershipForUserLegacyResponseBody
+	Data    components.TeamMembership
 }
 
 /*
@@ -1058,7 +1044,7 @@ func TeamsCheckPermissionsForProjectInOrg(ctx context.Context, req *TeamsCheckPe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsCheckPermissionsForProjectInOrgResponseBody{}
+	resp.Data = components.TeamProject{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1166,13 +1152,6 @@ func (r *TeamsCheckPermissionsForProjectInOrgReq) Rel(link RelName, resp *TeamsC
 }
 
 /*
-TeamsCheckPermissionsForProjectInOrgResponseBody is a response body for TeamsCheckPermissionsForProjectInOrg
-
-https://developer.github.com/v3/teams/#check-team-permissions-for-a-project
-*/
-type TeamsCheckPermissionsForProjectInOrgResponseBody components.TeamProject
-
-/*
 TeamsCheckPermissionsForProjectInOrgResponse is a response for TeamsCheckPermissionsForProjectInOrg
 
 https://developer.github.com/v3/teams/#check-team-permissions-for-a-project
@@ -1180,7 +1159,7 @@ https://developer.github.com/v3/teams/#check-team-permissions-for-a-project
 type TeamsCheckPermissionsForProjectInOrgResponse struct {
 	response
 	request *TeamsCheckPermissionsForProjectInOrgReq
-	Data    TeamsCheckPermissionsForProjectInOrgResponseBody
+	Data    components.TeamProject
 }
 
 /*
@@ -1204,7 +1183,7 @@ func TeamsCheckPermissionsForProjectLegacy(ctx context.Context, req *TeamsCheckP
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsCheckPermissionsForProjectLegacyResponseBody{}
+	resp.Data = components.TeamProject{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1309,13 +1288,6 @@ func (r *TeamsCheckPermissionsForProjectLegacyReq) Rel(link RelName, resp *Teams
 }
 
 /*
-TeamsCheckPermissionsForProjectLegacyResponseBody is a response body for TeamsCheckPermissionsForProjectLegacy
-
-https://developer.github.com/v3/teams/#check-team-permissions-for-a-project-legacy
-*/
-type TeamsCheckPermissionsForProjectLegacyResponseBody components.TeamProject
-
-/*
 TeamsCheckPermissionsForProjectLegacyResponse is a response for TeamsCheckPermissionsForProjectLegacy
 
 https://developer.github.com/v3/teams/#check-team-permissions-for-a-project-legacy
@@ -1323,7 +1295,7 @@ https://developer.github.com/v3/teams/#check-team-permissions-for-a-project-lega
 type TeamsCheckPermissionsForProjectLegacyResponse struct {
 	response
 	request *TeamsCheckPermissionsForProjectLegacyReq
-	Data    TeamsCheckPermissionsForProjectLegacyResponseBody
+	Data    components.TeamProject
 }
 
 /*
@@ -1347,7 +1319,7 @@ func TeamsCheckPermissionsForRepoInOrg(ctx context.Context, req *TeamsCheckPermi
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsCheckPermissionsForRepoInOrgResponseBody{}
+	resp.Data = components.TeamRepository{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1441,13 +1413,6 @@ func (r *TeamsCheckPermissionsForRepoInOrgReq) Rel(link RelName, resp *TeamsChec
 }
 
 /*
-TeamsCheckPermissionsForRepoInOrgResponseBody is a response body for TeamsCheckPermissionsForRepoInOrg
-
-https://developer.github.com/v3/teams/#check-team-permissions-for-a-repository
-*/
-type TeamsCheckPermissionsForRepoInOrgResponseBody components.TeamRepository
-
-/*
 TeamsCheckPermissionsForRepoInOrgResponse is a response for TeamsCheckPermissionsForRepoInOrg
 
 https://developer.github.com/v3/teams/#check-team-permissions-for-a-repository
@@ -1455,7 +1420,7 @@ https://developer.github.com/v3/teams/#check-team-permissions-for-a-repository
 type TeamsCheckPermissionsForRepoInOrgResponse struct {
 	response
 	request *TeamsCheckPermissionsForRepoInOrgReq
-	Data    TeamsCheckPermissionsForRepoInOrgResponseBody
+	Data    components.TeamRepository
 }
 
 /*
@@ -1479,7 +1444,7 @@ func TeamsCheckPermissionsForRepoLegacy(ctx context.Context, req *TeamsCheckPerm
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsCheckPermissionsForRepoLegacyResponseBody{}
+	resp.Data = components.TeamRepository{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1570,13 +1535,6 @@ func (r *TeamsCheckPermissionsForRepoLegacyReq) Rel(link RelName, resp *TeamsChe
 }
 
 /*
-TeamsCheckPermissionsForRepoLegacyResponseBody is a response body for TeamsCheckPermissionsForRepoLegacy
-
-https://developer.github.com/v3/teams/#check-team-permissions-for-a-repository-legacy
-*/
-type TeamsCheckPermissionsForRepoLegacyResponseBody components.TeamRepository
-
-/*
 TeamsCheckPermissionsForRepoLegacyResponse is a response for TeamsCheckPermissionsForRepoLegacy
 
 https://developer.github.com/v3/teams/#check-team-permissions-for-a-repository-legacy
@@ -1584,7 +1542,7 @@ https://developer.github.com/v3/teams/#check-team-permissions-for-a-repository-l
 type TeamsCheckPermissionsForRepoLegacyResponse struct {
 	response
 	request *TeamsCheckPermissionsForRepoLegacyReq
-	Data    TeamsCheckPermissionsForRepoLegacyResponseBody
+	Data    components.TeamRepository
 }
 
 /*
@@ -1608,7 +1566,7 @@ func TeamsCreate(ctx context.Context, req *TeamsCreateReq, opt ...RequestOption)
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsCreateResponseBody{}
+	resp.Data = components.TeamFull{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1748,13 +1706,6 @@ type TeamsCreateReqBody struct {
 }
 
 /*
-TeamsCreateResponseBody is a response body for TeamsCreate
-
-https://developer.github.com/v3/teams/#create-a-team
-*/
-type TeamsCreateResponseBody components.TeamFull
-
-/*
 TeamsCreateResponse is a response for TeamsCreate
 
 https://developer.github.com/v3/teams/#create-a-team
@@ -1762,7 +1713,7 @@ https://developer.github.com/v3/teams/#create-a-team
 type TeamsCreateResponse struct {
 	response
 	request *TeamsCreateReq
-	Data    TeamsCreateResponseBody
+	Data    components.TeamFull
 }
 
 /*
@@ -1786,7 +1737,7 @@ func TeamsCreateDiscussionCommentInOrg(ctx context.Context, req *TeamsCreateDisc
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsCreateDiscussionCommentInOrgResponseBody{}
+	resp.Data = components.TeamDiscussionComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1908,13 +1859,6 @@ type TeamsCreateDiscussionCommentInOrgReqBody struct {
 }
 
 /*
-TeamsCreateDiscussionCommentInOrgResponseBody is a response body for TeamsCreateDiscussionCommentInOrg
-
-https://developer.github.com/v3/teams/discussion_comments/#create-a-discussion-comment
-*/
-type TeamsCreateDiscussionCommentInOrgResponseBody components.TeamDiscussionComment
-
-/*
 TeamsCreateDiscussionCommentInOrgResponse is a response for TeamsCreateDiscussionCommentInOrg
 
 https://developer.github.com/v3/teams/discussion_comments/#create-a-discussion-comment
@@ -1922,7 +1866,7 @@ https://developer.github.com/v3/teams/discussion_comments/#create-a-discussion-c
 type TeamsCreateDiscussionCommentInOrgResponse struct {
 	response
 	request *TeamsCreateDiscussionCommentInOrgReq
-	Data    TeamsCreateDiscussionCommentInOrgResponseBody
+	Data    components.TeamDiscussionComment
 }
 
 /*
@@ -1946,7 +1890,7 @@ func TeamsCreateDiscussionCommentLegacy(ctx context.Context, req *TeamsCreateDis
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsCreateDiscussionCommentLegacyResponseBody{}
+	resp.Data = components.TeamDiscussionComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2065,13 +2009,6 @@ type TeamsCreateDiscussionCommentLegacyReqBody struct {
 }
 
 /*
-TeamsCreateDiscussionCommentLegacyResponseBody is a response body for TeamsCreateDiscussionCommentLegacy
-
-https://developer.github.com/v3/teams/discussion_comments/#create-a-discussion-comment-legacy
-*/
-type TeamsCreateDiscussionCommentLegacyResponseBody components.TeamDiscussionComment
-
-/*
 TeamsCreateDiscussionCommentLegacyResponse is a response for TeamsCreateDiscussionCommentLegacy
 
 https://developer.github.com/v3/teams/discussion_comments/#create-a-discussion-comment-legacy
@@ -2079,7 +2016,7 @@ https://developer.github.com/v3/teams/discussion_comments/#create-a-discussion-c
 type TeamsCreateDiscussionCommentLegacyResponse struct {
 	response
 	request *TeamsCreateDiscussionCommentLegacyReq
-	Data    TeamsCreateDiscussionCommentLegacyResponseBody
+	Data    components.TeamDiscussionComment
 }
 
 /*
@@ -2103,7 +2040,7 @@ func TeamsCreateDiscussionInOrg(ctx context.Context, req *TeamsCreateDiscussionI
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsCreateDiscussionInOrgResponseBody{}
+	resp.Data = components.TeamDiscussion{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2234,13 +2171,6 @@ type TeamsCreateDiscussionInOrgReqBody struct {
 }
 
 /*
-TeamsCreateDiscussionInOrgResponseBody is a response body for TeamsCreateDiscussionInOrg
-
-https://developer.github.com/v3/teams/discussions/#create-a-discussion
-*/
-type TeamsCreateDiscussionInOrgResponseBody components.TeamDiscussion
-
-/*
 TeamsCreateDiscussionInOrgResponse is a response for TeamsCreateDiscussionInOrg
 
 https://developer.github.com/v3/teams/discussions/#create-a-discussion
@@ -2248,7 +2178,7 @@ https://developer.github.com/v3/teams/discussions/#create-a-discussion
 type TeamsCreateDiscussionInOrgResponse struct {
 	response
 	request *TeamsCreateDiscussionInOrgReq
-	Data    TeamsCreateDiscussionInOrgResponseBody
+	Data    components.TeamDiscussion
 }
 
 /*
@@ -2272,7 +2202,7 @@ func TeamsCreateDiscussionLegacy(ctx context.Context, req *TeamsCreateDiscussion
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsCreateDiscussionLegacyResponseBody{}
+	resp.Data = components.TeamDiscussion{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2400,13 +2330,6 @@ type TeamsCreateDiscussionLegacyReqBody struct {
 }
 
 /*
-TeamsCreateDiscussionLegacyResponseBody is a response body for TeamsCreateDiscussionLegacy
-
-https://developer.github.com/v3/teams/discussions/#create-a-discussion-legacy
-*/
-type TeamsCreateDiscussionLegacyResponseBody components.TeamDiscussion
-
-/*
 TeamsCreateDiscussionLegacyResponse is a response for TeamsCreateDiscussionLegacy
 
 https://developer.github.com/v3/teams/discussions/#create-a-discussion-legacy
@@ -2414,7 +2337,7 @@ https://developer.github.com/v3/teams/discussions/#create-a-discussion-legacy
 type TeamsCreateDiscussionLegacyResponse struct {
 	response
 	request *TeamsCreateDiscussionLegacyReq
-	Data    TeamsCreateDiscussionLegacyResponseBody
+	Data    components.TeamDiscussion
 }
 
 /*
@@ -2438,7 +2361,7 @@ func TeamsCreateOrUpdateIdpGroupConnectionsInOrg(ctx context.Context, req *Teams
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsCreateOrUpdateIdpGroupConnectionsInOrgResponseBody{}
+	resp.Data = components.GroupMapping{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2562,13 +2485,6 @@ type TeamsCreateOrUpdateIdpGroupConnectionsInOrgReqBody struct {
 }
 
 /*
-TeamsCreateOrUpdateIdpGroupConnectionsInOrgResponseBody is a response body for TeamsCreateOrUpdateIdpGroupConnectionsInOrg
-
-https://developer.github.com/v3/teams/team_sync/#create-or-update-idp-group-connections
-*/
-type TeamsCreateOrUpdateIdpGroupConnectionsInOrgResponseBody components.GroupMapping
-
-/*
 TeamsCreateOrUpdateIdpGroupConnectionsInOrgResponse is a response for TeamsCreateOrUpdateIdpGroupConnectionsInOrg
 
 https://developer.github.com/v3/teams/team_sync/#create-or-update-idp-group-connections
@@ -2576,7 +2492,7 @@ https://developer.github.com/v3/teams/team_sync/#create-or-update-idp-group-conn
 type TeamsCreateOrUpdateIdpGroupConnectionsInOrgResponse struct {
 	response
 	request *TeamsCreateOrUpdateIdpGroupConnectionsInOrgReq
-	Data    TeamsCreateOrUpdateIdpGroupConnectionsInOrgResponseBody
+	Data    components.GroupMapping
 }
 
 /*
@@ -2600,7 +2516,7 @@ func TeamsCreateOrUpdateIdpGroupConnectionsLegacy(ctx context.Context, req *Team
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsCreateOrUpdateIdpGroupConnectionsLegacyResponseBody{}
+	resp.Data = components.GroupMapping{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2725,13 +2641,6 @@ type TeamsCreateOrUpdateIdpGroupConnectionsLegacyReqBody struct {
 }
 
 /*
-TeamsCreateOrUpdateIdpGroupConnectionsLegacyResponseBody is a response body for TeamsCreateOrUpdateIdpGroupConnectionsLegacy
-
-https://developer.github.com/v3/teams/team_sync/#create-or-update-idp-group-connections-legacy
-*/
-type TeamsCreateOrUpdateIdpGroupConnectionsLegacyResponseBody components.GroupMapping
-
-/*
 TeamsCreateOrUpdateIdpGroupConnectionsLegacyResponse is a response for TeamsCreateOrUpdateIdpGroupConnectionsLegacy
 
 https://developer.github.com/v3/teams/team_sync/#create-or-update-idp-group-connections-legacy
@@ -2739,7 +2648,7 @@ https://developer.github.com/v3/teams/team_sync/#create-or-update-idp-group-conn
 type TeamsCreateOrUpdateIdpGroupConnectionsLegacyResponse struct {
 	response
 	request *TeamsCreateOrUpdateIdpGroupConnectionsLegacyReq
-	Data    TeamsCreateOrUpdateIdpGroupConnectionsLegacyResponseBody
+	Data    components.GroupMapping
 }
 
 /*
@@ -3486,7 +3395,7 @@ func TeamsGetByName(ctx context.Context, req *TeamsGetByNameReq, opt ...RequestO
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsGetByNameResponseBody{}
+	resp.Data = components.TeamFull{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3578,13 +3487,6 @@ func (r *TeamsGetByNameReq) Rel(link RelName, resp *TeamsGetByNameResponse) bool
 }
 
 /*
-TeamsGetByNameResponseBody is a response body for TeamsGetByName
-
-https://developer.github.com/v3/teams/#get-a-team-by-name
-*/
-type TeamsGetByNameResponseBody components.TeamFull
-
-/*
 TeamsGetByNameResponse is a response for TeamsGetByName
 
 https://developer.github.com/v3/teams/#get-a-team-by-name
@@ -3592,7 +3494,7 @@ https://developer.github.com/v3/teams/#get-a-team-by-name
 type TeamsGetByNameResponse struct {
 	response
 	request *TeamsGetByNameReq
-	Data    TeamsGetByNameResponseBody
+	Data    components.TeamFull
 }
 
 /*
@@ -3616,7 +3518,7 @@ func TeamsGetDiscussionCommentInOrg(ctx context.Context, req *TeamsGetDiscussion
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsGetDiscussionCommentInOrgResponseBody{}
+	resp.Data = components.TeamDiscussionComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3724,13 +3626,6 @@ func (r *TeamsGetDiscussionCommentInOrgReq) Rel(link RelName, resp *TeamsGetDisc
 }
 
 /*
-TeamsGetDiscussionCommentInOrgResponseBody is a response body for TeamsGetDiscussionCommentInOrg
-
-https://developer.github.com/v3/teams/discussion_comments/#get-a-discussion-comment
-*/
-type TeamsGetDiscussionCommentInOrgResponseBody components.TeamDiscussionComment
-
-/*
 TeamsGetDiscussionCommentInOrgResponse is a response for TeamsGetDiscussionCommentInOrg
 
 https://developer.github.com/v3/teams/discussion_comments/#get-a-discussion-comment
@@ -3738,7 +3633,7 @@ https://developer.github.com/v3/teams/discussion_comments/#get-a-discussion-comm
 type TeamsGetDiscussionCommentInOrgResponse struct {
 	response
 	request *TeamsGetDiscussionCommentInOrgReq
-	Data    TeamsGetDiscussionCommentInOrgResponseBody
+	Data    components.TeamDiscussionComment
 }
 
 /*
@@ -3762,7 +3657,7 @@ func TeamsGetDiscussionCommentLegacy(ctx context.Context, req *TeamsGetDiscussio
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsGetDiscussionCommentLegacyResponseBody{}
+	resp.Data = components.TeamDiscussionComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3867,13 +3762,6 @@ func (r *TeamsGetDiscussionCommentLegacyReq) Rel(link RelName, resp *TeamsGetDis
 }
 
 /*
-TeamsGetDiscussionCommentLegacyResponseBody is a response body for TeamsGetDiscussionCommentLegacy
-
-https://developer.github.com/v3/teams/discussion_comments/#get-a-discussion-comment-legacy
-*/
-type TeamsGetDiscussionCommentLegacyResponseBody components.TeamDiscussionComment
-
-/*
 TeamsGetDiscussionCommentLegacyResponse is a response for TeamsGetDiscussionCommentLegacy
 
 https://developer.github.com/v3/teams/discussion_comments/#get-a-discussion-comment-legacy
@@ -3881,7 +3769,7 @@ https://developer.github.com/v3/teams/discussion_comments/#get-a-discussion-comm
 type TeamsGetDiscussionCommentLegacyResponse struct {
 	response
 	request *TeamsGetDiscussionCommentLegacyReq
-	Data    TeamsGetDiscussionCommentLegacyResponseBody
+	Data    components.TeamDiscussionComment
 }
 
 /*
@@ -3905,7 +3793,7 @@ func TeamsGetDiscussionInOrg(ctx context.Context, req *TeamsGetDiscussionInOrgRe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsGetDiscussionInOrgResponseBody{}
+	resp.Data = components.TeamDiscussion{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -4012,13 +3900,6 @@ func (r *TeamsGetDiscussionInOrgReq) Rel(link RelName, resp *TeamsGetDiscussionI
 }
 
 /*
-TeamsGetDiscussionInOrgResponseBody is a response body for TeamsGetDiscussionInOrg
-
-https://developer.github.com/v3/teams/discussions/#get-a-discussion
-*/
-type TeamsGetDiscussionInOrgResponseBody components.TeamDiscussion
-
-/*
 TeamsGetDiscussionInOrgResponse is a response for TeamsGetDiscussionInOrg
 
 https://developer.github.com/v3/teams/discussions/#get-a-discussion
@@ -4026,7 +3907,7 @@ https://developer.github.com/v3/teams/discussions/#get-a-discussion
 type TeamsGetDiscussionInOrgResponse struct {
 	response
 	request *TeamsGetDiscussionInOrgReq
-	Data    TeamsGetDiscussionInOrgResponseBody
+	Data    components.TeamDiscussion
 }
 
 /*
@@ -4050,7 +3931,7 @@ func TeamsGetDiscussionLegacy(ctx context.Context, req *TeamsGetDiscussionLegacy
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsGetDiscussionLegacyResponseBody{}
+	resp.Data = components.TeamDiscussion{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -4154,13 +4035,6 @@ func (r *TeamsGetDiscussionLegacyReq) Rel(link RelName, resp *TeamsGetDiscussion
 }
 
 /*
-TeamsGetDiscussionLegacyResponseBody is a response body for TeamsGetDiscussionLegacy
-
-https://developer.github.com/v3/teams/discussions/#get-a-discussion-legacy
-*/
-type TeamsGetDiscussionLegacyResponseBody components.TeamDiscussion
-
-/*
 TeamsGetDiscussionLegacyResponse is a response for TeamsGetDiscussionLegacy
 
 https://developer.github.com/v3/teams/discussions/#get-a-discussion-legacy
@@ -4168,7 +4042,7 @@ https://developer.github.com/v3/teams/discussions/#get-a-discussion-legacy
 type TeamsGetDiscussionLegacyResponse struct {
 	response
 	request *TeamsGetDiscussionLegacyReq
-	Data    TeamsGetDiscussionLegacyResponseBody
+	Data    components.TeamDiscussion
 }
 
 /*
@@ -4192,7 +4066,7 @@ func TeamsGetLegacy(ctx context.Context, req *TeamsGetLegacyReq, opt ...RequestO
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsGetLegacyResponseBody{}
+	resp.Data = components.TeamFull{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -4281,13 +4155,6 @@ func (r *TeamsGetLegacyReq) Rel(link RelName, resp *TeamsGetLegacyResponse) bool
 }
 
 /*
-TeamsGetLegacyResponseBody is a response body for TeamsGetLegacy
-
-https://developer.github.com/v3/teams/#get-a-team-legacy
-*/
-type TeamsGetLegacyResponseBody components.TeamFull
-
-/*
 TeamsGetLegacyResponse is a response for TeamsGetLegacy
 
 https://developer.github.com/v3/teams/#get-a-team-legacy
@@ -4295,7 +4162,7 @@ https://developer.github.com/v3/teams/#get-a-team-legacy
 type TeamsGetLegacyResponse struct {
 	response
 	request *TeamsGetLegacyReq
-	Data    TeamsGetLegacyResponseBody
+	Data    components.TeamFull
 }
 
 /*
@@ -4443,7 +4310,7 @@ func TeamsGetMembershipForUserInOrg(ctx context.Context, req *TeamsGetMembership
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsGetMembershipForUserInOrgResponseBody{}
+	resp.Data = components.TeamMembership{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -4536,13 +4403,6 @@ func (r *TeamsGetMembershipForUserInOrgReq) Rel(link RelName, resp *TeamsGetMemb
 }
 
 /*
-TeamsGetMembershipForUserInOrgResponseBody is a response body for TeamsGetMembershipForUserInOrg
-
-https://developer.github.com/v3/teams/members/#get-team-membership-for-a-user
-*/
-type TeamsGetMembershipForUserInOrgResponseBody components.TeamMembership
-
-/*
 TeamsGetMembershipForUserInOrgResponse is a response for TeamsGetMembershipForUserInOrg
 
 https://developer.github.com/v3/teams/members/#get-team-membership-for-a-user
@@ -4550,7 +4410,7 @@ https://developer.github.com/v3/teams/members/#get-team-membership-for-a-user
 type TeamsGetMembershipForUserInOrgResponse struct {
 	response
 	request *TeamsGetMembershipForUserInOrgReq
-	Data    TeamsGetMembershipForUserInOrgResponseBody
+	Data    components.TeamMembership
 }
 
 /*
@@ -4574,7 +4434,7 @@ func TeamsGetMembershipForUserLegacy(ctx context.Context, req *TeamsGetMembershi
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsGetMembershipForUserLegacyResponseBody{}
+	resp.Data = components.TeamMembership{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -4664,13 +4524,6 @@ func (r *TeamsGetMembershipForUserLegacyReq) Rel(link RelName, resp *TeamsGetMem
 }
 
 /*
-TeamsGetMembershipForUserLegacyResponseBody is a response body for TeamsGetMembershipForUserLegacy
-
-https://developer.github.com/v3/teams/members/#get-team-membership-for-a-user-legacy
-*/
-type TeamsGetMembershipForUserLegacyResponseBody components.TeamMembership
-
-/*
 TeamsGetMembershipForUserLegacyResponse is a response for TeamsGetMembershipForUserLegacy
 
 https://developer.github.com/v3/teams/members/#get-team-membership-for-a-user-legacy
@@ -4678,7 +4531,7 @@ https://developer.github.com/v3/teams/members/#get-team-membership-for-a-user-le
 type TeamsGetMembershipForUserLegacyResponse struct {
 	response
 	request *TeamsGetMembershipForUserLegacyReq
-	Data    TeamsGetMembershipForUserLegacyResponseBody
+	Data    components.TeamMembership
 }
 
 /*
@@ -5904,7 +5757,7 @@ func TeamsListIdpGroupsForLegacy(ctx context.Context, req *TeamsListIdpGroupsFor
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsListIdpGroupsForLegacyResponseBody{}
+	resp.Data = components.GroupMapping{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -5993,13 +5846,6 @@ func (r *TeamsListIdpGroupsForLegacyReq) Rel(link RelName, resp *TeamsListIdpGro
 }
 
 /*
-TeamsListIdpGroupsForLegacyResponseBody is a response body for TeamsListIdpGroupsForLegacy
-
-https://developer.github.com/v3/teams/team_sync/#list-idp-groups-for-a-team-legacy
-*/
-type TeamsListIdpGroupsForLegacyResponseBody components.GroupMapping
-
-/*
 TeamsListIdpGroupsForLegacyResponse is a response for TeamsListIdpGroupsForLegacy
 
 https://developer.github.com/v3/teams/team_sync/#list-idp-groups-for-a-team-legacy
@@ -6007,7 +5853,7 @@ https://developer.github.com/v3/teams/team_sync/#list-idp-groups-for-a-team-lega
 type TeamsListIdpGroupsForLegacyResponse struct {
 	response
 	request *TeamsListIdpGroupsForLegacyReq
-	Data    TeamsListIdpGroupsForLegacyResponseBody
+	Data    components.GroupMapping
 }
 
 /*
@@ -6031,7 +5877,7 @@ func TeamsListIdpGroupsForOrg(ctx context.Context, req *TeamsListIdpGroupsForOrg
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsListIdpGroupsForOrgResponseBody{}
+	resp.Data = components.GroupMapping{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -6132,13 +5978,6 @@ func (r *TeamsListIdpGroupsForOrgReq) Rel(link RelName, resp *TeamsListIdpGroups
 }
 
 /*
-TeamsListIdpGroupsForOrgResponseBody is a response body for TeamsListIdpGroupsForOrg
-
-https://developer.github.com/v3/teams/team_sync/#list-idp-groups-for-an-organization
-*/
-type TeamsListIdpGroupsForOrgResponseBody components.GroupMapping
-
-/*
 TeamsListIdpGroupsForOrgResponse is a response for TeamsListIdpGroupsForOrg
 
 https://developer.github.com/v3/teams/team_sync/#list-idp-groups-for-an-organization
@@ -6146,7 +5985,7 @@ https://developer.github.com/v3/teams/team_sync/#list-idp-groups-for-an-organiza
 type TeamsListIdpGroupsForOrgResponse struct {
 	response
 	request *TeamsListIdpGroupsForOrgReq
-	Data    TeamsListIdpGroupsForOrgResponseBody
+	Data    components.GroupMapping
 }
 
 /*
@@ -6170,7 +6009,7 @@ func TeamsListIdpGroupsInOrg(ctx context.Context, req *TeamsListIdpGroupsInOrgRe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsListIdpGroupsInOrgResponseBody{}
+	resp.Data = components.GroupMapping{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -6262,13 +6101,6 @@ func (r *TeamsListIdpGroupsInOrgReq) Rel(link RelName, resp *TeamsListIdpGroupsI
 }
 
 /*
-TeamsListIdpGroupsInOrgResponseBody is a response body for TeamsListIdpGroupsInOrg
-
-https://developer.github.com/v3/teams/team_sync/#list-idp-groups-for-a-team
-*/
-type TeamsListIdpGroupsInOrgResponseBody components.GroupMapping
-
-/*
 TeamsListIdpGroupsInOrgResponse is a response for TeamsListIdpGroupsInOrg
 
 https://developer.github.com/v3/teams/team_sync/#list-idp-groups-for-a-team
@@ -6276,7 +6108,7 @@ https://developer.github.com/v3/teams/team_sync/#list-idp-groups-for-a-team
 type TeamsListIdpGroupsInOrgResponse struct {
 	response
 	request *TeamsListIdpGroupsInOrgReq
-	Data    TeamsListIdpGroupsInOrgResponseBody
+	Data    components.GroupMapping
 }
 
 /*
@@ -8325,7 +8157,7 @@ func TeamsUpdateDiscussionCommentInOrg(ctx context.Context, req *TeamsUpdateDisc
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsUpdateDiscussionCommentInOrgResponseBody{}
+	resp.Data = components.TeamDiscussionComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -8448,13 +8280,6 @@ type TeamsUpdateDiscussionCommentInOrgReqBody struct {
 }
 
 /*
-TeamsUpdateDiscussionCommentInOrgResponseBody is a response body for TeamsUpdateDiscussionCommentInOrg
-
-https://developer.github.com/v3/teams/discussion_comments/#update-a-discussion-comment
-*/
-type TeamsUpdateDiscussionCommentInOrgResponseBody components.TeamDiscussionComment
-
-/*
 TeamsUpdateDiscussionCommentInOrgResponse is a response for TeamsUpdateDiscussionCommentInOrg
 
 https://developer.github.com/v3/teams/discussion_comments/#update-a-discussion-comment
@@ -8462,7 +8287,7 @@ https://developer.github.com/v3/teams/discussion_comments/#update-a-discussion-c
 type TeamsUpdateDiscussionCommentInOrgResponse struct {
 	response
 	request *TeamsUpdateDiscussionCommentInOrgReq
-	Data    TeamsUpdateDiscussionCommentInOrgResponseBody
+	Data    components.TeamDiscussionComment
 }
 
 /*
@@ -8486,7 +8311,7 @@ func TeamsUpdateDiscussionCommentLegacy(ctx context.Context, req *TeamsUpdateDis
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsUpdateDiscussionCommentLegacyResponseBody{}
+	resp.Data = components.TeamDiscussionComment{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -8606,13 +8431,6 @@ type TeamsUpdateDiscussionCommentLegacyReqBody struct {
 }
 
 /*
-TeamsUpdateDiscussionCommentLegacyResponseBody is a response body for TeamsUpdateDiscussionCommentLegacy
-
-https://developer.github.com/v3/teams/discussion_comments/#update-a-discussion-comment-legacy
-*/
-type TeamsUpdateDiscussionCommentLegacyResponseBody components.TeamDiscussionComment
-
-/*
 TeamsUpdateDiscussionCommentLegacyResponse is a response for TeamsUpdateDiscussionCommentLegacy
 
 https://developer.github.com/v3/teams/discussion_comments/#update-a-discussion-comment-legacy
@@ -8620,7 +8438,7 @@ https://developer.github.com/v3/teams/discussion_comments/#update-a-discussion-c
 type TeamsUpdateDiscussionCommentLegacyResponse struct {
 	response
 	request *TeamsUpdateDiscussionCommentLegacyReq
-	Data    TeamsUpdateDiscussionCommentLegacyResponseBody
+	Data    components.TeamDiscussionComment
 }
 
 /*
@@ -8644,7 +8462,7 @@ func TeamsUpdateDiscussionInOrg(ctx context.Context, req *TeamsUpdateDiscussionI
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsUpdateDiscussionInOrgResponseBody{}
+	resp.Data = components.TeamDiscussion{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -8769,13 +8587,6 @@ type TeamsUpdateDiscussionInOrgReqBody struct {
 }
 
 /*
-TeamsUpdateDiscussionInOrgResponseBody is a response body for TeamsUpdateDiscussionInOrg
-
-https://developer.github.com/v3/teams/discussions/#update-a-discussion
-*/
-type TeamsUpdateDiscussionInOrgResponseBody components.TeamDiscussion
-
-/*
 TeamsUpdateDiscussionInOrgResponse is a response for TeamsUpdateDiscussionInOrg
 
 https://developer.github.com/v3/teams/discussions/#update-a-discussion
@@ -8783,7 +8594,7 @@ https://developer.github.com/v3/teams/discussions/#update-a-discussion
 type TeamsUpdateDiscussionInOrgResponse struct {
 	response
 	request *TeamsUpdateDiscussionInOrgReq
-	Data    TeamsUpdateDiscussionInOrgResponseBody
+	Data    components.TeamDiscussion
 }
 
 /*
@@ -8807,7 +8618,7 @@ func TeamsUpdateDiscussionLegacy(ctx context.Context, req *TeamsUpdateDiscussion
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsUpdateDiscussionLegacyResponseBody{}
+	resp.Data = components.TeamDiscussion{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -8929,13 +8740,6 @@ type TeamsUpdateDiscussionLegacyReqBody struct {
 }
 
 /*
-TeamsUpdateDiscussionLegacyResponseBody is a response body for TeamsUpdateDiscussionLegacy
-
-https://developer.github.com/v3/teams/discussions/#update-a-discussion-legacy
-*/
-type TeamsUpdateDiscussionLegacyResponseBody components.TeamDiscussion
-
-/*
 TeamsUpdateDiscussionLegacyResponse is a response for TeamsUpdateDiscussionLegacy
 
 https://developer.github.com/v3/teams/discussions/#update-a-discussion-legacy
@@ -8943,7 +8747,7 @@ https://developer.github.com/v3/teams/discussions/#update-a-discussion-legacy
 type TeamsUpdateDiscussionLegacyResponse struct {
 	response
 	request *TeamsUpdateDiscussionLegacyReq
-	Data    TeamsUpdateDiscussionLegacyResponseBody
+	Data    components.TeamDiscussion
 }
 
 /*
@@ -8967,7 +8771,7 @@ func TeamsUpdateInOrg(ctx context.Context, req *TeamsUpdateInOrgReq, opt ...Requ
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsUpdateInOrgResponseBody{}
+	resp.Data = components.TeamFull{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -9104,13 +8908,6 @@ type TeamsUpdateInOrgReqBody struct {
 }
 
 /*
-TeamsUpdateInOrgResponseBody is a response body for TeamsUpdateInOrg
-
-https://developer.github.com/v3/teams/#update-a-team
-*/
-type TeamsUpdateInOrgResponseBody components.TeamFull
-
-/*
 TeamsUpdateInOrgResponse is a response for TeamsUpdateInOrg
 
 https://developer.github.com/v3/teams/#update-a-team
@@ -9118,7 +8915,7 @@ https://developer.github.com/v3/teams/#update-a-team
 type TeamsUpdateInOrgResponse struct {
 	response
 	request *TeamsUpdateInOrgReq
-	Data    TeamsUpdateInOrgResponseBody
+	Data    components.TeamFull
 }
 
 /*
@@ -9142,7 +8939,7 @@ func TeamsUpdateLegacy(ctx context.Context, req *TeamsUpdateLegacyReq, opt ...Re
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = TeamsUpdateLegacyResponseBody{}
+	resp.Data = components.TeamFull{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -9275,13 +9072,6 @@ type TeamsUpdateLegacyReqBody struct {
 }
 
 /*
-TeamsUpdateLegacyResponseBody is a response body for TeamsUpdateLegacy
-
-https://developer.github.com/v3/teams/#update-a-team-legacy
-*/
-type TeamsUpdateLegacyResponseBody components.TeamFull
-
-/*
 TeamsUpdateLegacyResponse is a response for TeamsUpdateLegacy
 
 https://developer.github.com/v3/teams/#update-a-team-legacy
@@ -9289,5 +9079,5 @@ https://developer.github.com/v3/teams/#update-a-team-legacy
 type TeamsUpdateLegacyResponse struct {
 	response
 	request *TeamsUpdateLegacyReq
-	Data    TeamsUpdateLegacyResponseBody
+	Data    components.TeamFull
 }

--- a/zz_unmarshal_gen_test.go
+++ b/zz_unmarshal_gen_test.go
@@ -224,23 +224,23 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "actions/list-repo-workflows",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActionsListRunnerApplicationsForOrgResponseBody{}
+		target := []components.RunnerApplication{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/actions/runners/downloads",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ActionsListRunnerApplicationsForOrgResponseBody",
+	name:           "[]components.RunnerApplication",
 	operationID:    "actions/list-runner-applications-for-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActionsListRunnerApplicationsForRepoResponseBody{}
+		target := []components.RunnerApplication{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/actions/runners/downloads",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ActionsListRunnerApplicationsForRepoResponseBody",
+	name:           "[]components.RunnerApplication",
 	operationID:    "actions/list-runner-applications-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -344,83 +344,83 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "activity/get-thread-subscription-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActivityListNotificationsForAuthenticatedUserResponseBody{}
+		target := []components.Thread{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/notifications",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ActivityListNotificationsForAuthenticatedUserResponseBody",
+	name:           "[]components.Thread",
 	operationID:    "activity/list-notifications-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActivityListRepoNotificationsForAuthenticatedUserResponseBody{}
+		target := []components.Thread{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/notifications",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ActivityListRepoNotificationsForAuthenticatedUserResponseBody",
+	name:           "[]components.Thread",
 	operationID:    "activity/list-repo-notifications-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActivityListReposStarredByAuthenticatedUserResponseBody{}
+		target := []components.StarredRepository{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/starred",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ActivityListReposStarredByAuthenticatedUserResponseBody",
+	name:           "[]components.StarredRepository",
 	operationID:    "activity/list-repos-starred-by-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActivityListReposStarredByUserResponseBody{}
+		target := []components.StarredRepository{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/users/{username}/starred",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ActivityListReposStarredByUserResponseBody",
+	name:           "[]components.StarredRepository",
 	operationID:    "activity/list-repos-starred-by-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActivityListReposWatchedByUserResponseBody{}
+		target := []components.MinimalRepository{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/users/{username}/subscriptions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ActivityListReposWatchedByUserResponseBody",
+	name:           "[]components.MinimalRepository",
 	operationID:    "activity/list-repos-watched-by-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActivityListStargazersForRepoResponseBody{}
+		target := []components.Stargazer{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/stargazers",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ActivityListStargazersForRepoResponseBody",
+	name:           "[]components.Stargazer",
 	operationID:    "activity/list-stargazers-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActivityListWatchedReposForAuthenticatedUserResponseBody{}
+		target := []components.MinimalRepository{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/subscriptions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ActivityListWatchedReposForAuthenticatedUserResponseBody",
+	name:           "[]components.MinimalRepository",
 	operationID:    "activity/list-watched-repos-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActivityListWatchersForRepoResponseBody{}
+		target := []components.SimpleUser{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/subscribers",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ActivityListWatchersForRepoResponseBody",
+	name:           "[]components.SimpleUser",
 	operationID:    "activity/list-watchers-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -574,23 +574,23 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "apps/get-user-installation",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.AppsListAccountsForPlanResponseBody{}
+		target := []components.MarketplacePurchase{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/marketplace_listing/plans/{plan_id}/accounts",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.AppsListAccountsForPlanResponseBody",
+	name:           "[]components.MarketplacePurchase",
 	operationID:    "apps/list-accounts-for-plan",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.AppsListAccountsForPlanStubbedResponseBody{}
+		target := []components.MarketplacePurchase{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/marketplace_listing/stubbed/plans/{plan_id}/accounts",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.AppsListAccountsForPlanStubbedResponseBody",
+	name:           "[]components.MarketplacePurchase",
 	operationID:    "apps/list-accounts-for-plan-stubbed",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -604,13 +604,13 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "apps/list-installation-repos-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.AppsListInstallationsResponseBody{}
+		target := []components.Installation{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/app/installations",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.AppsListInstallationsResponseBody",
+	name:           "[]components.Installation",
 	operationID:    "apps/list-installations",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -624,23 +624,23 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "apps/list-installations-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.AppsListPlansResponseBody{}
+		target := []components.MarketplaceListingPlan{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/marketplace_listing/plans",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.AppsListPlansResponseBody",
+	name:           "[]components.MarketplaceListingPlan",
 	operationID:    "apps/list-plans",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.AppsListPlansStubbedResponseBody{}
+		target := []components.MarketplaceListingPlan{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/marketplace_listing/stubbed/plans",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.AppsListPlansStubbedResponseBody",
+	name:           "[]components.MarketplaceListingPlan",
 	operationID:    "apps/list-plans-stubbed",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -654,23 +654,23 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "apps/list-repos-accessible-to-installation",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.AppsListSubscriptionsForAuthenticatedUserResponseBody{}
+		target := []components.UserMarketplacePurchase{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/marketplace_purchases",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.AppsListSubscriptionsForAuthenticatedUserResponseBody",
+	name:           "[]components.UserMarketplacePurchase",
 	operationID:    "apps/list-subscriptions-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.AppsListSubscriptionsForAuthenticatedUserStubbedResponseBody{}
+		target := []components.UserMarketplacePurchase{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/marketplace_purchases/stubbed",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.AppsListSubscriptionsForAuthenticatedUserStubbedResponseBody",
+	name:           "[]components.UserMarketplacePurchase",
 	operationID:    "apps/list-subscriptions-for-authenticated-user-stubbed",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -824,13 +824,13 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "checks/get-suite",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ChecksListAnnotationsResponseBody{}
+		target := []components.CheckAnnotation{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/check-runs/{check_run_id}/annotations",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ChecksListAnnotationsResponseBody",
+	name:           "[]components.CheckAnnotation",
 	operationID:    "checks/list-annotations",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -894,23 +894,23 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "code-scanning/get-alert",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.CodeScanningListAlertsForRepoResponseBody{}
+		target := []components.CodeScanningAlert{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/code-scanning/alerts",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.CodeScanningListAlertsForRepoResponseBody",
+	name:           "[]components.CodeScanningAlert",
 	operationID:    "code-scanning/list-alerts-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.CodesOfConductGetAllCodesOfConductResponseBody{}
+		target := []components.CodeOfConduct{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/codes_of_conduct",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.CodesOfConductGetAllCodesOfConductResponseBody",
+	name:           "[]components.CodeOfConduct",
 	operationID:    "codes-of-conduct/get-all-codes-of-conduct",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -994,73 +994,73 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "gists/get-revision",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GistsListResponseBody{}
+		target := []components.BaseGist{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/gists",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.GistsListResponseBody",
+	name:           "[]components.BaseGist",
 	operationID:    "gists/list",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GistsListCommentsResponseBody{}
+		target := []components.GistComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/gists/{gist_id}/comments",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.GistsListCommentsResponseBody",
+	name:           "[]components.GistComment",
 	operationID:    "gists/list-comments",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GistsListCommitsResponseBody{}
+		target := []components.GistCommit{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/gists/{gist_id}/commits",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.GistsListCommitsResponseBody",
+	name:           "[]components.GistCommit",
 	operationID:    "gists/list-commits",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GistsListForUserResponseBody{}
+		target := []components.BaseGist{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/users/{username}/gists",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.GistsListForUserResponseBody",
+	name:           "[]components.BaseGist",
 	operationID:    "gists/list-for-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GistsListForksResponseBody{}
+		target := []components.GistFull{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/gists/{gist_id}/forks",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.GistsListForksResponseBody",
+	name:           "[]components.GistFull",
 	operationID:    "gists/list-forks",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GistsListPublicResponseBody{}
+		target := []components.BaseGist{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/gists/public",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.GistsListPublicResponseBody",
+	name:           "[]components.BaseGist",
 	operationID:    "gists/list-public",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GistsListStarredResponseBody{}
+		target := []components.BaseGist{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/gists/starred",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.GistsListStarredResponseBody",
+	name:           "[]components.BaseGist",
 	operationID:    "gists/list-starred",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1184,13 +1184,13 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "git/get-tree",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GitListMatchingRefsResponseBody{}
+		target := []components.GitRef{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/git/matching-refs/{ref}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.GitListMatchingRefsResponseBody",
+	name:           "[]components.GitRef",
 	operationID:    "git/list-matching-refs",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1274,13 +1274,13 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "issues/add-assignees",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesAddLabelsResponseBody{}
+		target := []components.Label{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/issues/{issue_number}/labels",
 	httpMethod:     "POST",
 	httpStatusCode: 200,
-	name:           "octo.IssuesAddLabelsResponseBody",
+	name:           "[]components.Label",
 	operationID:    "issues/add-labels",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1374,143 +1374,143 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "issues/get-milestone",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesListResponseBody{}
+		target := []components.Issue{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/issues",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.IssuesListResponseBody",
+	name:           "[]components.Issue",
 	operationID:    "issues/list",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesListAssigneesResponseBody{}
+		target := []components.SimpleUser{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/assignees",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.IssuesListAssigneesResponseBody",
+	name:           "[]components.SimpleUser",
 	operationID:    "issues/list-assignees",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesListCommentsResponseBody{}
+		target := []components.IssueComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/issues/{issue_number}/comments",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.IssuesListCommentsResponseBody",
+	name:           "[]components.IssueComment",
 	operationID:    "issues/list-comments",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesListCommentsForRepoResponseBody{}
+		target := []components.IssueComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/issues/comments",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.IssuesListCommentsForRepoResponseBody",
+	name:           "[]components.IssueComment",
 	operationID:    "issues/list-comments-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesListEventsResponseBody{}
+		target := []components.IssueEventForIssue{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/issues/{issue_number}/events",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.IssuesListEventsResponseBody",
+	name:           "[]components.IssueEventForIssue",
 	operationID:    "issues/list-events",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesListEventsForRepoResponseBody{}
+		target := []components.IssueEvent{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/issues/events",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.IssuesListEventsForRepoResponseBody",
+	name:           "[]components.IssueEvent",
 	operationID:    "issues/list-events-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesListEventsForTimelineResponseBody{}
+		target := []components.IssueEventForIssue{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/issues/{issue_number}/timeline",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.IssuesListEventsForTimelineResponseBody",
+	name:           "[]components.IssueEventForIssue",
 	operationID:    "issues/list-events-for-timeline",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesListForAuthenticatedUserResponseBody{}
+		target := []components.Issue{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/issues",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.IssuesListForAuthenticatedUserResponseBody",
+	name:           "[]components.Issue",
 	operationID:    "issues/list-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesListForOrgResponseBody{}
+		target := []components.Issue{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/issues",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.IssuesListForOrgResponseBody",
+	name:           "[]components.Issue",
 	operationID:    "issues/list-for-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesListForRepoResponseBody{}
+		target := []components.IssueSimple{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/issues",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.IssuesListForRepoResponseBody",
+	name:           "[]components.IssueSimple",
 	operationID:    "issues/list-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesListLabelsForMilestoneResponseBody{}
+		target := []components.Label{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/milestones/{milestone_number}/labels",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.IssuesListLabelsForMilestoneResponseBody",
+	name:           "[]components.Label",
 	operationID:    "issues/list-labels-for-milestone",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesListLabelsForRepoResponseBody{}
+		target := []components.Label{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/labels",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.IssuesListLabelsForRepoResponseBody",
+	name:           "[]components.Label",
 	operationID:    "issues/list-labels-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesListLabelsOnIssueResponseBody{}
+		target := []components.Label{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/issues/{issue_number}/labels",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.IssuesListLabelsOnIssueResponseBody",
+	name:           "[]components.Label",
 	operationID:    "issues/list-labels-on-issue",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesListMilestonesResponseBody{}
+		target := []components.Milestone{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/milestones",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.IssuesListMilestonesResponseBody",
+	name:           "[]components.Milestone",
 	operationID:    "issues/list-milestones",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1524,23 +1524,23 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "issues/remove-assignees",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesRemoveLabelResponseBody{}
+		target := []components.Label{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/issues/{issue_number}/labels/{name}",
 	httpMethod:     "DELETE",
 	httpStatusCode: 200,
-	name:           "octo.IssuesRemoveLabelResponseBody",
+	name:           "[]components.Label",
 	operationID:    "issues/remove-label",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesSetLabelsResponseBody{}
+		target := []components.Label{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/issues/{issue_number}/labels",
 	httpMethod:     "PUT",
 	httpStatusCode: 200,
-	name:           "octo.IssuesSetLabelsResponseBody",
+	name:           "[]components.Label",
 	operationID:    "issues/set-labels",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1594,13 +1594,13 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "licenses/get",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.LicensesGetAllCommonlyUsedResponseBody{}
+		target := []components.LicenseSimple{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/licenses",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.LicensesGetAllCommonlyUsedResponseBody",
+	name:           "[]components.LicenseSimple",
 	operationID:    "licenses/get-all-commonly-used",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1624,13 +1624,13 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "meta/get",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.MigrationsGetCommitAuthorsResponseBody{}
+		target := []components.PorterAuthor{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/import/authors",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.MigrationsGetCommitAuthorsResponseBody",
+	name:           "[]components.PorterAuthor",
 	operationID:    "migrations/get-commit-authors",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1644,13 +1644,13 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "migrations/get-import-status",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.MigrationsGetLargeFilesResponseBody{}
+		target := []components.PorterLargeFile{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/import/large_files",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.MigrationsGetLargeFilesResponseBody",
+	name:           "[]components.PorterLargeFile",
 	operationID:    "migrations/get-large-files",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1674,43 +1674,43 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "migrations/get-status-for-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.MigrationsListForAuthenticatedUserResponseBody{}
+		target := []components.Migration{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/migrations",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.MigrationsListForAuthenticatedUserResponseBody",
+	name:           "[]components.Migration",
 	operationID:    "migrations/list-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.MigrationsListForOrgResponseBody{}
+		target := []components.Migration{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/migrations",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.MigrationsListForOrgResponseBody",
+	name:           "[]components.Migration",
 	operationID:    "migrations/list-for-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.MigrationsListReposForOrgResponseBody{}
+		target := []components.MinimalRepository{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/migrations/{migration_id}/repositories",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.MigrationsListReposForOrgResponseBody",
+	name:           "[]components.MinimalRepository",
 	operationID:    "migrations/list-repos-for-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.MigrationsListReposForUserResponseBody{}
+		target := []components.MinimalRepository{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/migrations/{migration_id}/repositories",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.MigrationsListReposForUserResponseBody",
+	name:           "[]components.MinimalRepository",
 	operationID:    "migrations/list-repos-for-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1844,23 +1844,23 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "oauth-authorizations/get-or-create-authorization-for-app-and-fingerprint",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OauthAuthorizationsListAuthorizationsResponseBody{}
+		target := []components.Authorization{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/authorizations",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.OauthAuthorizationsListAuthorizationsResponseBody",
+	name:           "[]components.Authorization",
 	operationID:    "oauth-authorizations/list-authorizations",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OauthAuthorizationsListGrantsResponseBody{}
+		target := []components.ApplicationGrant{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/applications/grants",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.OauthAuthorizationsListGrantsResponseBody",
+	name:           "[]components.ApplicationGrant",
 	operationID:    "oauth-authorizations/list-grants",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1934,13 +1934,13 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "orgs/get-webhook",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OrgsListResponseBody{}
+		target := []components.OrganizationSimple{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/organizations",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.OrgsListResponseBody",
+	name:           "[]components.OrganizationSimple",
 	operationID:    "orgs/list",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1954,113 +1954,113 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "orgs/list-app-installations",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OrgsListBlockedUsersResponseBody{}
+		target := []components.SimpleUser{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/blocks",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.OrgsListBlockedUsersResponseBody",
+	name:           "[]components.SimpleUser",
 	operationID:    "orgs/list-blocked-users",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OrgsListForAuthenticatedUserResponseBody{}
+		target := []components.OrganizationSimple{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/orgs",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.OrgsListForAuthenticatedUserResponseBody",
+	name:           "[]components.OrganizationSimple",
 	operationID:    "orgs/list-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OrgsListForUserResponseBody{}
+		target := []components.OrganizationSimple{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/users/{username}/orgs",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.OrgsListForUserResponseBody",
+	name:           "[]components.OrganizationSimple",
 	operationID:    "orgs/list-for-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OrgsListInvitationTeamsResponseBody{}
+		target := []components.Team{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/invitations/{invitation_id}/teams",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.OrgsListInvitationTeamsResponseBody",
+	name:           "[]components.Team",
 	operationID:    "orgs/list-invitation-teams",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OrgsListMembersResponseBody{}
+		target := []components.SimpleUser{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/members",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.OrgsListMembersResponseBody",
+	name:           "[]components.SimpleUser",
 	operationID:    "orgs/list-members",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OrgsListMembershipsForAuthenticatedUserResponseBody{}
+		target := []components.OrgMembership{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/memberships/orgs",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.OrgsListMembershipsForAuthenticatedUserResponseBody",
+	name:           "[]components.OrgMembership",
 	operationID:    "orgs/list-memberships-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OrgsListOutsideCollaboratorsResponseBody{}
+		target := []components.SimpleUser{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/outside_collaborators",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.OrgsListOutsideCollaboratorsResponseBody",
+	name:           "[]components.SimpleUser",
 	operationID:    "orgs/list-outside-collaborators",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OrgsListPendingInvitationsResponseBody{}
+		target := []components.OrganizationInvitation{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/invitations",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.OrgsListPendingInvitationsResponseBody",
+	name:           "[]components.OrganizationInvitation",
 	operationID:    "orgs/list-pending-invitations",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OrgsListPublicMembersResponseBody{}
+		target := []components.SimpleUser{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/public_members",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.OrgsListPublicMembersResponseBody",
+	name:           "[]components.SimpleUser",
 	operationID:    "orgs/list-public-members",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OrgsListSamlSsoAuthorizationsResponseBody{}
+		target := []components.CredentialAuthorization{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/credential-authorizations",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.OrgsListSamlSsoAuthorizationsResponseBody",
+	name:           "[]components.CredentialAuthorization",
 	operationID:    "orgs/list-saml-sso-authorizations",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OrgsListWebhooksResponseBody{}
+		target := []components.OrgHook{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/hooks",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.OrgsListWebhooksResponseBody",
+	name:           "[]components.OrgHook",
 	operationID:    "orgs/list-webhooks",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2194,63 +2194,63 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "projects/get-permission-for-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ProjectsListCardsResponseBody{}
+		target := []components.ProjectCard{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/projects/columns/{column_id}/cards",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ProjectsListCardsResponseBody",
+	name:           "[]components.ProjectCard",
 	operationID:    "projects/list-cards",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ProjectsListCollaboratorsResponseBody{}
+		target := []components.SimpleUser{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/projects/{project_id}/collaborators",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ProjectsListCollaboratorsResponseBody",
+	name:           "[]components.SimpleUser",
 	operationID:    "projects/list-collaborators",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ProjectsListColumnsResponseBody{}
+		target := []components.ProjectColumn{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/projects/{project_id}/columns",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ProjectsListColumnsResponseBody",
+	name:           "[]components.ProjectColumn",
 	operationID:    "projects/list-columns",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ProjectsListForOrgResponseBody{}
+		target := []components.Project{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/projects",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ProjectsListForOrgResponseBody",
+	name:           "[]components.Project",
 	operationID:    "projects/list-for-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ProjectsListForRepoResponseBody{}
+		target := []components.Project{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/projects",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ProjectsListForRepoResponseBody",
+	name:           "[]components.Project",
 	operationID:    "projects/list-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ProjectsListForUserResponseBody{}
+		target := []components.Project{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/users/{username}/projects",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ProjectsListForUserResponseBody",
+	name:           "[]components.Project",
 	operationID:    "projects/list-for-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2374,43 +2374,43 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "pulls/get-review-comment",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.PullsListResponseBody{}
+		target := []components.PullRequestSimple{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pulls",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.PullsListResponseBody",
+	name:           "[]components.PullRequestSimple",
 	operationID:    "pulls/list",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.PullsListCommentsForReviewResponseBody{}
+		target := []components.ReviewComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.PullsListCommentsForReviewResponseBody",
+	name:           "[]components.ReviewComment",
 	operationID:    "pulls/list-comments-for-review",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.PullsListCommitsResponseBody{}
+		target := []components.SimpleCommit{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pulls/{pull_number}/commits",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.PullsListCommitsResponseBody",
+	name:           "[]components.SimpleCommit",
 	operationID:    "pulls/list-commits",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.PullsListFilesResponseBody{}
+		target := []components.DiffEntry{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pulls/{pull_number}/files",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.PullsListFilesResponseBody",
+	name:           "[]components.DiffEntry",
 	operationID:    "pulls/list-files",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2424,33 +2424,33 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "pulls/list-requested-reviewers",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.PullsListReviewCommentsResponseBody{}
+		target := []components.PullRequestReviewComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pulls/{pull_number}/comments",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.PullsListReviewCommentsResponseBody",
+	name:           "[]components.PullRequestReviewComment",
 	operationID:    "pulls/list-review-comments",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.PullsListReviewCommentsForRepoResponseBody{}
+		target := []components.PullRequestReviewComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pulls/comments",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.PullsListReviewCommentsForRepoResponseBody",
+	name:           "[]components.PullRequestReviewComment",
 	operationID:    "pulls/list-review-comments-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.PullsListReviewsResponseBody{}
+		target := []components.PullRequestReview{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pulls/{pull_number}/reviews",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.PullsListReviewsResponseBody",
+	name:           "[]components.PullRequestReview",
 	operationID:    "pulls/list-reviews",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2644,93 +2644,93 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "reactions/create-for-team-discussion-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReactionsListForCommitCommentResponseBody{}
+		target := []components.Reaction{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/comments/{comment_id}/reactions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReactionsListForCommitCommentResponseBody",
+	name:           "[]components.Reaction",
 	operationID:    "reactions/list-for-commit-comment",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReactionsListForIssueResponseBody{}
+		target := []components.Reaction{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/issues/{issue_number}/reactions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReactionsListForIssueResponseBody",
+	name:           "[]components.Reaction",
 	operationID:    "reactions/list-for-issue",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReactionsListForIssueCommentResponseBody{}
+		target := []components.Reaction{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/issues/comments/{comment_id}/reactions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReactionsListForIssueCommentResponseBody",
+	name:           "[]components.Reaction",
 	operationID:    "reactions/list-for-issue-comment",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReactionsListForPullRequestReviewCommentResponseBody{}
+		target := []components.Reaction{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReactionsListForPullRequestReviewCommentResponseBody",
+	name:           "[]components.Reaction",
 	operationID:    "reactions/list-for-pull-request-review-comment",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReactionsListForTeamDiscussionCommentInOrgResponseBody{}
+		target := []components.Reaction{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReactionsListForTeamDiscussionCommentInOrgResponseBody",
+	name:           "[]components.Reaction",
 	operationID:    "reactions/list-for-team-discussion-comment-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReactionsListForTeamDiscussionCommentLegacyResponseBody{}
+		target := []components.Reaction{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}/reactions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReactionsListForTeamDiscussionCommentLegacyResponseBody",
+	name:           "[]components.Reaction",
 	operationID:    "reactions/list-for-team-discussion-comment-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReactionsListForTeamDiscussionInOrgResponseBody{}
+		target := []components.Reaction{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReactionsListForTeamDiscussionInOrgResponseBody",
+	name:           "[]components.Reaction",
 	operationID:    "reactions/list-for-team-discussion-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReactionsListForTeamDiscussionLegacyResponseBody{}
+		target := []components.Reaction{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/teams/{team_id}/discussions/{discussion_number}/reactions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReactionsListForTeamDiscussionLegacyResponseBody",
+	name:           "[]components.Reaction",
 	operationID:    "reactions/list-for-team-discussion-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposAddAppAccessRestrictionsResponseBody{}
+		target := []components.Integration{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps",
 	httpMethod:     "POST",
 	httpStatusCode: 200,
-	name:           "octo.ReposAddAppAccessRestrictionsResponseBody",
+	name:           "[]components.Integration",
 	operationID:    "repos/add-app-access-restrictions",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2754,23 +2754,23 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "repos/add-status-check-contexts",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposAddTeamAccessRestrictionsResponseBody{}
+		target := []components.Team{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams",
 	httpMethod:     "POST",
 	httpStatusCode: 200,
-	name:           "octo.ReposAddTeamAccessRestrictionsResponseBody",
+	name:           "[]components.Team",
 	operationID:    "repos/add-team-access-restrictions",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposAddUserAccessRestrictionsResponseBody{}
+		target := []components.SimpleUser{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users",
 	httpMethod:     "POST",
 	httpStatusCode: 200,
-	name:           "octo.ReposAddUserAccessRestrictionsResponseBody",
+	name:           "[]components.SimpleUser",
 	operationID:    "repos/add-user-access-restrictions",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2994,13 +2994,13 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "repos/get-all-topics",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetAppsWithAccessToProtectedBranchResponseBody{}
+		target := []components.Integration{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposGetAppsWithAccessToProtectedBranchResponseBody",
+	name:           "[]components.Integration",
 	operationID:    "repos/get-apps-with-access-to-protected-branch",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3034,13 +3034,13 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "repos/get-clones",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetCodeFrequencyStatsResponseBody{}
+		target := []components.CodeFrequencyStat{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/stats/code_frequency",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposGetCodeFrequencyStatsResponseBody",
+	name:           "[]components.CodeFrequencyStat",
 	operationID:    "repos/get-code-frequency-stats",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3074,13 +3074,13 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "repos/get-commit",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetCommitActivityStatsResponseBody{}
+		target := []components.CommitActivity{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/stats/commit_activity",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposGetCommitActivityStatsResponseBody",
+	name:           "[]components.CommitActivity",
 	operationID:    "repos/get-commit-activity-stats",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3124,13 +3124,13 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "repos/get-content",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetContributorsStatsResponseBody{}
+		target := []components.ContributorActivity{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/stats/contributors",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposGetContributorsStatsResponseBody",
+	name:           "[]components.ContributorActivity",
 	operationID:    "repos/get-contributors-stats",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3224,13 +3224,13 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "repos/get-pull-request-review-protection",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetPunchCardStatsResponseBody{}
+		target := []components.CodeFrequencyStat{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/stats/punch_card",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposGetPunchCardStatsResponseBody",
+	name:           "[]components.CodeFrequencyStat",
 	operationID:    "repos/get-punch-card-stats",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3284,43 +3284,43 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "repos/get-status-checks-protection",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetTeamsWithAccessToProtectedBranchResponseBody{}
+		target := []components.Team{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposGetTeamsWithAccessToProtectedBranchResponseBody",
+	name:           "[]components.Team",
 	operationID:    "repos/get-teams-with-access-to-protected-branch",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetTopPathsResponseBody{}
+		target := []components.ContentTraffic{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/traffic/popular/paths",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposGetTopPathsResponseBody",
+	name:           "[]components.ContentTraffic",
 	operationID:    "repos/get-top-paths",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetTopReferrersResponseBody{}
+		target := []components.ReferrerTraffic{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/traffic/popular/referrers",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposGetTopReferrersResponseBody",
+	name:           "[]components.ReferrerTraffic",
 	operationID:    "repos/get-top-referrers",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetUsersWithAccessToProtectedBranchResponseBody{}
+		target := []components.SimpleUser{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposGetUsersWithAccessToProtectedBranchResponseBody",
+	name:           "[]components.SimpleUser",
 	operationID:    "repos/get-users-with-access-to-protected-branch",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3344,173 +3344,173 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "repos/get-webhook",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposListBranchesResponseBody{}
+		target := []components.ShortBranch{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/branches",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposListBranchesResponseBody",
+	name:           "[]components.ShortBranch",
 	operationID:    "repos/list-branches",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposListBranchesForHeadCommitResponseBody{}
+		target := []components.BranchShort{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/commits/{commit_sha}/branches-where-head",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposListBranchesForHeadCommitResponseBody",
+	name:           "[]components.BranchShort",
 	operationID:    "repos/list-branches-for-head-commit",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposListCollaboratorsResponseBody{}
+		target := []components.Collaborator{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/collaborators",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposListCollaboratorsResponseBody",
+	name:           "[]components.Collaborator",
 	operationID:    "repos/list-collaborators",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposListCommentsForCommitResponseBody{}
+		target := []components.CommitComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/commits/{commit_sha}/comments",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposListCommentsForCommitResponseBody",
+	name:           "[]components.CommitComment",
 	operationID:    "repos/list-comments-for-commit",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposListCommitCommentsForRepoResponseBody{}
+		target := []components.CommitComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/comments",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposListCommitCommentsForRepoResponseBody",
+	name:           "[]components.CommitComment",
 	operationID:    "repos/list-commit-comments-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposListCommitStatusesForRefResponseBody{}
+		target := []components.Status{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/commits/{ref}/statuses",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposListCommitStatusesForRefResponseBody",
+	name:           "[]components.Status",
 	operationID:    "repos/list-commit-statuses-for-ref",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposListCommitsResponseBody{}
+		target := []components.SimpleCommit{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/commits",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposListCommitsResponseBody",
+	name:           "[]components.SimpleCommit",
 	operationID:    "repos/list-commits",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposListContributorsResponseBody{}
+		target := []components.Contributor{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/contributors",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposListContributorsResponseBody",
+	name:           "[]components.Contributor",
 	operationID:    "repos/list-contributors",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposListDeployKeysResponseBody{}
+		target := []components.DeployKey{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/keys",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposListDeployKeysResponseBody",
+	name:           "[]components.DeployKey",
 	operationID:    "repos/list-deploy-keys",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposListDeploymentStatusesResponseBody{}
+		target := []components.DeploymentStatus{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/deployments/{deployment_id}/statuses",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposListDeploymentStatusesResponseBody",
+	name:           "[]components.DeploymentStatus",
 	operationID:    "repos/list-deployment-statuses",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposListDeploymentsResponseBody{}
+		target := []components.Deployment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/deployments",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposListDeploymentsResponseBody",
+	name:           "[]components.Deployment",
 	operationID:    "repos/list-deployments",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposListForAuthenticatedUserResponseBody{}
+		target := []components.Repository{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/repos",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposListForAuthenticatedUserResponseBody",
+	name:           "[]components.Repository",
 	operationID:    "repos/list-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposListForOrgResponseBody{}
+		target := []components.MinimalRepository{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/repos",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposListForOrgResponseBody",
+	name:           "[]components.MinimalRepository",
 	operationID:    "repos/list-for-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposListForUserResponseBody{}
+		target := []components.MinimalRepository{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/users/{username}/repos",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposListForUserResponseBody",
+	name:           "[]components.MinimalRepository",
 	operationID:    "repos/list-for-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposListForksResponseBody{}
+		target := []components.MinimalRepository{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/forks",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposListForksResponseBody",
+	name:           "[]components.MinimalRepository",
 	operationID:    "repos/list-forks",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposListInvitationsResponseBody{}
+		target := []components.RepositoryInvitation{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/invitations",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposListInvitationsResponseBody",
+	name:           "[]components.RepositoryInvitation",
 	operationID:    "repos/list-invitations",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposListInvitationsForAuthenticatedUserResponseBody{}
+		target := []components.RepositoryInvitation{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/repository_invitations",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposListInvitationsForAuthenticatedUserResponseBody",
+	name:           "[]components.RepositoryInvitation",
 	operationID:    "repos/list-invitations-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3524,83 +3524,83 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "repos/list-languages",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposListPagesBuildsResponseBody{}
+		target := []components.PageBuild{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pages/builds",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposListPagesBuildsResponseBody",
+	name:           "[]components.PageBuild",
 	operationID:    "repos/list-pages-builds",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposListPublicResponseBody{}
+		target := []components.MinimalRepository{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repositories",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposListPublicResponseBody",
+	name:           "[]components.MinimalRepository",
 	operationID:    "repos/list-public",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposListPullRequestsAssociatedWithCommitResponseBody{}
+		target := []components.PullRequestSimple{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/commits/{commit_sha}/pulls",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposListPullRequestsAssociatedWithCommitResponseBody",
+	name:           "[]components.PullRequestSimple",
 	operationID:    "repos/list-pull-requests-associated-with-commit",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposListReleaseAssetsResponseBody{}
+		target := []components.ReleaseAsset{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/releases/{release_id}/assets",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposListReleaseAssetsResponseBody",
+	name:           "[]components.ReleaseAsset",
 	operationID:    "repos/list-release-assets",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposListReleasesResponseBody{}
+		target := []components.Release{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/releases",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposListReleasesResponseBody",
+	name:           "[]components.Release",
 	operationID:    "repos/list-releases",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposListTagsResponseBody{}
+		target := []components.Tag{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/tags",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposListTagsResponseBody",
+	name:           "[]components.Tag",
 	operationID:    "repos/list-tags",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposListTeamsResponseBody{}
+		target := []components.Team{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/teams",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposListTeamsResponseBody",
+	name:           "[]components.Team",
 	operationID:    "repos/list-teams",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposListWebhooksResponseBody{}
+		target := []components.Hook{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/hooks",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.ReposListWebhooksResponseBody",
+	name:           "[]components.Hook",
 	operationID:    "repos/list-webhooks",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3614,13 +3614,13 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "repos/merge",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposRemoveAppAccessRestrictionsResponseBody{}
+		target := []components.Integration{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps",
 	httpMethod:     "DELETE",
 	httpStatusCode: 200,
-	name:           "octo.ReposRemoveAppAccessRestrictionsResponseBody",
+	name:           "[]components.Integration",
 	operationID:    "repos/remove-app-access-restrictions",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3634,23 +3634,23 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "repos/remove-status-check-contexts",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposRemoveTeamAccessRestrictionsResponseBody{}
+		target := []components.Team{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams",
 	httpMethod:     "DELETE",
 	httpStatusCode: 200,
-	name:           "octo.ReposRemoveTeamAccessRestrictionsResponseBody",
+	name:           "[]components.Team",
 	operationID:    "repos/remove-team-access-restrictions",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposRemoveUserAccessRestrictionsResponseBody{}
+		target := []components.SimpleUser{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users",
 	httpMethod:     "DELETE",
 	httpStatusCode: 200,
-	name:           "octo.ReposRemoveUserAccessRestrictionsResponseBody",
+	name:           "[]components.SimpleUser",
 	operationID:    "repos/remove-user-access-restrictions",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3684,13 +3684,13 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "repos/set-admin-branch-protection",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposSetAppAccessRestrictionsResponseBody{}
+		target := []components.Integration{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps",
 	httpMethod:     "PUT",
 	httpStatusCode: 200,
-	name:           "octo.ReposSetAppAccessRestrictionsResponseBody",
+	name:           "[]components.Integration",
 	operationID:    "repos/set-app-access-restrictions",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3704,23 +3704,23 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "repos/set-status-check-contexts",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposSetTeamAccessRestrictionsResponseBody{}
+		target := []components.Team{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams",
 	httpMethod:     "PUT",
 	httpStatusCode: 200,
-	name:           "octo.ReposSetTeamAccessRestrictionsResponseBody",
+	name:           "[]components.Team",
 	operationID:    "repos/set-team-access-restrictions",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposSetUserAccessRestrictionsResponseBody{}
+		target := []components.SimpleUser{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users",
 	httpMethod:     "PUT",
 	httpStatusCode: 200,
-	name:           "octo.ReposSetUserAccessRestrictionsResponseBody",
+	name:           "[]components.SimpleUser",
 	operationID:    "repos/set-user-access-restrictions",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4154,83 +4154,83 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "teams/get-membership-for-user-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsListResponseBody{}
+		target := []components.Team{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.TeamsListResponseBody",
+	name:           "[]components.Team",
 	operationID:    "teams/list",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsListChildInOrgResponseBody{}
+		target := []components.Team{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/teams",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.TeamsListChildInOrgResponseBody",
+	name:           "[]components.Team",
 	operationID:    "teams/list-child-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsListChildLegacyResponseBody{}
+		target := []components.Team{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/teams/{team_id}/teams",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.TeamsListChildLegacyResponseBody",
+	name:           "[]components.Team",
 	operationID:    "teams/list-child-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsListDiscussionCommentsInOrgResponseBody{}
+		target := []components.TeamDiscussionComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.TeamsListDiscussionCommentsInOrgResponseBody",
+	name:           "[]components.TeamDiscussionComment",
 	operationID:    "teams/list-discussion-comments-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsListDiscussionCommentsLegacyResponseBody{}
+		target := []components.TeamDiscussionComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/teams/{team_id}/discussions/{discussion_number}/comments",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.TeamsListDiscussionCommentsLegacyResponseBody",
+	name:           "[]components.TeamDiscussionComment",
 	operationID:    "teams/list-discussion-comments-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsListDiscussionsInOrgResponseBody{}
+		target := []components.TeamDiscussion{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/discussions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.TeamsListDiscussionsInOrgResponseBody",
+	name:           "[]components.TeamDiscussion",
 	operationID:    "teams/list-discussions-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsListDiscussionsLegacyResponseBody{}
+		target := []components.TeamDiscussion{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/teams/{team_id}/discussions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.TeamsListDiscussionsLegacyResponseBody",
+	name:           "[]components.TeamDiscussion",
 	operationID:    "teams/list-discussions-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsListForAuthenticatedUserResponseBody{}
+		target := []components.TeamFull{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/teams",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.TeamsListForAuthenticatedUserResponseBody",
+	name:           "[]components.TeamFull",
 	operationID:    "teams/list-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4264,83 +4264,83 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "teams/list-idp-groups-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsListMembersInOrgResponseBody{}
+		target := []components.SimpleUser{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/members",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.TeamsListMembersInOrgResponseBody",
+	name:           "[]components.SimpleUser",
 	operationID:    "teams/list-members-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsListMembersLegacyResponseBody{}
+		target := []components.SimpleUser{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/teams/{team_id}/members",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.TeamsListMembersLegacyResponseBody",
+	name:           "[]components.SimpleUser",
 	operationID:    "teams/list-members-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsListPendingInvitationsInOrgResponseBody{}
+		target := []components.OrganizationInvitation{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/invitations",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.TeamsListPendingInvitationsInOrgResponseBody",
+	name:           "[]components.OrganizationInvitation",
 	operationID:    "teams/list-pending-invitations-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsListPendingInvitationsLegacyResponseBody{}
+		target := []components.OrganizationInvitation{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/teams/{team_id}/invitations",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.TeamsListPendingInvitationsLegacyResponseBody",
+	name:           "[]components.OrganizationInvitation",
 	operationID:    "teams/list-pending-invitations-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsListProjectsInOrgResponseBody{}
+		target := []components.TeamProject{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/projects",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.TeamsListProjectsInOrgResponseBody",
+	name:           "[]components.TeamProject",
 	operationID:    "teams/list-projects-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsListProjectsLegacyResponseBody{}
+		target := []components.TeamProject{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/teams/{team_id}/projects",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.TeamsListProjectsLegacyResponseBody",
+	name:           "[]components.TeamProject",
 	operationID:    "teams/list-projects-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsListReposInOrgResponseBody{}
+		target := []components.MinimalRepository{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/repos",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.TeamsListReposInOrgResponseBody",
+	name:           "[]components.MinimalRepository",
 	operationID:    "teams/list-repos-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsListReposLegacyResponseBody{}
+		target := []components.MinimalRepository{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/teams/{team_id}/repos",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.TeamsListReposLegacyResponseBody",
+	name:           "[]components.MinimalRepository",
 	operationID:    "teams/list-repos-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4404,13 +4404,13 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "teams/update-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.UsersAddEmailForAuthenticatedResponseBody{}
+		target := []components.Email{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/emails",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "octo.UsersAddEmailForAuthenticatedResponseBody",
+	name:           "[]components.Email",
 	operationID:    "users/add-email-for-authenticated",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4484,133 +4484,133 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	operationID:    "users/get-public-ssh-key-for-authenticated",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.UsersListResponseBody{}
+		target := []components.SimpleUser{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/users",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.UsersListResponseBody",
+	name:           "[]components.SimpleUser",
 	operationID:    "users/list",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.UsersListBlockedByAuthenticatedResponseBody{}
+		target := []components.SimpleUser{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/blocks",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.UsersListBlockedByAuthenticatedResponseBody",
+	name:           "[]components.SimpleUser",
 	operationID:    "users/list-blocked-by-authenticated",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.UsersListEmailsForAuthenticatedResponseBody{}
+		target := []components.Email{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/emails",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.UsersListEmailsForAuthenticatedResponseBody",
+	name:           "[]components.Email",
 	operationID:    "users/list-emails-for-authenticated",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.UsersListFollowedByAuthenticatedResponseBody{}
+		target := []components.SimpleUser{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/following",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.UsersListFollowedByAuthenticatedResponseBody",
+	name:           "[]components.SimpleUser",
 	operationID:    "users/list-followed-by-authenticated",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.UsersListFollowersForAuthenticatedUserResponseBody{}
+		target := []components.SimpleUser{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/followers",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.UsersListFollowersForAuthenticatedUserResponseBody",
+	name:           "[]components.SimpleUser",
 	operationID:    "users/list-followers-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.UsersListFollowersForUserResponseBody{}
+		target := []components.SimpleUser{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/users/{username}/followers",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.UsersListFollowersForUserResponseBody",
+	name:           "[]components.SimpleUser",
 	operationID:    "users/list-followers-for-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.UsersListFollowingForUserResponseBody{}
+		target := []components.SimpleUser{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/users/{username}/following",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.UsersListFollowingForUserResponseBody",
+	name:           "[]components.SimpleUser",
 	operationID:    "users/list-following-for-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.UsersListGpgKeysForAuthenticatedResponseBody{}
+		target := []components.GpgKey{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/gpg_keys",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.UsersListGpgKeysForAuthenticatedResponseBody",
+	name:           "[]components.GpgKey",
 	operationID:    "users/list-gpg-keys-for-authenticated",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.UsersListGpgKeysForUserResponseBody{}
+		target := []components.GpgKey{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/users/{username}/gpg_keys",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.UsersListGpgKeysForUserResponseBody",
+	name:           "[]components.GpgKey",
 	operationID:    "users/list-gpg-keys-for-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.UsersListPublicEmailsForAuthenticatedResponseBody{}
+		target := []components.Email{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/public_emails",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.UsersListPublicEmailsForAuthenticatedResponseBody",
+	name:           "[]components.Email",
 	operationID:    "users/list-public-emails-for-authenticated",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.UsersListPublicKeysForUserResponseBody{}
+		target := []components.KeySimple{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/users/{username}/keys",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.UsersListPublicKeysForUserResponseBody",
+	name:           "[]components.KeySimple",
 	operationID:    "users/list-public-keys-for-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.UsersListPublicSshKeysForAuthenticatedResponseBody{}
+		target := []components.Key{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/keys",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "octo.UsersListPublicSshKeysForAuthenticatedResponseBody",
+	name:           "[]components.Key",
 	operationID:    "users/list-public-ssh-keys-for-authenticated",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.UsersSetPrimaryEmailVisibilityForAuthenticatedResponseBody{}
+		target := []components.Email{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/email/visibility",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "octo.UsersSetPrimaryEmailVisibilityForAuthenticatedResponseBody",
+	name:           "[]components.Email",
 	operationID:    "users/set-primary-email-visibility-for-authenticated",
 }, {
 	decode: func(decoder *json.Decoder) error {

--- a/zz_unmarshal_gen_test.go
+++ b/zz_unmarshal_gen_test.go
@@ -5,6 +5,7 @@ package octo_test
 import (
 	"encoding/json"
 	"github.com/willabides/octo-go"
+	components "github.com/willabides/octo-go/components"
 )
 
 func init() {
@@ -13,163 +14,163 @@ func init() {
 
 var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActionsCreateRegistrationTokenForOrgResponseBody{}
+		target := components.AuthenticationToken{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/actions/runners/registration-token",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ActionsCreateRegistrationTokenForOrgResponseBody",
+	name:           "components.AuthenticationToken",
 	operationID:    "actions/create-registration-token-for-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActionsCreateRegistrationTokenForRepoResponseBody{}
+		target := components.AuthenticationToken{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/actions/runners/registration-token",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ActionsCreateRegistrationTokenForRepoResponseBody",
+	name:           "components.AuthenticationToken",
 	operationID:    "actions/create-registration-token-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActionsCreateRemoveTokenForOrgResponseBody{}
+		target := components.AuthenticationToken{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/actions/runners/remove-token",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ActionsCreateRemoveTokenForOrgResponseBody",
+	name:           "components.AuthenticationToken",
 	operationID:    "actions/create-remove-token-for-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActionsCreateRemoveTokenForRepoResponseBody{}
+		target := components.AuthenticationToken{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/actions/runners/remove-token",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ActionsCreateRemoveTokenForRepoResponseBody",
+	name:           "components.AuthenticationToken",
 	operationID:    "actions/create-remove-token-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActionsGetArtifactResponseBody{}
+		target := components.Artifact{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/actions/artifacts/{artifact_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActionsGetArtifactResponseBody",
+	name:           "components.Artifact",
 	operationID:    "actions/get-artifact",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActionsGetJobForWorkflowRunResponseBody{}
+		target := components.Job{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/actions/jobs/{job_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 202,
-	name:           "ActionsGetJobForWorkflowRunResponseBody",
+	name:           "components.Job",
 	operationID:    "actions/get-job-for-workflow-run",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActionsGetOrgPublicKeyResponseBody{}
+		target := components.ActionsPublicKey{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/actions/secrets/public-key",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActionsGetOrgPublicKeyResponseBody",
+	name:           "components.ActionsPublicKey",
 	operationID:    "actions/get-org-public-key",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActionsGetOrgSecretResponseBody{}
+		target := components.OrganizationActionsSecret{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/actions/secrets/{secret_name}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActionsGetOrgSecretResponseBody",
+	name:           "components.OrganizationActionsSecret",
 	operationID:    "actions/get-org-secret",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActionsGetRepoPublicKeyResponseBody{}
+		target := components.ActionsPublicKey{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/actions/secrets/public-key",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActionsGetRepoPublicKeyResponseBody",
+	name:           "components.ActionsPublicKey",
 	operationID:    "actions/get-repo-public-key",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActionsGetRepoSecretResponseBody{}
+		target := components.ActionsSecret{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/actions/secrets/{secret_name}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActionsGetRepoSecretResponseBody",
+	name:           "components.ActionsSecret",
 	operationID:    "actions/get-repo-secret",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActionsGetSelfHostedRunnerForOrgResponseBody{}
+		target := components.Runner{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/actions/runners/{runner_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActionsGetSelfHostedRunnerForOrgResponseBody",
+	name:           "components.Runner",
 	operationID:    "actions/get-self-hosted-runner-for-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActionsGetSelfHostedRunnerForRepoResponseBody{}
+		target := components.Runner{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/actions/runners/{runner_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActionsGetSelfHostedRunnerForRepoResponseBody",
+	name:           "components.Runner",
 	operationID:    "actions/get-self-hosted-runner-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActionsGetWorkflowResponseBody{}
+		target := components.Workflow{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/actions/workflows/{workflow_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActionsGetWorkflowResponseBody",
+	name:           "components.Workflow",
 	operationID:    "actions/get-workflow",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActionsGetWorkflowRunResponseBody{}
+		target := components.WorkflowRun{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/actions/runs/{run_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActionsGetWorkflowRunResponseBody",
+	name:           "components.WorkflowRun",
 	operationID:    "actions/get-workflow-run",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActionsGetWorkflowRunUsageResponseBody{}
+		target := components.WorkflowRunUsage{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/actions/runs/{run_id}/timing",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActionsGetWorkflowRunUsageResponseBody",
+	name:           "components.WorkflowRunUsage",
 	operationID:    "actions/get-workflow-run-usage",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActionsGetWorkflowUsageResponseBody{}
+		target := components.WorkflowUsage{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/actions/workflows/{workflow_id}/timing",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActionsGetWorkflowUsageResponseBody",
+	name:           "components.WorkflowUsage",
 	operationID:    "actions/get-workflow-usage",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -179,7 +180,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/actions/artifacts",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActionsListArtifactsForRepoResponseBody",
+	name:           "octo.ActionsListArtifactsForRepoResponseBody",
 	operationID:    "actions/list-artifacts-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -189,7 +190,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/actions/runs/{run_id}/jobs",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActionsListJobsForWorkflowRunResponseBody",
+	name:           "octo.ActionsListJobsForWorkflowRunResponseBody",
 	operationID:    "actions/list-jobs-for-workflow-run",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -199,7 +200,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/actions/secrets",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActionsListOrgSecretsResponseBody",
+	name:           "octo.ActionsListOrgSecretsResponseBody",
 	operationID:    "actions/list-org-secrets",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -209,7 +210,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/actions/secrets",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActionsListRepoSecretsResponseBody",
+	name:           "octo.ActionsListRepoSecretsResponseBody",
 	operationID:    "actions/list-repo-secrets",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -219,7 +220,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/actions/workflows",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActionsListRepoWorkflowsResponseBody",
+	name:           "octo.ActionsListRepoWorkflowsResponseBody",
 	operationID:    "actions/list-repo-workflows",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -229,7 +230,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/actions/runners/downloads",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActionsListRunnerApplicationsForOrgResponseBody",
+	name:           "octo.ActionsListRunnerApplicationsForOrgResponseBody",
 	operationID:    "actions/list-runner-applications-for-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -239,7 +240,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/actions/runners/downloads",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActionsListRunnerApplicationsForRepoResponseBody",
+	name:           "octo.ActionsListRunnerApplicationsForRepoResponseBody",
 	operationID:    "actions/list-runner-applications-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -249,7 +250,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/actions/secrets/{secret_name}/repositories",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActionsListSelectedReposForOrgSecretResponseBody",
+	name:           "octo.ActionsListSelectedReposForOrgSecretResponseBody",
 	operationID:    "actions/list-selected-repos-for-org-secret",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -259,7 +260,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/actions/runners",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActionsListSelfHostedRunnersForOrgResponseBody",
+	name:           "octo.ActionsListSelfHostedRunnersForOrgResponseBody",
 	operationID:    "actions/list-self-hosted-runners-for-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -269,7 +270,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/actions/runners",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActionsListSelfHostedRunnersForRepoResponseBody",
+	name:           "octo.ActionsListSelfHostedRunnersForRepoResponseBody",
 	operationID:    "actions/list-self-hosted-runners-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -279,7 +280,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/actions/runs/{run_id}/artifacts",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActionsListWorkflowRunArtifactsResponseBody",
+	name:           "octo.ActionsListWorkflowRunArtifactsResponseBody",
 	operationID:    "actions/list-workflow-run-artifacts",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -289,7 +290,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActionsListWorkflowRunsResponseBody",
+	name:           "octo.ActionsListWorkflowRunsResponseBody",
 	operationID:    "actions/list-workflow-runs",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -299,47 +300,47 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/actions/runs",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActionsListWorkflowRunsForRepoResponseBody",
+	name:           "octo.ActionsListWorkflowRunsForRepoResponseBody",
 	operationID:    "actions/list-workflow-runs-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActivityGetFeedsResponseBody{}
+		target := components.Feed{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/feeds",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActivityGetFeedsResponseBody",
+	name:           "components.Feed",
 	operationID:    "activity/get-feeds",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActivityGetRepoSubscriptionResponseBody{}
+		target := components.RepositorySubscription{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/subscription",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActivityGetRepoSubscriptionResponseBody",
+	name:           "components.RepositorySubscription",
 	operationID:    "activity/get-repo-subscription",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActivityGetThreadResponseBody{}
+		target := components.Thread{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/notifications/threads/{thread_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActivityGetThreadResponseBody",
+	name:           "components.Thread",
 	operationID:    "activity/get-thread",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActivityGetThreadSubscriptionForAuthenticatedUserResponseBody{}
+		target := components.ThreadSubscription{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/notifications/threads/{thread_id}/subscription",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActivityGetThreadSubscriptionForAuthenticatedUserResponseBody",
+	name:           "components.ThreadSubscription",
 	operationID:    "activity/get-thread-subscription-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -349,7 +350,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/notifications",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActivityListNotificationsForAuthenticatedUserResponseBody",
+	name:           "octo.ActivityListNotificationsForAuthenticatedUserResponseBody",
 	operationID:    "activity/list-notifications-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -359,7 +360,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/notifications",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActivityListRepoNotificationsForAuthenticatedUserResponseBody",
+	name:           "octo.ActivityListRepoNotificationsForAuthenticatedUserResponseBody",
 	operationID:    "activity/list-repo-notifications-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -369,7 +370,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/user/starred",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActivityListReposStarredByAuthenticatedUserResponseBody",
+	name:           "octo.ActivityListReposStarredByAuthenticatedUserResponseBody",
 	operationID:    "activity/list-repos-starred-by-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -379,7 +380,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/users/{username}/starred",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActivityListReposStarredByUserResponseBody",
+	name:           "octo.ActivityListReposStarredByUserResponseBody",
 	operationID:    "activity/list-repos-starred-by-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -389,7 +390,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/users/{username}/subscriptions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActivityListReposWatchedByUserResponseBody",
+	name:           "octo.ActivityListReposWatchedByUserResponseBody",
 	operationID:    "activity/list-repos-watched-by-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -399,7 +400,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/stargazers",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActivityListStargazersForRepoResponseBody",
+	name:           "octo.ActivityListStargazersForRepoResponseBody",
 	operationID:    "activity/list-stargazers-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -409,7 +410,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/user/subscriptions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActivityListWatchedReposForAuthenticatedUserResponseBody",
+	name:           "octo.ActivityListWatchedReposForAuthenticatedUserResponseBody",
 	operationID:    "activity/list-watched-repos-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -419,27 +420,27 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/subscribers",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ActivityListWatchersForRepoResponseBody",
+	name:           "octo.ActivityListWatchersForRepoResponseBody",
 	operationID:    "activity/list-watchers-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActivitySetRepoSubscriptionResponseBody{}
+		target := components.RepositorySubscription{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/subscription",
 	httpMethod:     "PUT",
 	httpStatusCode: 200,
-	name:           "ActivitySetRepoSubscriptionResponseBody",
+	name:           "components.RepositorySubscription",
 	operationID:    "activity/set-repo-subscription",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ActivitySetThreadSubscriptionResponseBody{}
+		target := components.ThreadSubscription{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/notifications/threads/{thread_id}/subscription",
 	httpMethod:     "PUT",
 	httpStatusCode: 200,
-	name:           "ActivitySetThreadSubscriptionResponseBody",
+	name:           "components.ThreadSubscription",
 	operationID:    "activity/set-thread-subscription",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -449,27 +450,27 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/applications/{client_id}/tokens/{access_token}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "AppsCheckAuthorizationResponseBody",
+	name:           "octo.AppsCheckAuthorizationResponseBody",
 	operationID:    "apps/check-authorization",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.AppsCheckTokenResponseBody{}
+		target := components.Authorization{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/applications/{client_id}/token",
 	httpMethod:     "POST",
 	httpStatusCode: 200,
-	name:           "AppsCheckTokenResponseBody",
+	name:           "components.Authorization",
 	operationID:    "apps/check-token",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.AppsCreateContentAttachmentResponseBody{}
+		target := components.ContentReferenceAttachment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/content_references/{content_reference_id}/attachments",
 	httpMethod:     "POST",
 	httpStatusCode: 200,
-	name:           "AppsCreateContentAttachmentResponseBody",
+	name:           "components.ContentReferenceAttachment",
 	operationID:    "apps/create-content-attachment",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -479,97 +480,97 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/app-manifests/{code}/conversions",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "AppsCreateFromManifestResponseBody",
+	name:           "octo.AppsCreateFromManifestResponseBody",
 	operationID:    "apps/create-from-manifest",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.AppsCreateInstallationAccessTokenResponseBody{}
+		target := components.InstallationToken{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/app/installations/{installation_id}/access_tokens",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "AppsCreateInstallationAccessTokenResponseBody",
+	name:           "components.InstallationToken",
 	operationID:    "apps/create-installation-access-token",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.AppsGetAuthenticatedResponseBody{}
+		target := components.Integration{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/app",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "AppsGetAuthenticatedResponseBody",
+	name:           "components.Integration",
 	operationID:    "apps/get-authenticated",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.AppsGetBySlugResponseBody{}
+		target := components.Integration{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/apps/{app_slug}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "AppsGetBySlugResponseBody",
+	name:           "components.Integration",
 	operationID:    "apps/get-by-slug",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.AppsGetInstallationResponseBody{}
+		target := components.Installation{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/app/installations/{installation_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "AppsGetInstallationResponseBody",
+	name:           "components.Installation",
 	operationID:    "apps/get-installation",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.AppsGetOrgInstallationResponseBody{}
+		target := components.Installation{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/installation",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "AppsGetOrgInstallationResponseBody",
+	name:           "components.Installation",
 	operationID:    "apps/get-org-installation",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.AppsGetRepoInstallationResponseBody{}
+		target := components.Installation{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/installation",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "AppsGetRepoInstallationResponseBody",
+	name:           "components.Installation",
 	operationID:    "apps/get-repo-installation",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.AppsGetSubscriptionPlanForAccountResponseBody{}
+		target := components.MarketplacePurchase{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/marketplace_listing/accounts/{account_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "AppsGetSubscriptionPlanForAccountResponseBody",
+	name:           "components.MarketplacePurchase",
 	operationID:    "apps/get-subscription-plan-for-account",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.AppsGetSubscriptionPlanForAccountStubbedResponseBody{}
+		target := components.MarketplacePurchase{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/marketplace_listing/stubbed/accounts/{account_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "AppsGetSubscriptionPlanForAccountStubbedResponseBody",
+	name:           "components.MarketplacePurchase",
 	operationID:    "apps/get-subscription-plan-for-account-stubbed",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.AppsGetUserInstallationResponseBody{}
+		target := components.Installation{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/users/{username}/installation",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "AppsGetUserInstallationResponseBody",
+	name:           "components.Installation",
 	operationID:    "apps/get-user-installation",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -579,7 +580,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/marketplace_listing/plans/{plan_id}/accounts",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "AppsListAccountsForPlanResponseBody",
+	name:           "octo.AppsListAccountsForPlanResponseBody",
 	operationID:    "apps/list-accounts-for-plan",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -589,7 +590,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/marketplace_listing/stubbed/plans/{plan_id}/accounts",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "AppsListAccountsForPlanStubbedResponseBody",
+	name:           "octo.AppsListAccountsForPlanStubbedResponseBody",
 	operationID:    "apps/list-accounts-for-plan-stubbed",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -599,7 +600,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/user/installations/{installation_id}/repositories",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "AppsListInstallationReposForAuthenticatedUserResponseBody",
+	name:           "octo.AppsListInstallationReposForAuthenticatedUserResponseBody",
 	operationID:    "apps/list-installation-repos-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -609,7 +610,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/app/installations",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "AppsListInstallationsResponseBody",
+	name:           "octo.AppsListInstallationsResponseBody",
 	operationID:    "apps/list-installations",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -619,7 +620,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/user/installations",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "AppsListInstallationsForAuthenticatedUserResponseBody",
+	name:           "octo.AppsListInstallationsForAuthenticatedUserResponseBody",
 	operationID:    "apps/list-installations-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -629,7 +630,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/marketplace_listing/plans",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "AppsListPlansResponseBody",
+	name:           "octo.AppsListPlansResponseBody",
 	operationID:    "apps/list-plans",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -639,7 +640,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/marketplace_listing/stubbed/plans",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "AppsListPlansStubbedResponseBody",
+	name:           "octo.AppsListPlansStubbedResponseBody",
 	operationID:    "apps/list-plans-stubbed",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -649,7 +650,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/installation/repositories",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "AppsListReposAccessibleToInstallationResponseBody",
+	name:           "octo.AppsListReposAccessibleToInstallationResponseBody",
 	operationID:    "apps/list-repos-accessible-to-installation",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -659,7 +660,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/user/marketplace_purchases",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "AppsListSubscriptionsForAuthenticatedUserResponseBody",
+	name:           "octo.AppsListSubscriptionsForAuthenticatedUserResponseBody",
 	operationID:    "apps/list-subscriptions-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -669,157 +670,157 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/user/marketplace_purchases/stubbed",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "AppsListSubscriptionsForAuthenticatedUserStubbedResponseBody",
+	name:           "octo.AppsListSubscriptionsForAuthenticatedUserStubbedResponseBody",
 	operationID:    "apps/list-subscriptions-for-authenticated-user-stubbed",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.AppsResetAuthorizationResponseBody{}
+		target := components.Authorization{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/applications/{client_id}/tokens/{access_token}",
 	httpMethod:     "POST",
 	httpStatusCode: 200,
-	name:           "AppsResetAuthorizationResponseBody",
+	name:           "components.Authorization",
 	operationID:    "apps/reset-authorization",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.AppsResetTokenResponseBody{}
+		target := components.Authorization{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/applications/{client_id}/token",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "AppsResetTokenResponseBody",
+	name:           "components.Authorization",
 	operationID:    "apps/reset-token",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.BillingGetGithubActionsBillingGheResponseBody{}
+		target := components.ActionsBillingUsage{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/enterprises/{enterprise_id}/settings/billing/actions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "BillingGetGithubActionsBillingGheResponseBody",
+	name:           "components.ActionsBillingUsage",
 	operationID:    "billing/get-github-actions-billing-ghe",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.BillingGetGithubActionsBillingOrgResponseBody{}
+		target := components.ActionsBillingUsage{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/settings/billing/actions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "BillingGetGithubActionsBillingOrgResponseBody",
+	name:           "components.ActionsBillingUsage",
 	operationID:    "billing/get-github-actions-billing-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.BillingGetGithubActionsBillingUserResponseBody{}
+		target := components.ActionsBillingUsage{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/users/{username}/settings/billing/actions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "BillingGetGithubActionsBillingUserResponseBody",
+	name:           "components.ActionsBillingUsage",
 	operationID:    "billing/get-github-actions-billing-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.BillingGetGithubPackagesBillingGheResponseBody{}
+		target := components.PackagesBillingUsage{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/enterprises/{enterprise_id}/settings/billing/packages",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "BillingGetGithubPackagesBillingGheResponseBody",
+	name:           "components.PackagesBillingUsage",
 	operationID:    "billing/get-github-packages-billing-ghe",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.BillingGetGithubPackagesBillingOrgResponseBody{}
+		target := components.PackagesBillingUsage{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/settings/billing/packages",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "BillingGetGithubPackagesBillingOrgResponseBody",
+	name:           "components.PackagesBillingUsage",
 	operationID:    "billing/get-github-packages-billing-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.BillingGetGithubPackagesBillingUserResponseBody{}
+		target := components.PackagesBillingUsage{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/users/{username}/settings/billing/packages",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "BillingGetGithubPackagesBillingUserResponseBody",
+	name:           "components.PackagesBillingUsage",
 	operationID:    "billing/get-github-packages-billing-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.BillingGetSharedStorageBillingGheResponseBody{}
+		target := components.CombinedBillingUsage{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/enterprises/{enterprise_id}/settings/billing/shared-storage",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "BillingGetSharedStorageBillingGheResponseBody",
+	name:           "components.CombinedBillingUsage",
 	operationID:    "billing/get-shared-storage-billing-ghe",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.BillingGetSharedStorageBillingOrgResponseBody{}
+		target := components.CombinedBillingUsage{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/settings/billing/shared-storage",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "BillingGetSharedStorageBillingOrgResponseBody",
+	name:           "components.CombinedBillingUsage",
 	operationID:    "billing/get-shared-storage-billing-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.BillingGetSharedStorageBillingUserResponseBody{}
+		target := components.CombinedBillingUsage{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/users/{username}/settings/billing/shared-storage",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "BillingGetSharedStorageBillingUserResponseBody",
+	name:           "components.CombinedBillingUsage",
 	operationID:    "billing/get-shared-storage-billing-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ChecksCreateResponseBody{}
+		target := components.CheckRun{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/check-runs",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ChecksCreateResponseBody",
+	name:           "components.CheckRun",
 	operationID:    "checks/create",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ChecksCreateSuiteResponseBody{}
+		target := components.CheckSuite{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/check-suites",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ChecksCreateSuiteResponseBody",
+	name:           "components.CheckSuite",
 	operationID:    "checks/create-suite",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ChecksGetResponseBody{}
+		target := components.CheckRun{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/check-runs/{check_run_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ChecksGetResponseBody",
+	name:           "components.CheckRun",
 	operationID:    "checks/get",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ChecksGetSuiteResponseBody{}
+		target := components.CheckSuite{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/check-suites/{check_suite_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ChecksGetSuiteResponseBody",
+	name:           "components.CheckSuite",
 	operationID:    "checks/get-suite",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -829,7 +830,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/check-runs/{check_run_id}/annotations",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ChecksListAnnotationsResponseBody",
+	name:           "octo.ChecksListAnnotationsResponseBody",
 	operationID:    "checks/list-annotations",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -839,7 +840,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/commits/{ref}/check-runs",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ChecksListForRefResponseBody",
+	name:           "octo.ChecksListForRefResponseBody",
 	operationID:    "checks/list-for-ref",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -849,7 +850,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ChecksListForSuiteResponseBody",
+	name:           "octo.ChecksListForSuiteResponseBody",
 	operationID:    "checks/list-for-suite",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -859,37 +860,37 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/commits/{ref}/check-suites",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ChecksListSuitesForRefResponseBody",
+	name:           "octo.ChecksListSuitesForRefResponseBody",
 	operationID:    "checks/list-suites-for-ref",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ChecksSetSuitesPreferencesResponseBody{}
+		target := components.CheckSuitePreference{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/check-suites/preferences",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "ChecksSetSuitesPreferencesResponseBody",
+	name:           "components.CheckSuitePreference",
 	operationID:    "checks/set-suites-preferences",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ChecksUpdateResponseBody{}
+		target := components.CheckRun{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/check-runs/{check_run_id}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "ChecksUpdateResponseBody",
+	name:           "components.CheckRun",
 	operationID:    "checks/update",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.CodeScanningGetAlertResponseBody{}
+		target := components.CodeScanningAlert{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/code-scanning/alerts/{alert_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "CodeScanningGetAlertResponseBody",
+	name:           "components.CodeScanningAlert",
 	operationID:    "code-scanning/get-alert",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -899,7 +900,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/code-scanning/alerts",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "CodeScanningListAlertsForRepoResponseBody",
+	name:           "octo.CodeScanningListAlertsForRepoResponseBody",
 	operationID:    "code-scanning/list-alerts-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -909,87 +910,87 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/codes_of_conduct",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "CodesOfConductGetAllCodesOfConductResponseBody",
+	name:           "octo.CodesOfConductGetAllCodesOfConductResponseBody",
 	operationID:    "codes-of-conduct/get-all-codes-of-conduct",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.CodesOfConductGetConductCodeResponseBody{}
+		target := components.CodeOfConduct{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/codes_of_conduct/{key}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "CodesOfConductGetConductCodeResponseBody",
+	name:           "components.CodeOfConduct",
 	operationID:    "codes-of-conduct/get-conduct-code",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.CodesOfConductGetForRepoResponseBody{}
+		target := components.CodeOfConduct{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/community/code_of_conduct",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "CodesOfConductGetForRepoResponseBody",
+	name:           "components.CodeOfConduct",
 	operationID:    "codes-of-conduct/get-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GistsCreateResponseBody{}
+		target := components.GistFull{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/gists",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "GistsCreateResponseBody",
+	name:           "components.GistFull",
 	operationID:    "gists/create",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GistsCreateCommentResponseBody{}
+		target := components.GistComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/gists/{gist_id}/comments",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "GistsCreateCommentResponseBody",
+	name:           "components.GistComment",
 	operationID:    "gists/create-comment",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GistsForkResponseBody{}
+		target := components.BaseGist{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/gists/{gist_id}/forks",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "GistsForkResponseBody",
+	name:           "components.BaseGist",
 	operationID:    "gists/fork",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GistsGetResponseBody{}
+		target := components.GistFull{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/gists/{gist_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "GistsGetResponseBody",
+	name:           "components.GistFull",
 	operationID:    "gists/get",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GistsGetCommentResponseBody{}
+		target := components.GistComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/gists/{gist_id}/comments/{comment_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "GistsGetCommentResponseBody",
+	name:           "components.GistComment",
 	operationID:    "gists/get-comment",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GistsGetRevisionResponseBody{}
+		target := components.GistFull{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/gists/{gist_id}/{sha}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "GistsGetRevisionResponseBody",
+	name:           "components.GistFull",
 	operationID:    "gists/get-revision",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -999,7 +1000,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/gists",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "GistsListResponseBody",
+	name:           "octo.GistsListResponseBody",
 	operationID:    "gists/list",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1009,7 +1010,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/gists/{gist_id}/comments",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "GistsListCommentsResponseBody",
+	name:           "octo.GistsListCommentsResponseBody",
 	operationID:    "gists/list-comments",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1019,7 +1020,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/gists/{gist_id}/commits",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "GistsListCommitsResponseBody",
+	name:           "octo.GistsListCommitsResponseBody",
 	operationID:    "gists/list-commits",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1029,7 +1030,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/users/{username}/gists",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "GistsListForUserResponseBody",
+	name:           "octo.GistsListForUserResponseBody",
 	operationID:    "gists/list-for-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1039,7 +1040,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/gists/{gist_id}/forks",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "GistsListForksResponseBody",
+	name:           "octo.GistsListForksResponseBody",
 	operationID:    "gists/list-forks",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1049,7 +1050,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/gists/public",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "GistsListPublicResponseBody",
+	name:           "octo.GistsListPublicResponseBody",
 	operationID:    "gists/list-public",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1059,127 +1060,127 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/gists/starred",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "GistsListStarredResponseBody",
+	name:           "octo.GistsListStarredResponseBody",
 	operationID:    "gists/list-starred",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GistsUpdateResponseBody{}
+		target := components.GistFull{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/gists/{gist_id}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "GistsUpdateResponseBody",
+	name:           "components.GistFull",
 	operationID:    "gists/update",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GistsUpdateCommentResponseBody{}
+		target := components.GistComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/gists/{gist_id}/comments/{comment_id}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "GistsUpdateCommentResponseBody",
+	name:           "components.GistComment",
 	operationID:    "gists/update-comment",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GitCreateBlobResponseBody{}
+		target := components.ShortBlob{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/git/blobs",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "GitCreateBlobResponseBody",
+	name:           "components.ShortBlob",
 	operationID:    "git/create-blob",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GitCreateCommitResponseBody{}
+		target := components.GitCommit{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/git/commits",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "GitCreateCommitResponseBody",
+	name:           "components.GitCommit",
 	operationID:    "git/create-commit",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GitCreateRefResponseBody{}
+		target := components.GitRef{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/git/refs",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "GitCreateRefResponseBody",
+	name:           "components.GitRef",
 	operationID:    "git/create-ref",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GitCreateTagResponseBody{}
+		target := components.GitTag{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/git/tags",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "GitCreateTagResponseBody",
+	name:           "components.GitTag",
 	operationID:    "git/create-tag",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GitCreateTreeResponseBody{}
+		target := components.GitTree{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/git/trees",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "GitCreateTreeResponseBody",
+	name:           "components.GitTree",
 	operationID:    "git/create-tree",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GitGetBlobResponseBody{}
+		target := components.Blob{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/git/blobs/{file_sha}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "GitGetBlobResponseBody",
+	name:           "components.Blob",
 	operationID:    "git/get-blob",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GitGetCommitResponseBody{}
+		target := components.GitCommit{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/git/commits/{commit_sha}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "GitGetCommitResponseBody",
+	name:           "components.GitCommit",
 	operationID:    "git/get-commit",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GitGetRefResponseBody{}
+		target := components.GitRef{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/git/ref/{ref}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "GitGetRefResponseBody",
+	name:           "components.GitRef",
 	operationID:    "git/get-ref",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GitGetTagResponseBody{}
+		target := components.GitTag{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/git/tags/{tag_sha}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "GitGetTagResponseBody",
+	name:           "components.GitTag",
 	operationID:    "git/get-tag",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GitGetTreeResponseBody{}
+		target := components.GitTree{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/git/trees/{tree_sha}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "GitGetTreeResponseBody",
+	name:           "components.GitTree",
 	operationID:    "git/get-tree",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1189,17 +1190,17 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/git/matching-refs/{ref}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "GitListMatchingRefsResponseBody",
+	name:           "octo.GitListMatchingRefsResponseBody",
 	operationID:    "git/list-matching-refs",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GitUpdateRefResponseBody{}
+		target := components.GitRef{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/git/refs/{ref}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "GitUpdateRefResponseBody",
+	name:           "components.GitRef",
 	operationID:    "git/update-ref",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1209,67 +1210,67 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/gitignore/templates",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "GitignoreGetAllTemplatesResponseBody",
+	name:           "octo.GitignoreGetAllTemplatesResponseBody",
 	operationID:    "gitignore/get-all-templates",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.GitignoreGetTemplateResponseBody{}
+		target := components.GitignoreTemplate{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/gitignore/templates/{name}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "GitignoreGetTemplateResponseBody",
+	name:           "components.GitignoreTemplate",
 	operationID:    "gitignore/get-template",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.InteractionsGetRestrictionsForOrgResponseBody{}
+		target := components.InteractionLimit{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/interaction-limits",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "InteractionsGetRestrictionsForOrgResponseBody",
+	name:           "components.InteractionLimit",
 	operationID:    "interactions/get-restrictions-for-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.InteractionsGetRestrictionsForRepoResponseBody{}
+		target := components.InteractionLimit{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/interaction-limits",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "InteractionsGetRestrictionsForRepoResponseBody",
+	name:           "components.InteractionLimit",
 	operationID:    "interactions/get-restrictions-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.InteractionsSetRestrictionsForOrgResponseBody{}
+		target := components.InteractionLimit{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/interaction-limits",
 	httpMethod:     "PUT",
 	httpStatusCode: 200,
-	name:           "InteractionsSetRestrictionsForOrgResponseBody",
+	name:           "components.InteractionLimit",
 	operationID:    "interactions/set-restrictions-for-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.InteractionsSetRestrictionsForRepoResponseBody{}
+		target := components.InteractionLimit{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/interaction-limits",
 	httpMethod:     "PUT",
 	httpStatusCode: 200,
-	name:           "InteractionsSetRestrictionsForRepoResponseBody",
+	name:           "components.InteractionLimit",
 	operationID:    "interactions/set-restrictions-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesAddAssigneesResponseBody{}
+		target := components.IssueSimple{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/issues/{issue_number}/assignees",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "IssuesAddAssigneesResponseBody",
+	name:           "components.IssueSimple",
 	operationID:    "issues/add-assignees",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1279,97 +1280,97 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/issues/{issue_number}/labels",
 	httpMethod:     "POST",
 	httpStatusCode: 200,
-	name:           "IssuesAddLabelsResponseBody",
+	name:           "octo.IssuesAddLabelsResponseBody",
 	operationID:    "issues/add-labels",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesCreateResponseBody{}
+		target := components.Issue{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/issues",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "IssuesCreateResponseBody",
+	name:           "components.Issue",
 	operationID:    "issues/create",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesCreateCommentResponseBody{}
+		target := components.IssueComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/issues/{issue_number}/comments",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "IssuesCreateCommentResponseBody",
+	name:           "components.IssueComment",
 	operationID:    "issues/create-comment",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesCreateLabelResponseBody{}
+		target := components.Label{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/labels",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "IssuesCreateLabelResponseBody",
+	name:           "components.Label",
 	operationID:    "issues/create-label",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesCreateMilestoneResponseBody{}
+		target := components.Milestone{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/milestones",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "IssuesCreateMilestoneResponseBody",
+	name:           "components.Milestone",
 	operationID:    "issues/create-milestone",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesGetResponseBody{}
+		target := components.Issue{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/issues/{issue_number}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "IssuesGetResponseBody",
+	name:           "components.Issue",
 	operationID:    "issues/get",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesGetCommentResponseBody{}
+		target := components.IssueComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/issues/comments/{comment_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "IssuesGetCommentResponseBody",
+	name:           "components.IssueComment",
 	operationID:    "issues/get-comment",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesGetEventResponseBody{}
+		target := components.IssueEvent{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/issues/events/{event_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "IssuesGetEventResponseBody",
+	name:           "components.IssueEvent",
 	operationID:    "issues/get-event",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesGetLabelResponseBody{}
+		target := components.Label{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/labels/{name}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "IssuesGetLabelResponseBody",
+	name:           "components.Label",
 	operationID:    "issues/get-label",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesGetMilestoneResponseBody{}
+		target := components.Milestone{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/milestones/{milestone_number}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "IssuesGetMilestoneResponseBody",
+	name:           "components.Milestone",
 	operationID:    "issues/get-milestone",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1379,7 +1380,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/issues",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "IssuesListResponseBody",
+	name:           "octo.IssuesListResponseBody",
 	operationID:    "issues/list",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1389,7 +1390,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/assignees",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "IssuesListAssigneesResponseBody",
+	name:           "octo.IssuesListAssigneesResponseBody",
 	operationID:    "issues/list-assignees",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1399,7 +1400,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/issues/{issue_number}/comments",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "IssuesListCommentsResponseBody",
+	name:           "octo.IssuesListCommentsResponseBody",
 	operationID:    "issues/list-comments",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1409,7 +1410,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/issues/comments",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "IssuesListCommentsForRepoResponseBody",
+	name:           "octo.IssuesListCommentsForRepoResponseBody",
 	operationID:    "issues/list-comments-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1419,7 +1420,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/issues/{issue_number}/events",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "IssuesListEventsResponseBody",
+	name:           "octo.IssuesListEventsResponseBody",
 	operationID:    "issues/list-events",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1429,7 +1430,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/issues/events",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "IssuesListEventsForRepoResponseBody",
+	name:           "octo.IssuesListEventsForRepoResponseBody",
 	operationID:    "issues/list-events-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1439,7 +1440,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/issues/{issue_number}/timeline",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "IssuesListEventsForTimelineResponseBody",
+	name:           "octo.IssuesListEventsForTimelineResponseBody",
 	operationID:    "issues/list-events-for-timeline",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1449,7 +1450,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/user/issues",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "IssuesListForAuthenticatedUserResponseBody",
+	name:           "octo.IssuesListForAuthenticatedUserResponseBody",
 	operationID:    "issues/list-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1459,7 +1460,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/issues",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "IssuesListForOrgResponseBody",
+	name:           "octo.IssuesListForOrgResponseBody",
 	operationID:    "issues/list-for-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1469,7 +1470,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/issues",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "IssuesListForRepoResponseBody",
+	name:           "octo.IssuesListForRepoResponseBody",
 	operationID:    "issues/list-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1479,7 +1480,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/milestones/{milestone_number}/labels",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "IssuesListLabelsForMilestoneResponseBody",
+	name:           "octo.IssuesListLabelsForMilestoneResponseBody",
 	operationID:    "issues/list-labels-for-milestone",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1489,7 +1490,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/labels",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "IssuesListLabelsForRepoResponseBody",
+	name:           "octo.IssuesListLabelsForRepoResponseBody",
 	operationID:    "issues/list-labels-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1499,7 +1500,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/issues/{issue_number}/labels",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "IssuesListLabelsOnIssueResponseBody",
+	name:           "octo.IssuesListLabelsOnIssueResponseBody",
 	operationID:    "issues/list-labels-on-issue",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1509,17 +1510,17 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/milestones",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "IssuesListMilestonesResponseBody",
+	name:           "octo.IssuesListMilestonesResponseBody",
 	operationID:    "issues/list-milestones",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesRemoveAssigneesResponseBody{}
+		target := components.IssueSimple{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/issues/{issue_number}/assignees",
 	httpMethod:     "DELETE",
 	httpStatusCode: 200,
-	name:           "IssuesRemoveAssigneesResponseBody",
+	name:           "components.IssueSimple",
 	operationID:    "issues/remove-assignees",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1529,7 +1530,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/issues/{issue_number}/labels/{name}",
 	httpMethod:     "DELETE",
 	httpStatusCode: 200,
-	name:           "IssuesRemoveLabelResponseBody",
+	name:           "octo.IssuesRemoveLabelResponseBody",
 	operationID:    "issues/remove-label",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1539,57 +1540,57 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/issues/{issue_number}/labels",
 	httpMethod:     "PUT",
 	httpStatusCode: 200,
-	name:           "IssuesSetLabelsResponseBody",
+	name:           "octo.IssuesSetLabelsResponseBody",
 	operationID:    "issues/set-labels",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesUpdateResponseBody{}
+		target := components.Issue{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/issues/{issue_number}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "IssuesUpdateResponseBody",
+	name:           "components.Issue",
 	operationID:    "issues/update",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesUpdateCommentResponseBody{}
+		target := components.IssueComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/issues/comments/{comment_id}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "IssuesUpdateCommentResponseBody",
+	name:           "components.IssueComment",
 	operationID:    "issues/update-comment",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesUpdateLabelResponseBody{}
+		target := components.Label{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/labels/{name}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "IssuesUpdateLabelResponseBody",
+	name:           "components.Label",
 	operationID:    "issues/update-label",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.IssuesUpdateMilestoneResponseBody{}
+		target := components.Milestone{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/milestones/{milestone_number}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "IssuesUpdateMilestoneResponseBody",
+	name:           "components.Milestone",
 	operationID:    "issues/update-milestone",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.LicensesGetResponseBody{}
+		target := components.License{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/licenses/{license}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "LicensesGetResponseBody",
+	name:           "components.License",
 	operationID:    "licenses/get",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1599,27 +1600,27 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/licenses",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "LicensesGetAllCommonlyUsedResponseBody",
+	name:           "octo.LicensesGetAllCommonlyUsedResponseBody",
 	operationID:    "licenses/get-all-commonly-used",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.LicensesGetForRepoResponseBody{}
+		target := components.LicenseContent{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/license",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "LicensesGetForRepoResponseBody",
+	name:           "components.LicenseContent",
 	operationID:    "licenses/get-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.MetaGetResponseBody{}
+		target := components.ApiOverview{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/meta",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "MetaGetResponseBody",
+	name:           "components.ApiOverview",
 	operationID:    "meta/get",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1629,17 +1630,17 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/import/authors",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "MigrationsGetCommitAuthorsResponseBody",
+	name:           "octo.MigrationsGetCommitAuthorsResponseBody",
 	operationID:    "migrations/get-commit-authors",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.MigrationsGetImportStatusResponseBody{}
+		target := components.Import{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/import",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "MigrationsGetImportStatusResponseBody",
+	name:           "components.Import",
 	operationID:    "migrations/get-import-status",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1649,27 +1650,27 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/import/large_files",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "MigrationsGetLargeFilesResponseBody",
+	name:           "octo.MigrationsGetLargeFilesResponseBody",
 	operationID:    "migrations/get-large-files",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.MigrationsGetStatusForAuthenticatedUserResponseBody{}
+		target := components.Migration{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/migrations/{migration_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "MigrationsGetStatusForAuthenticatedUserResponseBody",
+	name:           "components.Migration",
 	operationID:    "migrations/get-status-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.MigrationsGetStatusForOrgResponseBody{}
+		target := components.Migration{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/migrations/{migration_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "MigrationsGetStatusForOrgResponseBody",
+	name:           "components.Migration",
 	operationID:    "migrations/get-status-for-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1679,7 +1680,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/user/migrations",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "MigrationsListForAuthenticatedUserResponseBody",
+	name:           "octo.MigrationsListForAuthenticatedUserResponseBody",
 	operationID:    "migrations/list-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1689,7 +1690,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/migrations",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "MigrationsListForOrgResponseBody",
+	name:           "octo.MigrationsListForOrgResponseBody",
 	operationID:    "migrations/list-for-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1699,7 +1700,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/migrations/{migration_id}/repositories",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "MigrationsListReposForOrgResponseBody",
+	name:           "octo.MigrationsListReposForOrgResponseBody",
 	operationID:    "migrations/list-repos-for-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1709,137 +1710,137 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/user/migrations/{migration_id}/repositories",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "MigrationsListReposForUserResponseBody",
+	name:           "octo.MigrationsListReposForUserResponseBody",
 	operationID:    "migrations/list-repos-for-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.MigrationsMapCommitAuthorResponseBody{}
+		target := components.PorterAuthor{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/import/authors/{author_id}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "MigrationsMapCommitAuthorResponseBody",
+	name:           "components.PorterAuthor",
 	operationID:    "migrations/map-commit-author",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.MigrationsSetLfsPreferenceResponseBody{}
+		target := components.Import{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/import/lfs",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "MigrationsSetLfsPreferenceResponseBody",
+	name:           "components.Import",
 	operationID:    "migrations/set-lfs-preference",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.MigrationsStartForAuthenticatedUserResponseBody{}
+		target := components.Migration{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/migrations",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "MigrationsStartForAuthenticatedUserResponseBody",
+	name:           "components.Migration",
 	operationID:    "migrations/start-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.MigrationsStartForOrgResponseBody{}
+		target := components.Migration{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/migrations",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "MigrationsStartForOrgResponseBody",
+	name:           "components.Migration",
 	operationID:    "migrations/start-for-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.MigrationsStartImportResponseBody{}
+		target := components.Import{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/import",
 	httpMethod:     "PUT",
 	httpStatusCode: 201,
-	name:           "MigrationsStartImportResponseBody",
+	name:           "components.Import",
 	operationID:    "migrations/start-import",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.MigrationsUpdateImportResponseBody{}
+		target := components.Import{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/import",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "MigrationsUpdateImportResponseBody",
+	name:           "components.Import",
 	operationID:    "migrations/update-import",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OauthAuthorizationsCreateAuthorizationResponseBody{}
+		target := components.Authorization{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/authorizations",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "OauthAuthorizationsCreateAuthorizationResponseBody",
+	name:           "components.Authorization",
 	operationID:    "oauth-authorizations/create-authorization",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OauthAuthorizationsGetAuthorizationResponseBody{}
+		target := components.Authorization{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/authorizations/{authorization_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "OauthAuthorizationsGetAuthorizationResponseBody",
+	name:           "components.Authorization",
 	operationID:    "oauth-authorizations/get-authorization",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OauthAuthorizationsGetGrantResponseBody{}
+		target := components.ApplicationGrant{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/applications/grants/{grant_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "OauthAuthorizationsGetGrantResponseBody",
+	name:           "components.ApplicationGrant",
 	operationID:    "oauth-authorizations/get-grant",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OauthAuthorizationsGetOrCreateAuthorizationForAppResponseBody{}
+		target := components.Authorization{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/authorizations/clients/{client_id}",
 	httpMethod:     "PUT",
 	httpStatusCode: 200,
-	name:           "OauthAuthorizationsGetOrCreateAuthorizationForAppResponseBody",
+	name:           "components.Authorization",
 	operationID:    "oauth-authorizations/get-or-create-authorization-for-app",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OauthAuthorizationsGetOrCreateAuthorizationForAppResponseBody{}
+		target := components.Authorization{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/authorizations/clients/{client_id}",
 	httpMethod:     "PUT",
 	httpStatusCode: 201,
-	name:           "OauthAuthorizationsGetOrCreateAuthorizationForAppResponseBody",
+	name:           "components.Authorization",
 	operationID:    "oauth-authorizations/get-or-create-authorization-for-app",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OauthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintResponseBody{}
+		target := components.Authorization{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/authorizations/clients/{client_id}/{fingerprint}",
 	httpMethod:     "PUT",
 	httpStatusCode: 200,
-	name:           "OauthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintResponseBody",
+	name:           "components.Authorization",
 	operationID:    "oauth-authorizations/get-or-create-authorization-for-app-and-fingerprint",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OauthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintResponseBody{}
+		target := components.Authorization{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/authorizations/clients/{client_id}/{fingerprint}",
 	httpMethod:     "PUT",
 	httpStatusCode: 201,
-	name:           "OauthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintResponseBody",
+	name:           "components.Authorization",
 	operationID:    "oauth-authorizations/get-or-create-authorization-for-app-and-fingerprint",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1849,7 +1850,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/authorizations",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "OauthAuthorizationsListAuthorizationsResponseBody",
+	name:           "octo.OauthAuthorizationsListAuthorizationsResponseBody",
 	operationID:    "oauth-authorizations/list-authorizations",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1859,77 +1860,77 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/applications/grants",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "OauthAuthorizationsListGrantsResponseBody",
+	name:           "octo.OauthAuthorizationsListGrantsResponseBody",
 	operationID:    "oauth-authorizations/list-grants",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OauthAuthorizationsUpdateAuthorizationResponseBody{}
+		target := components.Authorization{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/authorizations/{authorization_id}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "OauthAuthorizationsUpdateAuthorizationResponseBody",
+	name:           "components.Authorization",
 	operationID:    "oauth-authorizations/update-authorization",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OrgsCreateInvitationResponseBody{}
+		target := components.OrganizationInvitation{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/invitations",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "OrgsCreateInvitationResponseBody",
+	name:           "components.OrganizationInvitation",
 	operationID:    "orgs/create-invitation",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OrgsCreateWebhookResponseBody{}
+		target := components.OrgHook{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/hooks",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "OrgsCreateWebhookResponseBody",
+	name:           "components.OrgHook",
 	operationID:    "orgs/create-webhook",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OrgsGetResponseBody{}
+		target := components.OrganizationFull{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "OrgsGetResponseBody",
+	name:           "components.OrganizationFull",
 	operationID:    "orgs/get",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OrgsGetMembershipForAuthenticatedUserResponseBody{}
+		target := components.OrgMembership{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/memberships/orgs/{org}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "OrgsGetMembershipForAuthenticatedUserResponseBody",
+	name:           "components.OrgMembership",
 	operationID:    "orgs/get-membership-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OrgsGetMembershipForUserResponseBody{}
+		target := components.OrgMembership{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/memberships/{username}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "OrgsGetMembershipForUserResponseBody",
+	name:           "components.OrgMembership",
 	operationID:    "orgs/get-membership-for-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OrgsGetWebhookResponseBody{}
+		target := components.OrgHook{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/hooks/{hook_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "OrgsGetWebhookResponseBody",
+	name:           "components.OrgHook",
 	operationID:    "orgs/get-webhook",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1939,7 +1940,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/organizations",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "OrgsListResponseBody",
+	name:           "octo.OrgsListResponseBody",
 	operationID:    "orgs/list",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1949,7 +1950,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/installations",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "OrgsListAppInstallationsResponseBody",
+	name:           "octo.OrgsListAppInstallationsResponseBody",
 	operationID:    "orgs/list-app-installations",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1959,7 +1960,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/blocks",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "OrgsListBlockedUsersResponseBody",
+	name:           "octo.OrgsListBlockedUsersResponseBody",
 	operationID:    "orgs/list-blocked-users",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1969,7 +1970,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/user/orgs",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "OrgsListForAuthenticatedUserResponseBody",
+	name:           "octo.OrgsListForAuthenticatedUserResponseBody",
 	operationID:    "orgs/list-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1979,7 +1980,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/users/{username}/orgs",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "OrgsListForUserResponseBody",
+	name:           "octo.OrgsListForUserResponseBody",
 	operationID:    "orgs/list-for-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1989,7 +1990,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/invitations/{invitation_id}/teams",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "OrgsListInvitationTeamsResponseBody",
+	name:           "octo.OrgsListInvitationTeamsResponseBody",
 	operationID:    "orgs/list-invitation-teams",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -1999,7 +2000,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/members",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "OrgsListMembersResponseBody",
+	name:           "octo.OrgsListMembersResponseBody",
 	operationID:    "orgs/list-members",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2009,7 +2010,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/user/memberships/orgs",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "OrgsListMembershipsForAuthenticatedUserResponseBody",
+	name:           "octo.OrgsListMembershipsForAuthenticatedUserResponseBody",
 	operationID:    "orgs/list-memberships-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2019,7 +2020,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/outside_collaborators",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "OrgsListOutsideCollaboratorsResponseBody",
+	name:           "octo.OrgsListOutsideCollaboratorsResponseBody",
 	operationID:    "orgs/list-outside-collaborators",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2029,7 +2030,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/invitations",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "OrgsListPendingInvitationsResponseBody",
+	name:           "octo.OrgsListPendingInvitationsResponseBody",
 	operationID:    "orgs/list-pending-invitations",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2039,7 +2040,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/public_members",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "OrgsListPublicMembersResponseBody",
+	name:           "octo.OrgsListPublicMembersResponseBody",
 	operationID:    "orgs/list-public-members",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2049,7 +2050,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/credential-authorizations",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "OrgsListSamlSsoAuthorizationsResponseBody",
+	name:           "octo.OrgsListSamlSsoAuthorizationsResponseBody",
 	operationID:    "orgs/list-saml-sso-authorizations",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2059,137 +2060,137 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/hooks",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "OrgsListWebhooksResponseBody",
+	name:           "octo.OrgsListWebhooksResponseBody",
 	operationID:    "orgs/list-webhooks",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OrgsSetMembershipForUserResponseBody{}
+		target := components.OrgMembership{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/memberships/{username}",
 	httpMethod:     "PUT",
 	httpStatusCode: 200,
-	name:           "OrgsSetMembershipForUserResponseBody",
+	name:           "components.OrgMembership",
 	operationID:    "orgs/set-membership-for-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OrgsUpdateResponseBody{}
+		target := components.OrganizationFull{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "OrgsUpdateResponseBody",
+	name:           "components.OrganizationFull",
 	operationID:    "orgs/update",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OrgsUpdateMembershipForAuthenticatedUserResponseBody{}
+		target := components.OrgMembership{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/memberships/orgs/{org}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "OrgsUpdateMembershipForAuthenticatedUserResponseBody",
+	name:           "components.OrgMembership",
 	operationID:    "orgs/update-membership-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.OrgsUpdateWebhookResponseBody{}
+		target := components.OrgHook{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/hooks/{hook_id}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "OrgsUpdateWebhookResponseBody",
+	name:           "components.OrgHook",
 	operationID:    "orgs/update-webhook",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ProjectsCreateCardResponseBody{}
+		target := components.ProjectCard{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/projects/columns/{column_id}/cards",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ProjectsCreateCardResponseBody",
+	name:           "components.ProjectCard",
 	operationID:    "projects/create-card",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ProjectsCreateColumnResponseBody{}
+		target := components.ProjectColumn{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/projects/{project_id}/columns",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ProjectsCreateColumnResponseBody",
+	name:           "components.ProjectColumn",
 	operationID:    "projects/create-column",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ProjectsCreateForAuthenticatedUserResponseBody{}
+		target := components.Project{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/projects",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ProjectsCreateForAuthenticatedUserResponseBody",
+	name:           "components.Project",
 	operationID:    "projects/create-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ProjectsCreateForOrgResponseBody{}
+		target := components.Project{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/projects",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ProjectsCreateForOrgResponseBody",
+	name:           "components.Project",
 	operationID:    "projects/create-for-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ProjectsCreateForRepoResponseBody{}
+		target := components.Project{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/projects",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ProjectsCreateForRepoResponseBody",
+	name:           "components.Project",
 	operationID:    "projects/create-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ProjectsGetResponseBody{}
+		target := components.Project{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/projects/{project_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ProjectsGetResponseBody",
+	name:           "components.Project",
 	operationID:    "projects/get",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ProjectsGetCardResponseBody{}
+		target := components.ProjectCard{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/projects/columns/cards/{card_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ProjectsGetCardResponseBody",
+	name:           "components.ProjectCard",
 	operationID:    "projects/get-card",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ProjectsGetColumnResponseBody{}
+		target := components.ProjectColumn{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/projects/columns/{column_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ProjectsGetColumnResponseBody",
+	name:           "components.ProjectColumn",
 	operationID:    "projects/get-column",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ProjectsGetPermissionForUserResponseBody{}
+		target := components.RepositoryCollaboratorPermission{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/projects/{project_id}/collaborators/{username}/permission",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ProjectsGetPermissionForUserResponseBody",
+	name:           "components.RepositoryCollaboratorPermission",
 	operationID:    "projects/get-permission-for-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2199,7 +2200,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/projects/columns/{column_id}/cards",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ProjectsListCardsResponseBody",
+	name:           "octo.ProjectsListCardsResponseBody",
 	operationID:    "projects/list-cards",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2209,7 +2210,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/projects/{project_id}/collaborators",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ProjectsListCollaboratorsResponseBody",
+	name:           "octo.ProjectsListCollaboratorsResponseBody",
 	operationID:    "projects/list-collaborators",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2219,7 +2220,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/projects/{project_id}/columns",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ProjectsListColumnsResponseBody",
+	name:           "octo.ProjectsListColumnsResponseBody",
 	operationID:    "projects/list-columns",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2229,7 +2230,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/projects",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ProjectsListForOrgResponseBody",
+	name:           "octo.ProjectsListForOrgResponseBody",
 	operationID:    "projects/list-for-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2239,7 +2240,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/projects",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ProjectsListForRepoResponseBody",
+	name:           "octo.ProjectsListForRepoResponseBody",
 	operationID:    "projects/list-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2249,127 +2250,127 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/users/{username}/projects",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ProjectsListForUserResponseBody",
+	name:           "octo.ProjectsListForUserResponseBody",
 	operationID:    "projects/list-for-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ProjectsUpdateResponseBody{}
+		target := components.Project{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/projects/{project_id}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "ProjectsUpdateResponseBody",
+	name:           "components.Project",
 	operationID:    "projects/update",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ProjectsUpdateCardResponseBody{}
+		target := components.ProjectCard{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/projects/columns/cards/{card_id}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "ProjectsUpdateCardResponseBody",
+	name:           "components.ProjectCard",
 	operationID:    "projects/update-card",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ProjectsUpdateColumnResponseBody{}
+		target := components.ProjectColumn{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/projects/columns/{column_id}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "ProjectsUpdateColumnResponseBody",
+	name:           "components.ProjectColumn",
 	operationID:    "projects/update-column",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.PullsCreateResponseBody{}
+		target := components.PullRequest{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pulls",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "PullsCreateResponseBody",
+	name:           "components.PullRequest",
 	operationID:    "pulls/create",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.PullsCreateReplyForReviewCommentResponseBody{}
+		target := components.PullRequestReviewComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "PullsCreateReplyForReviewCommentResponseBody",
+	name:           "components.PullRequestReviewComment",
 	operationID:    "pulls/create-reply-for-review-comment",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.PullsCreateReviewResponseBody{}
+		target := components.PullRequestReview{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pulls/{pull_number}/reviews",
 	httpMethod:     "POST",
 	httpStatusCode: 200,
-	name:           "PullsCreateReviewResponseBody",
+	name:           "components.PullRequestReview",
 	operationID:    "pulls/create-review",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.PullsCreateReviewCommentResponseBody{}
+		target := components.PullRequestReviewComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pulls/{pull_number}/comments",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "PullsCreateReviewCommentResponseBody",
+	name:           "components.PullRequestReviewComment",
 	operationID:    "pulls/create-review-comment",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.PullsDeletePendingReviewResponseBody{}
+		target := components.PullRequestReview{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}",
 	httpMethod:     "DELETE",
 	httpStatusCode: 200,
-	name:           "PullsDeletePendingReviewResponseBody",
+	name:           "components.PullRequestReview",
 	operationID:    "pulls/delete-pending-review",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.PullsDismissReviewResponseBody{}
+		target := components.PullRequestReview{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals",
 	httpMethod:     "PUT",
 	httpStatusCode: 200,
-	name:           "PullsDismissReviewResponseBody",
+	name:           "components.PullRequestReview",
 	operationID:    "pulls/dismiss-review",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.PullsGetResponseBody{}
+		target := components.PullRequest{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pulls/{pull_number}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "PullsGetResponseBody",
+	name:           "components.PullRequest",
 	operationID:    "pulls/get",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.PullsGetReviewResponseBody{}
+		target := components.PullRequestReview{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "PullsGetReviewResponseBody",
+	name:           "components.PullRequestReview",
 	operationID:    "pulls/get-review",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.PullsGetReviewCommentResponseBody{}
+		target := components.PullRequestReviewComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pulls/comments/{comment_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "PullsGetReviewCommentResponseBody",
+	name:           "components.PullRequestReviewComment",
 	operationID:    "pulls/get-review-comment",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2379,7 +2380,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/pulls",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "PullsListResponseBody",
+	name:           "octo.PullsListResponseBody",
 	operationID:    "pulls/list",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2389,7 +2390,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "PullsListCommentsForReviewResponseBody",
+	name:           "octo.PullsListCommentsForReviewResponseBody",
 	operationID:    "pulls/list-comments-for-review",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2399,7 +2400,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/pulls/{pull_number}/commits",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "PullsListCommitsResponseBody",
+	name:           "octo.PullsListCommitsResponseBody",
 	operationID:    "pulls/list-commits",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2409,17 +2410,17 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/pulls/{pull_number}/files",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "PullsListFilesResponseBody",
+	name:           "octo.PullsListFilesResponseBody",
 	operationID:    "pulls/list-files",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.PullsListRequestedReviewersResponseBody{}
+		target := components.PullRequestReviewRequest{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "PullsListRequestedReviewersResponseBody",
+	name:           "components.PullRequestReviewRequest",
 	operationID:    "pulls/list-requested-reviewers",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2429,7 +2430,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/pulls/{pull_number}/comments",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "PullsListReviewCommentsResponseBody",
+	name:           "octo.PullsListReviewCommentsResponseBody",
 	operationID:    "pulls/list-review-comments",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2439,7 +2440,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/pulls/comments",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "PullsListReviewCommentsForRepoResponseBody",
+	name:           "octo.PullsListReviewCommentsForRepoResponseBody",
 	operationID:    "pulls/list-review-comments-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2449,47 +2450,47 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/pulls/{pull_number}/reviews",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "PullsListReviewsResponseBody",
+	name:           "octo.PullsListReviewsResponseBody",
 	operationID:    "pulls/list-reviews",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.PullsMergeResponseBody{}
+		target := components.PullRequestMergeResult{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pulls/{pull_number}/merge",
 	httpMethod:     "PUT",
 	httpStatusCode: 200,
-	name:           "PullsMergeResponseBody",
+	name:           "components.PullRequestMergeResult",
 	operationID:    "pulls/merge",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.PullsRequestReviewersResponseBody{}
+		target := components.PullRequestSimple{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "PullsRequestReviewersResponseBody",
+	name:           "components.PullRequestSimple",
 	operationID:    "pulls/request-reviewers",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.PullsSubmitReviewResponseBody{}
+		target := components.PullRequestReview{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events",
 	httpMethod:     "POST",
 	httpStatusCode: 200,
-	name:           "PullsSubmitReviewResponseBody",
+	name:           "components.PullRequestReview",
 	operationID:    "pulls/submit-review",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.PullsUpdateResponseBody{}
+		target := components.PullRequest{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pulls/{pull_number}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "PullsUpdateResponseBody",
+	name:           "components.PullRequest",
 	operationID:    "pulls/update",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2499,147 +2500,147 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/pulls/{pull_number}/update-branch",
 	httpMethod:     "PUT",
 	httpStatusCode: 202,
-	name:           "PullsUpdateBranchResponseBody",
+	name:           "octo.PullsUpdateBranchResponseBody",
 	operationID:    "pulls/update-branch",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.PullsUpdateReviewResponseBody{}
+		target := components.PullRequestReview{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}",
 	httpMethod:     "PUT",
 	httpStatusCode: 200,
-	name:           "PullsUpdateReviewResponseBody",
+	name:           "components.PullRequestReview",
 	operationID:    "pulls/update-review",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.PullsUpdateReviewCommentResponseBody{}
+		target := components.PullRequestReviewComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pulls/comments/{comment_id}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "PullsUpdateReviewCommentResponseBody",
+	name:           "components.PullRequestReviewComment",
 	operationID:    "pulls/update-review-comment",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.RateLimitGetResponseBody{}
+		target := components.RateLimitOverview{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/rate_limit",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "RateLimitGetResponseBody",
+	name:           "components.RateLimitOverview",
 	operationID:    "rate-limit/get",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReactionsCreateForCommitCommentResponseBody{}
+		target := components.Reaction{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/comments/{comment_id}/reactions",
 	httpMethod:     "POST",
 	httpStatusCode: 200,
-	name:           "ReactionsCreateForCommitCommentResponseBody",
+	name:           "components.Reaction",
 	operationID:    "reactions/create-for-commit-comment",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReactionsCreateForCommitCommentResponseBody{}
+		target := components.Reaction{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/comments/{comment_id}/reactions",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ReactionsCreateForCommitCommentResponseBody",
+	name:           "components.Reaction",
 	operationID:    "reactions/create-for-commit-comment",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReactionsCreateForIssueResponseBody{}
+		target := components.Reaction{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/issues/{issue_number}/reactions",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ReactionsCreateForIssueResponseBody",
+	name:           "components.Reaction",
 	operationID:    "reactions/create-for-issue",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReactionsCreateForIssueCommentResponseBody{}
+		target := components.Reaction{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/issues/comments/{comment_id}/reactions",
 	httpMethod:     "POST",
 	httpStatusCode: 200,
-	name:           "ReactionsCreateForIssueCommentResponseBody",
+	name:           "components.Reaction",
 	operationID:    "reactions/create-for-issue-comment",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReactionsCreateForIssueCommentResponseBody{}
+		target := components.Reaction{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/issues/comments/{comment_id}/reactions",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ReactionsCreateForIssueCommentResponseBody",
+	name:           "components.Reaction",
 	operationID:    "reactions/create-for-issue-comment",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReactionsCreateForPullRequestReviewCommentResponseBody{}
+		target := components.Reaction{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions",
 	httpMethod:     "POST",
 	httpStatusCode: 200,
-	name:           "ReactionsCreateForPullRequestReviewCommentResponseBody",
+	name:           "components.Reaction",
 	operationID:    "reactions/create-for-pull-request-review-comment",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReactionsCreateForPullRequestReviewCommentResponseBody{}
+		target := components.Reaction{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ReactionsCreateForPullRequestReviewCommentResponseBody",
+	name:           "components.Reaction",
 	operationID:    "reactions/create-for-pull-request-review-comment",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReactionsCreateForTeamDiscussionCommentInOrgResponseBody{}
+		target := components.Reaction{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ReactionsCreateForTeamDiscussionCommentInOrgResponseBody",
+	name:           "components.Reaction",
 	operationID:    "reactions/create-for-team-discussion-comment-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReactionsCreateForTeamDiscussionCommentLegacyResponseBody{}
+		target := components.Reaction{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}/reactions",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ReactionsCreateForTeamDiscussionCommentLegacyResponseBody",
+	name:           "components.Reaction",
 	operationID:    "reactions/create-for-team-discussion-comment-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReactionsCreateForTeamDiscussionInOrgResponseBody{}
+		target := components.Reaction{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ReactionsCreateForTeamDiscussionInOrgResponseBody",
+	name:           "components.Reaction",
 	operationID:    "reactions/create-for-team-discussion-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReactionsCreateForTeamDiscussionLegacyResponseBody{}
+		target := components.Reaction{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/teams/{team_id}/discussions/{discussion_number}/reactions",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ReactionsCreateForTeamDiscussionLegacyResponseBody",
+	name:           "components.Reaction",
 	operationID:    "reactions/create-for-team-discussion-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2649,7 +2650,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/comments/{comment_id}/reactions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReactionsListForCommitCommentResponseBody",
+	name:           "octo.ReactionsListForCommitCommentResponseBody",
 	operationID:    "reactions/list-for-commit-comment",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2659,7 +2660,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/issues/{issue_number}/reactions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReactionsListForIssueResponseBody",
+	name:           "octo.ReactionsListForIssueResponseBody",
 	operationID:    "reactions/list-for-issue",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2669,7 +2670,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/issues/comments/{comment_id}/reactions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReactionsListForIssueCommentResponseBody",
+	name:           "octo.ReactionsListForIssueCommentResponseBody",
 	operationID:    "reactions/list-for-issue-comment",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2679,7 +2680,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReactionsListForPullRequestReviewCommentResponseBody",
+	name:           "octo.ReactionsListForPullRequestReviewCommentResponseBody",
 	operationID:    "reactions/list-for-pull-request-review-comment",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2689,7 +2690,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReactionsListForTeamDiscussionCommentInOrgResponseBody",
+	name:           "octo.ReactionsListForTeamDiscussionCommentInOrgResponseBody",
 	operationID:    "reactions/list-for-team-discussion-comment-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2699,7 +2700,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}/reactions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReactionsListForTeamDiscussionCommentLegacyResponseBody",
+	name:           "octo.ReactionsListForTeamDiscussionCommentLegacyResponseBody",
 	operationID:    "reactions/list-for-team-discussion-comment-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2709,7 +2710,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReactionsListForTeamDiscussionInOrgResponseBody",
+	name:           "octo.ReactionsListForTeamDiscussionInOrgResponseBody",
 	operationID:    "reactions/list-for-team-discussion-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2719,7 +2720,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/teams/{team_id}/discussions/{discussion_number}/reactions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReactionsListForTeamDiscussionLegacyResponseBody",
+	name:           "octo.ReactionsListForTeamDiscussionLegacyResponseBody",
 	operationID:    "reactions/list-for-team-discussion-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2729,17 +2730,17 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps",
 	httpMethod:     "POST",
 	httpStatusCode: 200,
-	name:           "ReposAddAppAccessRestrictionsResponseBody",
+	name:           "octo.ReposAddAppAccessRestrictionsResponseBody",
 	operationID:    "repos/add-app-access-restrictions",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposAddCollaboratorResponseBody{}
+		target := components.RepositoryInvitation{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/collaborators/{username}",
 	httpMethod:     "PUT",
 	httpStatusCode: 201,
-	name:           "ReposAddCollaboratorResponseBody",
+	name:           "components.RepositoryInvitation",
 	operationID:    "repos/add-collaborator",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2749,7 +2750,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts",
 	httpMethod:     "POST",
 	httpStatusCode: 200,
-	name:           "ReposAddStatusCheckContextsResponseBody",
+	name:           "octo.ReposAddStatusCheckContextsResponseBody",
 	operationID:    "repos/add-status-check-contexts",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2759,7 +2760,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams",
 	httpMethod:     "POST",
 	httpStatusCode: 200,
-	name:           "ReposAddTeamAccessRestrictionsResponseBody",
+	name:           "octo.ReposAddTeamAccessRestrictionsResponseBody",
 	operationID:    "repos/add-team-access-restrictions",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2769,207 +2770,207 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users",
 	httpMethod:     "POST",
 	httpStatusCode: 200,
-	name:           "ReposAddUserAccessRestrictionsResponseBody",
+	name:           "octo.ReposAddUserAccessRestrictionsResponseBody",
 	operationID:    "repos/add-user-access-restrictions",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposCompareCommitsResponseBody{}
+		target := components.CommitComparison{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/compare/{base}...{head}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposCompareCommitsResponseBody",
+	name:           "components.CommitComparison",
 	operationID:    "repos/compare-commits",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposCreateCommitCommentResponseBody{}
+		target := components.CommitComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/commits/{commit_sha}/comments",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ReposCreateCommitCommentResponseBody",
+	name:           "components.CommitComment",
 	operationID:    "repos/create-commit-comment",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposCreateCommitSignatureProtectionResponseBody{}
+		target := components.ProtectedBranchAdminEnforced{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/required_signatures",
 	httpMethod:     "POST",
 	httpStatusCode: 200,
-	name:           "ReposCreateCommitSignatureProtectionResponseBody",
+	name:           "components.ProtectedBranchAdminEnforced",
 	operationID:    "repos/create-commit-signature-protection",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposCreateCommitStatusResponseBody{}
+		target := components.Status{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/statuses/{sha}",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ReposCreateCommitStatusResponseBody",
+	name:           "components.Status",
 	operationID:    "repos/create-commit-status",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposCreateDeployKeyResponseBody{}
+		target := components.DeployKey{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/keys",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ReposCreateDeployKeyResponseBody",
+	name:           "components.DeployKey",
 	operationID:    "repos/create-deploy-key",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposCreateDeploymentResponseBody{}
+		target := components.Deployment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/deployments",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ReposCreateDeploymentResponseBody",
+	name:           "components.Deployment",
 	operationID:    "repos/create-deployment",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposCreateDeploymentStatusResponseBody{}
+		target := components.DeploymentStatus{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/deployments/{deployment_id}/statuses",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ReposCreateDeploymentStatusResponseBody",
+	name:           "components.DeploymentStatus",
 	operationID:    "repos/create-deployment-status",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposCreateForAuthenticatedUserResponseBody{}
+		target := components.Repository{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/repos",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ReposCreateForAuthenticatedUserResponseBody",
+	name:           "components.Repository",
 	operationID:    "repos/create-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposCreateForkResponseBody{}
+		target := components.Repository{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/forks",
 	httpMethod:     "POST",
 	httpStatusCode: 202,
-	name:           "ReposCreateForkResponseBody",
+	name:           "components.Repository",
 	operationID:    "repos/create-fork",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposCreateInOrgResponseBody{}
+		target := components.Repository{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/repos",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ReposCreateInOrgResponseBody",
+	name:           "components.Repository",
 	operationID:    "repos/create-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposCreateOrUpdateFileContentsResponseBody{}
+		target := components.FileCommit{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/contents/{path}",
 	httpMethod:     "PUT",
 	httpStatusCode: 200,
-	name:           "ReposCreateOrUpdateFileContentsResponseBody",
+	name:           "components.FileCommit",
 	operationID:    "repos/create-or-update-file-contents",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposCreateOrUpdateFileContentsResponseBody{}
+		target := components.FileCommit{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/contents/{path}",
 	httpMethod:     "PUT",
 	httpStatusCode: 201,
-	name:           "ReposCreateOrUpdateFileContentsResponseBody",
+	name:           "components.FileCommit",
 	operationID:    "repos/create-or-update-file-contents",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposCreatePagesSiteResponseBody{}
+		target := components.Page{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pages",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ReposCreatePagesSiteResponseBody",
+	name:           "components.Page",
 	operationID:    "repos/create-pages-site",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposCreateReleaseResponseBody{}
+		target := components.Release{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/releases",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ReposCreateReleaseResponseBody",
+	name:           "components.Release",
 	operationID:    "repos/create-release",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposCreateUsingTemplateResponseBody{}
+		target := components.Repository{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{template_owner}/{template_repo}/generate",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ReposCreateUsingTemplateResponseBody",
+	name:           "components.Repository",
 	operationID:    "repos/create-using-template",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposCreateWebhookResponseBody{}
+		target := components.Hook{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/hooks",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ReposCreateWebhookResponseBody",
+	name:           "components.Hook",
 	operationID:    "repos/create-webhook",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposDeleteFileResponseBody{}
+		target := components.FileCommit{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/contents/{path}",
 	httpMethod:     "DELETE",
 	httpStatusCode: 200,
-	name:           "ReposDeleteFileResponseBody",
+	name:           "components.FileCommit",
 	operationID:    "repos/delete-file",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetResponseBody{}
+		target := components.FullRepository{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetResponseBody",
+	name:           "components.FullRepository",
 	operationID:    "repos/get",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetAccessRestrictionsResponseBody{}
+		target := components.BranchRestrictionPolicy{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetAccessRestrictionsResponseBody",
+	name:           "components.BranchRestrictionPolicy",
 	operationID:    "repos/get-access-restrictions",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetAdminBranchProtectionResponseBody{}
+		target := components.ProtectedBranchAdminEnforced{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetAdminBranchProtectionResponseBody",
+	name:           "components.ProtectedBranchAdminEnforced",
 	operationID:    "repos/get-admin-branch-protection",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2979,17 +2980,17 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetAllStatusCheckContextsResponseBody",
+	name:           "octo.ReposGetAllStatusCheckContextsResponseBody",
 	operationID:    "repos/get-all-status-check-contexts",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetAllTopicsResponseBody{}
+		target := components.Topic{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/topics",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetAllTopicsResponseBody",
+	name:           "components.Topic",
 	operationID:    "repos/get-all-topics",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -2999,37 +3000,37 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetAppsWithAccessToProtectedBranchResponseBody",
+	name:           "octo.ReposGetAppsWithAccessToProtectedBranchResponseBody",
 	operationID:    "repos/get-apps-with-access-to-protected-branch",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetBranchResponseBody{}
+		target := components.BranchWithProtection{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetBranchResponseBody",
+	name:           "components.BranchWithProtection",
 	operationID:    "repos/get-branch",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetBranchProtectionResponseBody{}
+		target := components.BranchProtection{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetBranchProtectionResponseBody",
+	name:           "components.BranchProtection",
 	operationID:    "repos/get-branch-protection",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetClonesResponseBody{}
+		target := components.CloneTraffic{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/traffic/clones",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetClonesResponseBody",
+	name:           "components.CloneTraffic",
 	operationID:    "repos/get-clones",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3039,37 +3040,37 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/stats/code_frequency",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetCodeFrequencyStatsResponseBody",
+	name:           "octo.ReposGetCodeFrequencyStatsResponseBody",
 	operationID:    "repos/get-code-frequency-stats",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetCollaboratorPermissionLevelResponseBody{}
+		target := components.RepositoryCollaboratorPermission{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/collaborators/{username}/permission",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetCollaboratorPermissionLevelResponseBody",
+	name:           "components.RepositoryCollaboratorPermission",
 	operationID:    "repos/get-collaborator-permission-level",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetCombinedStatusForRefResponseBody{}
+		target := components.CombinedCommitStatus{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/commits/{ref}/status",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetCombinedStatusForRefResponseBody",
+	name:           "components.CombinedCommitStatus",
 	operationID:    "repos/get-combined-status-for-ref",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetCommitResponseBody{}
+		target := components.Commit{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/commits/{ref}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetCommitResponseBody",
+	name:           "components.Commit",
 	operationID:    "repos/get-commit",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3079,37 +3080,37 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/stats/commit_activity",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetCommitActivityStatsResponseBody",
+	name:           "octo.ReposGetCommitActivityStatsResponseBody",
 	operationID:    "repos/get-commit-activity-stats",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetCommitCommentResponseBody{}
+		target := components.CommitComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/comments/{comment_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetCommitCommentResponseBody",
+	name:           "components.CommitComment",
 	operationID:    "repos/get-commit-comment",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetCommitSignatureProtectionResponseBody{}
+		target := components.ProtectedBranchAdminEnforced{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/required_signatures",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetCommitSignatureProtectionResponseBody",
+	name:           "components.ProtectedBranchAdminEnforced",
 	operationID:    "repos/get-commit-signature-protection",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetCommunityProfileMetricsResponseBody{}
+		target := components.CommunityProfile{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/community/profile",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetCommunityProfileMetricsResponseBody",
+	name:           "components.CommunityProfile",
 	operationID:    "repos/get-community-profile-metrics",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3119,7 +3120,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/contents/{path}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetContentResponseBody",
+	name:           "octo.ReposGetContentResponseBody",
 	operationID:    "repos/get-content",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3129,97 +3130,97 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/stats/contributors",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetContributorsStatsResponseBody",
+	name:           "octo.ReposGetContributorsStatsResponseBody",
 	operationID:    "repos/get-contributors-stats",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetDeployKeyResponseBody{}
+		target := components.DeployKey{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/keys/{key_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetDeployKeyResponseBody",
+	name:           "components.DeployKey",
 	operationID:    "repos/get-deploy-key",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetDeploymentResponseBody{}
+		target := components.Deployment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/deployments/{deployment_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetDeploymentResponseBody",
+	name:           "components.Deployment",
 	operationID:    "repos/get-deployment",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetDeploymentStatusResponseBody{}
+		target := components.DeploymentStatus{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/deployments/{deployment_id}/statuses/{status_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetDeploymentStatusResponseBody",
+	name:           "components.DeploymentStatus",
 	operationID:    "repos/get-deployment-status",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetLatestPagesBuildResponseBody{}
+		target := components.PageBuild{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pages/builds/latest",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetLatestPagesBuildResponseBody",
+	name:           "components.PageBuild",
 	operationID:    "repos/get-latest-pages-build",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetLatestReleaseResponseBody{}
+		target := components.Release{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/releases/latest",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetLatestReleaseResponseBody",
+	name:           "components.Release",
 	operationID:    "repos/get-latest-release",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetPagesResponseBody{}
+		target := components.Page{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pages",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetPagesResponseBody",
+	name:           "components.Page",
 	operationID:    "repos/get-pages",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetPagesBuildResponseBody{}
+		target := components.PageBuild{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pages/builds/{build_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetPagesBuildResponseBody",
+	name:           "components.PageBuild",
 	operationID:    "repos/get-pages-build",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetParticipationStatsResponseBody{}
+		target := components.ParticipationStats{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/stats/participation",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetParticipationStatsResponseBody",
+	name:           "components.ParticipationStats",
 	operationID:    "repos/get-participation-stats",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetPullRequestReviewProtectionResponseBody{}
+		target := components.ProtectedBranchPullRequestReview{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetPullRequestReviewProtectionResponseBody",
+	name:           "components.ProtectedBranchPullRequestReview",
 	operationID:    "repos/get-pull-request-review-protection",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3229,57 +3230,57 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/stats/punch_card",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetPunchCardStatsResponseBody",
+	name:           "octo.ReposGetPunchCardStatsResponseBody",
 	operationID:    "repos/get-punch-card-stats",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetReadmeResponseBody{}
+		target := components.ContentFile{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/readme",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetReadmeResponseBody",
+	name:           "components.ContentFile",
 	operationID:    "repos/get-readme",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetReleaseResponseBody{}
+		target := components.Release{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/releases/{release_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetReleaseResponseBody",
+	name:           "components.Release",
 	operationID:    "repos/get-release",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetReleaseAssetResponseBody{}
+		target := components.ReleaseAsset{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/releases/assets/{asset_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetReleaseAssetResponseBody",
+	name:           "components.ReleaseAsset",
 	operationID:    "repos/get-release-asset",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetReleaseByTagResponseBody{}
+		target := components.Release{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/releases/tags/{tag}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetReleaseByTagResponseBody",
+	name:           "components.Release",
 	operationID:    "repos/get-release-by-tag",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetStatusChecksProtectionResponseBody{}
+		target := components.StatusCheckPolicy{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetStatusChecksProtectionResponseBody",
+	name:           "components.StatusCheckPolicy",
 	operationID:    "repos/get-status-checks-protection",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3289,7 +3290,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetTeamsWithAccessToProtectedBranchResponseBody",
+	name:           "octo.ReposGetTeamsWithAccessToProtectedBranchResponseBody",
 	operationID:    "repos/get-teams-with-access-to-protected-branch",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3299,7 +3300,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/traffic/popular/paths",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetTopPathsResponseBody",
+	name:           "octo.ReposGetTopPathsResponseBody",
 	operationID:    "repos/get-top-paths",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3309,7 +3310,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/traffic/popular/referrers",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetTopReferrersResponseBody",
+	name:           "octo.ReposGetTopReferrersResponseBody",
 	operationID:    "repos/get-top-referrers",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3319,27 +3320,27 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetUsersWithAccessToProtectedBranchResponseBody",
+	name:           "octo.ReposGetUsersWithAccessToProtectedBranchResponseBody",
 	operationID:    "repos/get-users-with-access-to-protected-branch",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetViewsResponseBody{}
+		target := components.ViewTraffic{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/traffic/views",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetViewsResponseBody",
+	name:           "components.ViewTraffic",
 	operationID:    "repos/get-views",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposGetWebhookResponseBody{}
+		target := components.Hook{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/hooks/{hook_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposGetWebhookResponseBody",
+	name:           "components.Hook",
 	operationID:    "repos/get-webhook",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3349,7 +3350,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/branches",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposListBranchesResponseBody",
+	name:           "octo.ReposListBranchesResponseBody",
 	operationID:    "repos/list-branches",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3359,7 +3360,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/commits/{commit_sha}/branches-where-head",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposListBranchesForHeadCommitResponseBody",
+	name:           "octo.ReposListBranchesForHeadCommitResponseBody",
 	operationID:    "repos/list-branches-for-head-commit",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3369,7 +3370,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/collaborators",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposListCollaboratorsResponseBody",
+	name:           "octo.ReposListCollaboratorsResponseBody",
 	operationID:    "repos/list-collaborators",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3379,7 +3380,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/commits/{commit_sha}/comments",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposListCommentsForCommitResponseBody",
+	name:           "octo.ReposListCommentsForCommitResponseBody",
 	operationID:    "repos/list-comments-for-commit",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3389,7 +3390,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/comments",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposListCommitCommentsForRepoResponseBody",
+	name:           "octo.ReposListCommitCommentsForRepoResponseBody",
 	operationID:    "repos/list-commit-comments-for-repo",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3399,7 +3400,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/commits/{ref}/statuses",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposListCommitStatusesForRefResponseBody",
+	name:           "octo.ReposListCommitStatusesForRefResponseBody",
 	operationID:    "repos/list-commit-statuses-for-ref",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3409,7 +3410,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/commits",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposListCommitsResponseBody",
+	name:           "octo.ReposListCommitsResponseBody",
 	operationID:    "repos/list-commits",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3419,7 +3420,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/contributors",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposListContributorsResponseBody",
+	name:           "octo.ReposListContributorsResponseBody",
 	operationID:    "repos/list-contributors",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3429,7 +3430,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/keys",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposListDeployKeysResponseBody",
+	name:           "octo.ReposListDeployKeysResponseBody",
 	operationID:    "repos/list-deploy-keys",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3439,7 +3440,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/deployments/{deployment_id}/statuses",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposListDeploymentStatusesResponseBody",
+	name:           "octo.ReposListDeploymentStatusesResponseBody",
 	operationID:    "repos/list-deployment-statuses",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3449,7 +3450,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/deployments",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposListDeploymentsResponseBody",
+	name:           "octo.ReposListDeploymentsResponseBody",
 	operationID:    "repos/list-deployments",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3459,7 +3460,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/user/repos",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposListForAuthenticatedUserResponseBody",
+	name:           "octo.ReposListForAuthenticatedUserResponseBody",
 	operationID:    "repos/list-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3469,7 +3470,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/repos",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposListForOrgResponseBody",
+	name:           "octo.ReposListForOrgResponseBody",
 	operationID:    "repos/list-for-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3479,7 +3480,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/users/{username}/repos",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposListForUserResponseBody",
+	name:           "octo.ReposListForUserResponseBody",
 	operationID:    "repos/list-for-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3489,7 +3490,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/forks",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposListForksResponseBody",
+	name:           "octo.ReposListForksResponseBody",
 	operationID:    "repos/list-forks",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3499,7 +3500,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/invitations",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposListInvitationsResponseBody",
+	name:           "octo.ReposListInvitationsResponseBody",
 	operationID:    "repos/list-invitations",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3509,17 +3510,17 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/user/repository_invitations",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposListInvitationsForAuthenticatedUserResponseBody",
+	name:           "octo.ReposListInvitationsForAuthenticatedUserResponseBody",
 	operationID:    "repos/list-invitations-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposListLanguagesResponseBody{}
+		target := components.Language{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/languages",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposListLanguagesResponseBody",
+	name:           "components.Language",
 	operationID:    "repos/list-languages",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3529,7 +3530,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/pages/builds",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposListPagesBuildsResponseBody",
+	name:           "octo.ReposListPagesBuildsResponseBody",
 	operationID:    "repos/list-pages-builds",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3539,7 +3540,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repositories",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposListPublicResponseBody",
+	name:           "octo.ReposListPublicResponseBody",
 	operationID:    "repos/list-public",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3549,7 +3550,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/commits/{commit_sha}/pulls",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposListPullRequestsAssociatedWithCommitResponseBody",
+	name:           "octo.ReposListPullRequestsAssociatedWithCommitResponseBody",
 	operationID:    "repos/list-pull-requests-associated-with-commit",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3559,7 +3560,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/releases/{release_id}/assets",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposListReleaseAssetsResponseBody",
+	name:           "octo.ReposListReleaseAssetsResponseBody",
 	operationID:    "repos/list-release-assets",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3569,7 +3570,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/releases",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposListReleasesResponseBody",
+	name:           "octo.ReposListReleasesResponseBody",
 	operationID:    "repos/list-releases",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3579,7 +3580,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/tags",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposListTagsResponseBody",
+	name:           "octo.ReposListTagsResponseBody",
 	operationID:    "repos/list-tags",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3589,7 +3590,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/teams",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposListTeamsResponseBody",
+	name:           "octo.ReposListTeamsResponseBody",
 	operationID:    "repos/list-teams",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3599,17 +3600,17 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/hooks",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ReposListWebhooksResponseBody",
+	name:           "octo.ReposListWebhooksResponseBody",
 	operationID:    "repos/list-webhooks",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposMergeResponseBody{}
+		target := components.Commit{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/merges",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ReposMergeResponseBody",
+	name:           "components.Commit",
 	operationID:    "repos/merge",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3619,7 +3620,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps",
 	httpMethod:     "DELETE",
 	httpStatusCode: 200,
-	name:           "ReposRemoveAppAccessRestrictionsResponseBody",
+	name:           "octo.ReposRemoveAppAccessRestrictionsResponseBody",
 	operationID:    "repos/remove-app-access-restrictions",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3629,7 +3630,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts",
 	httpMethod:     "DELETE",
 	httpStatusCode: 200,
-	name:           "ReposRemoveStatusCheckContextsResponseBody",
+	name:           "octo.ReposRemoveStatusCheckContextsResponseBody",
 	operationID:    "repos/remove-status-check-contexts",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3639,7 +3640,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams",
 	httpMethod:     "DELETE",
 	httpStatusCode: 200,
-	name:           "ReposRemoveTeamAccessRestrictionsResponseBody",
+	name:           "octo.ReposRemoveTeamAccessRestrictionsResponseBody",
 	operationID:    "repos/remove-team-access-restrictions",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3649,37 +3650,37 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users",
 	httpMethod:     "DELETE",
 	httpStatusCode: 200,
-	name:           "ReposRemoveUserAccessRestrictionsResponseBody",
+	name:           "octo.ReposRemoveUserAccessRestrictionsResponseBody",
 	operationID:    "repos/remove-user-access-restrictions",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposReplaceAllTopicsResponseBody{}
+		target := components.Topic{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/topics",
 	httpMethod:     "PUT",
 	httpStatusCode: 200,
-	name:           "ReposReplaceAllTopicsResponseBody",
+	name:           "components.Topic",
 	operationID:    "repos/replace-all-topics",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposRequestPagesBuildResponseBody{}
+		target := components.PageBuildStatus{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/pages/builds",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ReposRequestPagesBuildResponseBody",
+	name:           "components.PageBuildStatus",
 	operationID:    "repos/request-pages-build",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposSetAdminBranchProtectionResponseBody{}
+		target := components.ProtectedBranchAdminEnforced{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins",
 	httpMethod:     "POST",
 	httpStatusCode: 200,
-	name:           "ReposSetAdminBranchProtectionResponseBody",
+	name:           "components.ProtectedBranchAdminEnforced",
 	operationID:    "repos/set-admin-branch-protection",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3689,7 +3690,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps",
 	httpMethod:     "PUT",
 	httpStatusCode: 200,
-	name:           "ReposSetAppAccessRestrictionsResponseBody",
+	name:           "octo.ReposSetAppAccessRestrictionsResponseBody",
 	operationID:    "repos/set-app-access-restrictions",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3699,7 +3700,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts",
 	httpMethod:     "PUT",
 	httpStatusCode: 200,
-	name:           "ReposSetStatusCheckContextsResponseBody",
+	name:           "octo.ReposSetStatusCheckContextsResponseBody",
 	operationID:    "repos/set-status-check-contexts",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3709,7 +3710,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams",
 	httpMethod:     "PUT",
 	httpStatusCode: 200,
-	name:           "ReposSetTeamAccessRestrictionsResponseBody",
+	name:           "octo.ReposSetTeamAccessRestrictionsResponseBody",
 	operationID:    "repos/set-team-access-restrictions",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3719,157 +3720,157 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users",
 	httpMethod:     "PUT",
 	httpStatusCode: 200,
-	name:           "ReposSetUserAccessRestrictionsResponseBody",
+	name:           "octo.ReposSetUserAccessRestrictionsResponseBody",
 	operationID:    "repos/set-user-access-restrictions",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposTransferResponseBody{}
+		target := components.Repository{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/transfer",
 	httpMethod:     "POST",
 	httpStatusCode: 202,
-	name:           "ReposTransferResponseBody",
+	name:           "components.Repository",
 	operationID:    "repos/transfer",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposUpdateResponseBody{}
+		target := components.FullRepository{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "ReposUpdateResponseBody",
+	name:           "components.FullRepository",
 	operationID:    "repos/update",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposUpdateCommitCommentResponseBody{}
+		target := components.CommitComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/comments/{comment_id}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "ReposUpdateCommitCommentResponseBody",
+	name:           "components.CommitComment",
 	operationID:    "repos/update-commit-comment",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposUpdateInvitationResponseBody{}
+		target := components.RepositoryInvitation{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/invitations/{invitation_id}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "ReposUpdateInvitationResponseBody",
+	name:           "components.RepositoryInvitation",
 	operationID:    "repos/update-invitation",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposUpdatePullRequestReviewProtectionResponseBody{}
+		target := components.ProtectedBranchPullRequestReview{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "ReposUpdatePullRequestReviewProtectionResponseBody",
+	name:           "components.ProtectedBranchPullRequestReview",
 	operationID:    "repos/update-pull-request-review-protection",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposUpdateReleaseResponseBody{}
+		target := components.Release{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/releases/{release_id}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "ReposUpdateReleaseResponseBody",
+	name:           "components.Release",
 	operationID:    "repos/update-release",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposUpdateReleaseAssetResponseBody{}
+		target := components.ReleaseAsset{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/releases/assets/{asset_id}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "ReposUpdateReleaseAssetResponseBody",
+	name:           "components.ReleaseAsset",
 	operationID:    "repos/update-release-asset",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposUpdateStatusCheckProtectionResponseBody{}
+		target := components.StatusCheckPolicy{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "ReposUpdateStatusCheckProtectionResponseBody",
+	name:           "components.StatusCheckPolicy",
 	operationID:    "repos/update-status-check-protection",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposUpdateWebhookResponseBody{}
+		target := components.Hook{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/hooks/{hook_id}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "ReposUpdateWebhookResponseBody",
+	name:           "components.Hook",
 	operationID:    "repos/update-webhook",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ReposUploadReleaseAssetResponseBody{}
+		target := components.ReleaseAsset{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/repos/{owner}/{repo}/releases/{release_id}/assets",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ReposUploadReleaseAssetResponseBody",
+	name:           "components.ReleaseAsset",
 	operationID:    "repos/upload-release-asset",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ScimGetProvisioningInformationForUserResponseBody{}
+		target := components.ScimUser{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/scim/v2/organizations/{org}/Users/{scim_user_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ScimGetProvisioningInformationForUserResponseBody",
+	name:           "components.ScimUser",
 	operationID:    "scim/get-provisioning-information-for-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ScimListProvisionedIdentitiesResponseBody{}
+		target := components.ScimUserList{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/scim/v2/organizations/{org}/Users",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "ScimListProvisionedIdentitiesResponseBody",
+	name:           "components.ScimUserList",
 	operationID:    "scim/list-provisioned-identities",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ScimProvisionAndInviteUserResponseBody{}
+		target := components.ScimUser{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/scim/v2/organizations/{org}/Users",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "ScimProvisionAndInviteUserResponseBody",
+	name:           "components.ScimUser",
 	operationID:    "scim/provision-and-invite-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ScimSetInformationForProvisionedUserResponseBody{}
+		target := components.ScimUser{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/scim/v2/organizations/{org}/Users/{scim_user_id}",
 	httpMethod:     "PUT",
 	httpStatusCode: 200,
-	name:           "ScimSetInformationForProvisionedUserResponseBody",
+	name:           "components.ScimUser",
 	operationID:    "scim/set-information-for-provisioned-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.ScimUpdateAttributeForUserResponseBody{}
+		target := components.ScimUser{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/scim/v2/organizations/{org}/Users/{scim_user_id}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "ScimUpdateAttributeForUserResponseBody",
+	name:           "components.ScimUser",
 	operationID:    "scim/update-attribute-for-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3879,7 +3880,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/search/code",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "SearchCodeResponseBody",
+	name:           "octo.SearchCodeResponseBody",
 	operationID:    "search/code",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3889,7 +3890,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/search/commits",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "SearchCommitsResponseBody",
+	name:           "octo.SearchCommitsResponseBody",
 	operationID:    "search/commits",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3899,7 +3900,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/search/issues",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "SearchIssuesAndPullRequestsResponseBody",
+	name:           "octo.SearchIssuesAndPullRequestsResponseBody",
 	operationID:    "search/issues-and-pull-requests",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3909,7 +3910,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/search/labels",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "SearchLabelsResponseBody",
+	name:           "octo.SearchLabelsResponseBody",
 	operationID:    "search/labels",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3919,7 +3920,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/search/repositories",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "SearchReposResponseBody",
+	name:           "octo.SearchReposResponseBody",
 	operationID:    "search/repos",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3929,7 +3930,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/search/topics",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "SearchTopicsResponseBody",
+	name:           "octo.SearchTopicsResponseBody",
 	operationID:    "search/topics",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -3939,217 +3940,217 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/search/users",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "SearchUsersResponseBody",
+	name:           "octo.SearchUsersResponseBody",
 	operationID:    "search/users",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsAddOrUpdateMembershipForUserInOrgResponseBody{}
+		target := components.TeamMembership{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/memberships/{username}",
 	httpMethod:     "PUT",
 	httpStatusCode: 200,
-	name:           "TeamsAddOrUpdateMembershipForUserInOrgResponseBody",
+	name:           "components.TeamMembership",
 	operationID:    "teams/add-or-update-membership-for-user-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsAddOrUpdateMembershipForUserLegacyResponseBody{}
+		target := components.TeamMembership{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/teams/{team_id}/memberships/{username}",
 	httpMethod:     "PUT",
 	httpStatusCode: 200,
-	name:           "TeamsAddOrUpdateMembershipForUserLegacyResponseBody",
+	name:           "components.TeamMembership",
 	operationID:    "teams/add-or-update-membership-for-user-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsCheckPermissionsForProjectInOrgResponseBody{}
+		target := components.TeamProject{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/projects/{project_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsCheckPermissionsForProjectInOrgResponseBody",
+	name:           "components.TeamProject",
 	operationID:    "teams/check-permissions-for-project-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsCheckPermissionsForProjectLegacyResponseBody{}
+		target := components.TeamProject{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/teams/{team_id}/projects/{project_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsCheckPermissionsForProjectLegacyResponseBody",
+	name:           "components.TeamProject",
 	operationID:    "teams/check-permissions-for-project-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsCheckPermissionsForRepoInOrgResponseBody{}
+		target := components.TeamRepository{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsCheckPermissionsForRepoInOrgResponseBody",
+	name:           "components.TeamRepository",
 	operationID:    "teams/check-permissions-for-repo-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsCheckPermissionsForRepoLegacyResponseBody{}
+		target := components.TeamRepository{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/teams/{team_id}/repos/{owner}/{repo}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsCheckPermissionsForRepoLegacyResponseBody",
+	name:           "components.TeamRepository",
 	operationID:    "teams/check-permissions-for-repo-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsCreateResponseBody{}
+		target := components.TeamFull{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "TeamsCreateResponseBody",
+	name:           "components.TeamFull",
 	operationID:    "teams/create",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsCreateDiscussionCommentInOrgResponseBody{}
+		target := components.TeamDiscussionComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "TeamsCreateDiscussionCommentInOrgResponseBody",
+	name:           "components.TeamDiscussionComment",
 	operationID:    "teams/create-discussion-comment-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsCreateDiscussionCommentLegacyResponseBody{}
+		target := components.TeamDiscussionComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/teams/{team_id}/discussions/{discussion_number}/comments",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "TeamsCreateDiscussionCommentLegacyResponseBody",
+	name:           "components.TeamDiscussionComment",
 	operationID:    "teams/create-discussion-comment-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsCreateDiscussionInOrgResponseBody{}
+		target := components.TeamDiscussion{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/discussions",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "TeamsCreateDiscussionInOrgResponseBody",
+	name:           "components.TeamDiscussion",
 	operationID:    "teams/create-discussion-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsCreateDiscussionLegacyResponseBody{}
+		target := components.TeamDiscussion{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/teams/{team_id}/discussions",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "TeamsCreateDiscussionLegacyResponseBody",
+	name:           "components.TeamDiscussion",
 	operationID:    "teams/create-discussion-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsCreateOrUpdateIdpGroupConnectionsInOrgResponseBody{}
+		target := components.GroupMapping{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/team-sync/group-mappings",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "TeamsCreateOrUpdateIdpGroupConnectionsInOrgResponseBody",
+	name:           "components.GroupMapping",
 	operationID:    "teams/create-or-update-idp-group-connections-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsCreateOrUpdateIdpGroupConnectionsLegacyResponseBody{}
+		target := components.GroupMapping{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/teams/{team_id}/team-sync/group-mappings",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "TeamsCreateOrUpdateIdpGroupConnectionsLegacyResponseBody",
+	name:           "components.GroupMapping",
 	operationID:    "teams/create-or-update-idp-group-connections-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsGetByNameResponseBody{}
+		target := components.TeamFull{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams/{team_slug}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsGetByNameResponseBody",
+	name:           "components.TeamFull",
 	operationID:    "teams/get-by-name",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsGetDiscussionCommentInOrgResponseBody{}
+		target := components.TeamDiscussionComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsGetDiscussionCommentInOrgResponseBody",
+	name:           "components.TeamDiscussionComment",
 	operationID:    "teams/get-discussion-comment-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsGetDiscussionCommentLegacyResponseBody{}
+		target := components.TeamDiscussionComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsGetDiscussionCommentLegacyResponseBody",
+	name:           "components.TeamDiscussionComment",
 	operationID:    "teams/get-discussion-comment-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsGetDiscussionInOrgResponseBody{}
+		target := components.TeamDiscussion{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsGetDiscussionInOrgResponseBody",
+	name:           "components.TeamDiscussion",
 	operationID:    "teams/get-discussion-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsGetDiscussionLegacyResponseBody{}
+		target := components.TeamDiscussion{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/teams/{team_id}/discussions/{discussion_number}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsGetDiscussionLegacyResponseBody",
+	name:           "components.TeamDiscussion",
 	operationID:    "teams/get-discussion-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsGetLegacyResponseBody{}
+		target := components.TeamFull{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/teams/{team_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsGetLegacyResponseBody",
+	name:           "components.TeamFull",
 	operationID:    "teams/get-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsGetMembershipForUserInOrgResponseBody{}
+		target := components.TeamMembership{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/memberships/{username}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsGetMembershipForUserInOrgResponseBody",
+	name:           "components.TeamMembership",
 	operationID:    "teams/get-membership-for-user-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsGetMembershipForUserLegacyResponseBody{}
+		target := components.TeamMembership{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/teams/{team_id}/memberships/{username}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsGetMembershipForUserLegacyResponseBody",
+	name:           "components.TeamMembership",
 	operationID:    "teams/get-membership-for-user-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4159,7 +4160,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/teams",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsListResponseBody",
+	name:           "octo.TeamsListResponseBody",
 	operationID:    "teams/list",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4169,7 +4170,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/teams",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsListChildInOrgResponseBody",
+	name:           "octo.TeamsListChildInOrgResponseBody",
 	operationID:    "teams/list-child-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4179,7 +4180,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/teams/{team_id}/teams",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsListChildLegacyResponseBody",
+	name:           "octo.TeamsListChildLegacyResponseBody",
 	operationID:    "teams/list-child-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4189,7 +4190,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsListDiscussionCommentsInOrgResponseBody",
+	name:           "octo.TeamsListDiscussionCommentsInOrgResponseBody",
 	operationID:    "teams/list-discussion-comments-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4199,7 +4200,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/teams/{team_id}/discussions/{discussion_number}/comments",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsListDiscussionCommentsLegacyResponseBody",
+	name:           "octo.TeamsListDiscussionCommentsLegacyResponseBody",
 	operationID:    "teams/list-discussion-comments-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4209,7 +4210,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/discussions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsListDiscussionsInOrgResponseBody",
+	name:           "octo.TeamsListDiscussionsInOrgResponseBody",
 	operationID:    "teams/list-discussions-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4219,7 +4220,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/teams/{team_id}/discussions",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsListDiscussionsLegacyResponseBody",
+	name:           "octo.TeamsListDiscussionsLegacyResponseBody",
 	operationID:    "teams/list-discussions-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4229,37 +4230,37 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/user/teams",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsListForAuthenticatedUserResponseBody",
+	name:           "octo.TeamsListForAuthenticatedUserResponseBody",
 	operationID:    "teams/list-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsListIdpGroupsForLegacyResponseBody{}
+		target := components.GroupMapping{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/teams/{team_id}/team-sync/group-mappings",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsListIdpGroupsForLegacyResponseBody",
+	name:           "components.GroupMapping",
 	operationID:    "teams/list-idp-groups-for-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsListIdpGroupsForOrgResponseBody{}
+		target := components.GroupMapping{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/team-sync/groups",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsListIdpGroupsForOrgResponseBody",
+	name:           "components.GroupMapping",
 	operationID:    "teams/list-idp-groups-for-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsListIdpGroupsInOrgResponseBody{}
+		target := components.GroupMapping{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/team-sync/group-mappings",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsListIdpGroupsInOrgResponseBody",
+	name:           "components.GroupMapping",
 	operationID:    "teams/list-idp-groups-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4269,7 +4270,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/members",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsListMembersInOrgResponseBody",
+	name:           "octo.TeamsListMembersInOrgResponseBody",
 	operationID:    "teams/list-members-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4279,7 +4280,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/teams/{team_id}/members",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsListMembersLegacyResponseBody",
+	name:           "octo.TeamsListMembersLegacyResponseBody",
 	operationID:    "teams/list-members-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4289,7 +4290,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/invitations",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsListPendingInvitationsInOrgResponseBody",
+	name:           "octo.TeamsListPendingInvitationsInOrgResponseBody",
 	operationID:    "teams/list-pending-invitations-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4299,7 +4300,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/teams/{team_id}/invitations",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsListPendingInvitationsLegacyResponseBody",
+	name:           "octo.TeamsListPendingInvitationsLegacyResponseBody",
 	operationID:    "teams/list-pending-invitations-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4309,7 +4310,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/projects",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsListProjectsInOrgResponseBody",
+	name:           "octo.TeamsListProjectsInOrgResponseBody",
 	operationID:    "teams/list-projects-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4319,7 +4320,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/teams/{team_id}/projects",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsListProjectsLegacyResponseBody",
+	name:           "octo.TeamsListProjectsLegacyResponseBody",
 	operationID:    "teams/list-projects-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4329,7 +4330,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/repos",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsListReposInOrgResponseBody",
+	name:           "octo.TeamsListReposInOrgResponseBody",
 	operationID:    "teams/list-repos-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4339,67 +4340,67 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/teams/{team_id}/repos",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "TeamsListReposLegacyResponseBody",
+	name:           "octo.TeamsListReposLegacyResponseBody",
 	operationID:    "teams/list-repos-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsUpdateDiscussionCommentInOrgResponseBody{}
+		target := components.TeamDiscussionComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "TeamsUpdateDiscussionCommentInOrgResponseBody",
+	name:           "components.TeamDiscussionComment",
 	operationID:    "teams/update-discussion-comment-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsUpdateDiscussionCommentLegacyResponseBody{}
+		target := components.TeamDiscussionComment{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "TeamsUpdateDiscussionCommentLegacyResponseBody",
+	name:           "components.TeamDiscussionComment",
 	operationID:    "teams/update-discussion-comment-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsUpdateDiscussionInOrgResponseBody{}
+		target := components.TeamDiscussion{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "TeamsUpdateDiscussionInOrgResponseBody",
+	name:           "components.TeamDiscussion",
 	operationID:    "teams/update-discussion-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsUpdateDiscussionLegacyResponseBody{}
+		target := components.TeamDiscussion{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/teams/{team_id}/discussions/{discussion_number}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "TeamsUpdateDiscussionLegacyResponseBody",
+	name:           "components.TeamDiscussion",
 	operationID:    "teams/update-discussion-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsUpdateInOrgResponseBody{}
+		target := components.TeamFull{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/orgs/{org}/teams/{team_slug}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 201,
-	name:           "TeamsUpdateInOrgResponseBody",
+	name:           "components.TeamFull",
 	operationID:    "teams/update-in-org",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.TeamsUpdateLegacyResponseBody{}
+		target := components.TeamFull{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/teams/{team_id}",
 	httpMethod:     "PATCH",
 	httpStatusCode: 201,
-	name:           "TeamsUpdateLegacyResponseBody",
+	name:           "components.TeamFull",
 	operationID:    "teams/update-legacy",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4409,27 +4410,27 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/user/emails",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "UsersAddEmailForAuthenticatedResponseBody",
+	name:           "octo.UsersAddEmailForAuthenticatedResponseBody",
 	operationID:    "users/add-email-for-authenticated",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.UsersCreateGpgKeyForAuthenticatedResponseBody{}
+		target := components.GpgKey{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/gpg_keys",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "UsersCreateGpgKeyForAuthenticatedResponseBody",
+	name:           "components.GpgKey",
 	operationID:    "users/create-gpg-key-for-authenticated",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.UsersCreatePublicSshKeyForAuthenticatedResponseBody{}
+		target := components.Key{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/keys",
 	httpMethod:     "POST",
 	httpStatusCode: 201,
-	name:           "UsersCreatePublicSshKeyForAuthenticatedResponseBody",
+	name:           "components.Key",
 	operationID:    "users/create-public-ssh-key-for-authenticated",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4439,7 +4440,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/user",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "UsersGetAuthenticatedResponseBody",
+	name:           "octo.UsersGetAuthenticatedResponseBody",
 	operationID:    "users/get-authenticated",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4449,37 +4450,37 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/users/{username}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "UsersGetByUsernameResponseBody",
+	name:           "octo.UsersGetByUsernameResponseBody",
 	operationID:    "users/get-by-username",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.UsersGetContextForUserResponseBody{}
+		target := components.Hovercard{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/users/{username}/hovercard",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "UsersGetContextForUserResponseBody",
+	name:           "components.Hovercard",
 	operationID:    "users/get-context-for-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.UsersGetGpgKeyForAuthenticatedResponseBody{}
+		target := components.GpgKey{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/gpg_keys/{gpg_key_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "UsersGetGpgKeyForAuthenticatedResponseBody",
+	name:           "components.GpgKey",
 	operationID:    "users/get-gpg-key-for-authenticated",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.UsersGetPublicSshKeyForAuthenticatedResponseBody{}
+		target := components.Key{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user/keys/{key_id}",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "UsersGetPublicSshKeyForAuthenticatedResponseBody",
+	name:           "components.Key",
 	operationID:    "users/get-public-ssh-key-for-authenticated",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4489,7 +4490,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/users",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "UsersListResponseBody",
+	name:           "octo.UsersListResponseBody",
 	operationID:    "users/list",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4499,7 +4500,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/user/blocks",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "UsersListBlockedByAuthenticatedResponseBody",
+	name:           "octo.UsersListBlockedByAuthenticatedResponseBody",
 	operationID:    "users/list-blocked-by-authenticated",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4509,7 +4510,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/user/emails",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "UsersListEmailsForAuthenticatedResponseBody",
+	name:           "octo.UsersListEmailsForAuthenticatedResponseBody",
 	operationID:    "users/list-emails-for-authenticated",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4519,7 +4520,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/user/following",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "UsersListFollowedByAuthenticatedResponseBody",
+	name:           "octo.UsersListFollowedByAuthenticatedResponseBody",
 	operationID:    "users/list-followed-by-authenticated",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4529,7 +4530,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/user/followers",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "UsersListFollowersForAuthenticatedUserResponseBody",
+	name:           "octo.UsersListFollowersForAuthenticatedUserResponseBody",
 	operationID:    "users/list-followers-for-authenticated-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4539,7 +4540,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/users/{username}/followers",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "UsersListFollowersForUserResponseBody",
+	name:           "octo.UsersListFollowersForUserResponseBody",
 	operationID:    "users/list-followers-for-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4549,7 +4550,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/users/{username}/following",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "UsersListFollowingForUserResponseBody",
+	name:           "octo.UsersListFollowingForUserResponseBody",
 	operationID:    "users/list-following-for-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4559,7 +4560,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/user/gpg_keys",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "UsersListGpgKeysForAuthenticatedResponseBody",
+	name:           "octo.UsersListGpgKeysForAuthenticatedResponseBody",
 	operationID:    "users/list-gpg-keys-for-authenticated",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4569,7 +4570,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/users/{username}/gpg_keys",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "UsersListGpgKeysForUserResponseBody",
+	name:           "octo.UsersListGpgKeysForUserResponseBody",
 	operationID:    "users/list-gpg-keys-for-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4579,7 +4580,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/user/public_emails",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "UsersListPublicEmailsForAuthenticatedResponseBody",
+	name:           "octo.UsersListPublicEmailsForAuthenticatedResponseBody",
 	operationID:    "users/list-public-emails-for-authenticated",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4589,7 +4590,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/users/{username}/keys",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "UsersListPublicKeysForUserResponseBody",
+	name:           "octo.UsersListPublicKeysForUserResponseBody",
 	operationID:    "users/list-public-keys-for-user",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4599,7 +4600,7 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/user/keys",
 	httpMethod:     "GET",
 	httpStatusCode: 200,
-	name:           "UsersListPublicSshKeysForAuthenticatedResponseBody",
+	name:           "octo.UsersListPublicSshKeysForAuthenticatedResponseBody",
 	operationID:    "users/list-public-ssh-keys-for-authenticated",
 }, {
 	decode: func(decoder *json.Decoder) error {
@@ -4609,16 +4610,16 @@ var generatedUnmarshalResponseBodyTests = []unmarshalResponseBodyTest{{
 	endpointPath:   "/user/email/visibility",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "UsersSetPrimaryEmailVisibilityForAuthenticatedResponseBody",
+	name:           "octo.UsersSetPrimaryEmailVisibilityForAuthenticatedResponseBody",
 	operationID:    "users/set-primary-email-visibility-for-authenticated",
 }, {
 	decode: func(decoder *json.Decoder) error {
-		target := octo.UsersUpdateAuthenticatedResponseBody{}
+		target := components.PrivateUser{}
 		return decoder.Decode(&target)
 	},
 	endpointPath:   "/user",
 	httpMethod:     "PATCH",
 	httpStatusCode: 200,
-	name:           "UsersUpdateAuthenticatedResponseBody",
+	name:           "components.PrivateUser",
 	operationID:    "users/update-authenticated",
 }}

--- a/zz_users_gen.go
+++ b/zz_users_gen.go
@@ -659,7 +659,7 @@ func UsersCreateGpgKeyForAuthenticated(ctx context.Context, req *UsersCreateGpgK
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = UsersCreateGpgKeyForAuthenticatedResponseBody{}
+	resp.Data = components.GpgKey{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -762,13 +762,6 @@ type UsersCreateGpgKeyForAuthenticatedReqBody struct {
 }
 
 /*
-UsersCreateGpgKeyForAuthenticatedResponseBody is a response body for UsersCreateGpgKeyForAuthenticated
-
-https://developer.github.com/v3/users/gpg_keys/#create-a-gpg-key-for-the-authenticated-user
-*/
-type UsersCreateGpgKeyForAuthenticatedResponseBody components.GpgKey
-
-/*
 UsersCreateGpgKeyForAuthenticatedResponse is a response for UsersCreateGpgKeyForAuthenticated
 
 https://developer.github.com/v3/users/gpg_keys/#create-a-gpg-key-for-the-authenticated-user
@@ -776,7 +769,7 @@ https://developer.github.com/v3/users/gpg_keys/#create-a-gpg-key-for-the-authent
 type UsersCreateGpgKeyForAuthenticatedResponse struct {
 	response
 	request *UsersCreateGpgKeyForAuthenticatedReq
-	Data    UsersCreateGpgKeyForAuthenticatedResponseBody
+	Data    components.GpgKey
 }
 
 /*
@@ -800,7 +793,7 @@ func UsersCreatePublicSshKeyForAuthenticated(ctx context.Context, req *UsersCrea
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = UsersCreatePublicSshKeyForAuthenticatedResponseBody{}
+	resp.Data = components.Key{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -906,13 +899,6 @@ type UsersCreatePublicSshKeyForAuthenticatedReqBody struct {
 }
 
 /*
-UsersCreatePublicSshKeyForAuthenticatedResponseBody is a response body for UsersCreatePublicSshKeyForAuthenticated
-
-https://developer.github.com/v3/users/keys/#create-a-public-ssh-key-for-the-authenticated-user
-*/
-type UsersCreatePublicSshKeyForAuthenticatedResponseBody components.Key
-
-/*
 UsersCreatePublicSshKeyForAuthenticatedResponse is a response for UsersCreatePublicSshKeyForAuthenticated
 
 https://developer.github.com/v3/users/keys/#create-a-public-ssh-key-for-the-authenticated-user
@@ -920,7 +906,7 @@ https://developer.github.com/v3/users/keys/#create-a-public-ssh-key-for-the-auth
 type UsersCreatePublicSshKeyForAuthenticatedResponse struct {
 	response
 	request *UsersCreatePublicSshKeyForAuthenticatedReq
-	Data    UsersCreatePublicSshKeyForAuthenticatedResponseBody
+	Data    components.Key
 }
 
 /*
@@ -1796,7 +1782,7 @@ func UsersGetContextForUser(ctx context.Context, req *UsersGetContextForUserReq,
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = UsersGetContextForUserResponseBody{}
+	resp.Data = components.Hovercard{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -1904,13 +1890,6 @@ func (r *UsersGetContextForUserReq) Rel(link RelName, resp *UsersGetContextForUs
 }
 
 /*
-UsersGetContextForUserResponseBody is a response body for UsersGetContextForUser
-
-https://developer.github.com/v3/users/#get-contextual-information-for-a-user
-*/
-type UsersGetContextForUserResponseBody components.Hovercard
-
-/*
 UsersGetContextForUserResponse is a response for UsersGetContextForUser
 
 https://developer.github.com/v3/users/#get-contextual-information-for-a-user
@@ -1918,7 +1897,7 @@ https://developer.github.com/v3/users/#get-contextual-information-for-a-user
 type UsersGetContextForUserResponse struct {
 	response
 	request *UsersGetContextForUserReq
-	Data    UsersGetContextForUserResponseBody
+	Data    components.Hovercard
 }
 
 /*
@@ -1942,7 +1921,7 @@ func UsersGetGpgKeyForAuthenticated(ctx context.Context, req *UsersGetGpgKeyForA
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = UsersGetGpgKeyForAuthenticatedResponseBody{}
+	resp.Data = components.GpgKey{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2033,13 +2012,6 @@ func (r *UsersGetGpgKeyForAuthenticatedReq) Rel(link RelName, resp *UsersGetGpgK
 }
 
 /*
-UsersGetGpgKeyForAuthenticatedResponseBody is a response body for UsersGetGpgKeyForAuthenticated
-
-https://developer.github.com/v3/users/gpg_keys/#get-a-gpg-key-for-the-authenticated-user
-*/
-type UsersGetGpgKeyForAuthenticatedResponseBody components.GpgKey
-
-/*
 UsersGetGpgKeyForAuthenticatedResponse is a response for UsersGetGpgKeyForAuthenticated
 
 https://developer.github.com/v3/users/gpg_keys/#get-a-gpg-key-for-the-authenticated-user
@@ -2047,7 +2019,7 @@ https://developer.github.com/v3/users/gpg_keys/#get-a-gpg-key-for-the-authentica
 type UsersGetGpgKeyForAuthenticatedResponse struct {
 	response
 	request *UsersGetGpgKeyForAuthenticatedReq
-	Data    UsersGetGpgKeyForAuthenticatedResponseBody
+	Data    components.GpgKey
 }
 
 /*
@@ -2071,7 +2043,7 @@ func UsersGetPublicSshKeyForAuthenticated(ctx context.Context, req *UsersGetPubl
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = UsersGetPublicSshKeyForAuthenticatedResponseBody{}
+	resp.Data = components.Key{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2162,13 +2134,6 @@ func (r *UsersGetPublicSshKeyForAuthenticatedReq) Rel(link RelName, resp *UsersG
 }
 
 /*
-UsersGetPublicSshKeyForAuthenticatedResponseBody is a response body for UsersGetPublicSshKeyForAuthenticated
-
-https://developer.github.com/v3/users/keys/#get-a-public-ssh-key-for-the-authenticated-user
-*/
-type UsersGetPublicSshKeyForAuthenticatedResponseBody components.Key
-
-/*
 UsersGetPublicSshKeyForAuthenticatedResponse is a response for UsersGetPublicSshKeyForAuthenticated
 
 https://developer.github.com/v3/users/keys/#get-a-public-ssh-key-for-the-authenticated-user
@@ -2176,7 +2141,7 @@ https://developer.github.com/v3/users/keys/#get-a-public-ssh-key-for-the-authent
 type UsersGetPublicSshKeyForAuthenticatedResponse struct {
 	response
 	request *UsersGetPublicSshKeyForAuthenticatedReq
-	Data    UsersGetPublicSshKeyForAuthenticatedResponseBody
+	Data    components.Key
 }
 
 /*
@@ -4232,7 +4197,7 @@ func UsersUpdateAuthenticated(ctx context.Context, req *UsersUpdateAuthenticated
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = UsersUpdateAuthenticatedResponseBody{}
+	resp.Data = components.PrivateUser{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -4356,13 +4321,6 @@ type UsersUpdateAuthenticatedReqBody struct {
 }
 
 /*
-UsersUpdateAuthenticatedResponseBody is a response body for UsersUpdateAuthenticated
-
-https://developer.github.com/v3/users/#update-the-authenticated-user
-*/
-type UsersUpdateAuthenticatedResponseBody components.PrivateUser
-
-/*
 UsersUpdateAuthenticatedResponse is a response for UsersUpdateAuthenticated
 
 https://developer.github.com/v3/users/#update-the-authenticated-user
@@ -4370,5 +4328,5 @@ https://developer.github.com/v3/users/#update-the-authenticated-user
 type UsersUpdateAuthenticatedResponse struct {
 	response
 	request *UsersUpdateAuthenticatedReq
-	Data    UsersUpdateAuthenticatedResponseBody
+	Data    components.PrivateUser
 }

--- a/zz_users_gen.go
+++ b/zz_users_gen.go
@@ -33,7 +33,7 @@ func UsersAddEmailForAuthenticated(ctx context.Context, req *UsersAddEmailForAut
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = UsersAddEmailForAuthenticatedResponseBody{}
+	resp.Data = []components.Email{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -141,13 +141,6 @@ type UsersAddEmailForAuthenticatedReqBody struct {
 }
 
 /*
-UsersAddEmailForAuthenticatedResponseBody is a response body for UsersAddEmailForAuthenticated
-
-https://developer.github.com/v3/users/emails/#add-an-email-address-for-the-authenticated-user
-*/
-type UsersAddEmailForAuthenticatedResponseBody []components.Email
-
-/*
 UsersAddEmailForAuthenticatedResponse is a response for UsersAddEmailForAuthenticated
 
 https://developer.github.com/v3/users/emails/#add-an-email-address-for-the-authenticated-user
@@ -155,7 +148,7 @@ https://developer.github.com/v3/users/emails/#add-an-email-address-for-the-authe
 type UsersAddEmailForAuthenticatedResponse struct {
 	response
 	request *UsersAddEmailForAuthenticatedReq
-	Data    UsersAddEmailForAuthenticatedResponseBody
+	Data    []components.Email
 }
 
 /*
@@ -2165,7 +2158,7 @@ func UsersList(ctx context.Context, req *UsersListReq, opt ...RequestOption) (*U
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = UsersListResponseBody{}
+	resp.Data = []components.SimpleUser{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2269,13 +2262,6 @@ func (r *UsersListReq) Rel(link RelName, resp *UsersListResponse) bool {
 }
 
 /*
-UsersListResponseBody is a response body for UsersList
-
-https://developer.github.com/v3/users/#list-users
-*/
-type UsersListResponseBody []components.SimpleUser
-
-/*
 UsersListResponse is a response for UsersList
 
 https://developer.github.com/v3/users/#list-users
@@ -2283,7 +2269,7 @@ https://developer.github.com/v3/users/#list-users
 type UsersListResponse struct {
 	response
 	request *UsersListReq
-	Data    UsersListResponseBody
+	Data    []components.SimpleUser
 }
 
 /*
@@ -2307,7 +2293,7 @@ func UsersListBlockedByAuthenticated(ctx context.Context, req *UsersListBlockedB
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = UsersListBlockedByAuthenticatedResponseBody{}
+	resp.Data = []components.SimpleUser{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2395,13 +2381,6 @@ func (r *UsersListBlockedByAuthenticatedReq) Rel(link RelName, resp *UsersListBl
 }
 
 /*
-UsersListBlockedByAuthenticatedResponseBody is a response body for UsersListBlockedByAuthenticated
-
-https://developer.github.com/v3/users/blocking/#list-users-blocked-by-the-authenticated-user
-*/
-type UsersListBlockedByAuthenticatedResponseBody []components.SimpleUser
-
-/*
 UsersListBlockedByAuthenticatedResponse is a response for UsersListBlockedByAuthenticated
 
 https://developer.github.com/v3/users/blocking/#list-users-blocked-by-the-authenticated-user
@@ -2409,7 +2388,7 @@ https://developer.github.com/v3/users/blocking/#list-users-blocked-by-the-authen
 type UsersListBlockedByAuthenticatedResponse struct {
 	response
 	request *UsersListBlockedByAuthenticatedReq
-	Data    UsersListBlockedByAuthenticatedResponseBody
+	Data    []components.SimpleUser
 }
 
 /*
@@ -2433,7 +2412,7 @@ func UsersListEmailsForAuthenticated(ctx context.Context, req *UsersListEmailsFo
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = UsersListEmailsForAuthenticatedResponseBody{}
+	resp.Data = []components.Email{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2533,13 +2512,6 @@ func (r *UsersListEmailsForAuthenticatedReq) Rel(link RelName, resp *UsersListEm
 }
 
 /*
-UsersListEmailsForAuthenticatedResponseBody is a response body for UsersListEmailsForAuthenticated
-
-https://developer.github.com/v3/users/emails/#list-email-addresses-for-the-authenticated-user
-*/
-type UsersListEmailsForAuthenticatedResponseBody []components.Email
-
-/*
 UsersListEmailsForAuthenticatedResponse is a response for UsersListEmailsForAuthenticated
 
 https://developer.github.com/v3/users/emails/#list-email-addresses-for-the-authenticated-user
@@ -2547,7 +2519,7 @@ https://developer.github.com/v3/users/emails/#list-email-addresses-for-the-authe
 type UsersListEmailsForAuthenticatedResponse struct {
 	response
 	request *UsersListEmailsForAuthenticatedReq
-	Data    UsersListEmailsForAuthenticatedResponseBody
+	Data    []components.Email
 }
 
 /*
@@ -2571,7 +2543,7 @@ func UsersListFollowedByAuthenticated(ctx context.Context, req *UsersListFollowe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = UsersListFollowedByAuthenticatedResponseBody{}
+	resp.Data = []components.SimpleUser{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2671,13 +2643,6 @@ func (r *UsersListFollowedByAuthenticatedReq) Rel(link RelName, resp *UsersListF
 }
 
 /*
-UsersListFollowedByAuthenticatedResponseBody is a response body for UsersListFollowedByAuthenticated
-
-https://developer.github.com/v3/users/followers/#list-the-people-the-authenticated-user-follows
-*/
-type UsersListFollowedByAuthenticatedResponseBody []components.SimpleUser
-
-/*
 UsersListFollowedByAuthenticatedResponse is a response for UsersListFollowedByAuthenticated
 
 https://developer.github.com/v3/users/followers/#list-the-people-the-authenticated-user-follows
@@ -2685,7 +2650,7 @@ https://developer.github.com/v3/users/followers/#list-the-people-the-authenticat
 type UsersListFollowedByAuthenticatedResponse struct {
 	response
 	request *UsersListFollowedByAuthenticatedReq
-	Data    UsersListFollowedByAuthenticatedResponseBody
+	Data    []components.SimpleUser
 }
 
 /*
@@ -2709,7 +2674,7 @@ func UsersListFollowersForAuthenticatedUser(ctx context.Context, req *UsersListF
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = UsersListFollowersForAuthenticatedUserResponseBody{}
+	resp.Data = []components.SimpleUser{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2809,13 +2774,6 @@ func (r *UsersListFollowersForAuthenticatedUserReq) Rel(link RelName, resp *User
 }
 
 /*
-UsersListFollowersForAuthenticatedUserResponseBody is a response body for UsersListFollowersForAuthenticatedUser
-
-https://developer.github.com/v3/users/followers/#list-followers-of-the-authenticated-user
-*/
-type UsersListFollowersForAuthenticatedUserResponseBody []components.SimpleUser
-
-/*
 UsersListFollowersForAuthenticatedUserResponse is a response for UsersListFollowersForAuthenticatedUser
 
 https://developer.github.com/v3/users/followers/#list-followers-of-the-authenticated-user
@@ -2823,7 +2781,7 @@ https://developer.github.com/v3/users/followers/#list-followers-of-the-authentic
 type UsersListFollowersForAuthenticatedUserResponse struct {
 	response
 	request *UsersListFollowersForAuthenticatedUserReq
-	Data    UsersListFollowersForAuthenticatedUserResponseBody
+	Data    []components.SimpleUser
 }
 
 /*
@@ -2847,7 +2805,7 @@ func UsersListFollowersForUser(ctx context.Context, req *UsersListFollowersForUs
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = UsersListFollowersForUserResponseBody{}
+	resp.Data = []components.SimpleUser{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -2948,13 +2906,6 @@ func (r *UsersListFollowersForUserReq) Rel(link RelName, resp *UsersListFollower
 }
 
 /*
-UsersListFollowersForUserResponseBody is a response body for UsersListFollowersForUser
-
-https://developer.github.com/v3/users/followers/#list-followers-of-a-user
-*/
-type UsersListFollowersForUserResponseBody []components.SimpleUser
-
-/*
 UsersListFollowersForUserResponse is a response for UsersListFollowersForUser
 
 https://developer.github.com/v3/users/followers/#list-followers-of-a-user
@@ -2962,7 +2913,7 @@ https://developer.github.com/v3/users/followers/#list-followers-of-a-user
 type UsersListFollowersForUserResponse struct {
 	response
 	request *UsersListFollowersForUserReq
-	Data    UsersListFollowersForUserResponseBody
+	Data    []components.SimpleUser
 }
 
 /*
@@ -2986,7 +2937,7 @@ func UsersListFollowingForUser(ctx context.Context, req *UsersListFollowingForUs
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = UsersListFollowingForUserResponseBody{}
+	resp.Data = []components.SimpleUser{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3087,13 +3038,6 @@ func (r *UsersListFollowingForUserReq) Rel(link RelName, resp *UsersListFollowin
 }
 
 /*
-UsersListFollowingForUserResponseBody is a response body for UsersListFollowingForUser
-
-https://developer.github.com/v3/users/followers/#list-the-people-a-user-follows
-*/
-type UsersListFollowingForUserResponseBody []components.SimpleUser
-
-/*
 UsersListFollowingForUserResponse is a response for UsersListFollowingForUser
 
 https://developer.github.com/v3/users/followers/#list-the-people-a-user-follows
@@ -3101,7 +3045,7 @@ https://developer.github.com/v3/users/followers/#list-the-people-a-user-follows
 type UsersListFollowingForUserResponse struct {
 	response
 	request *UsersListFollowingForUserReq
-	Data    UsersListFollowingForUserResponseBody
+	Data    []components.SimpleUser
 }
 
 /*
@@ -3125,7 +3069,7 @@ func UsersListGpgKeysForAuthenticated(ctx context.Context, req *UsersListGpgKeys
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = UsersListGpgKeysForAuthenticatedResponseBody{}
+	resp.Data = []components.GpgKey{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3225,13 +3169,6 @@ func (r *UsersListGpgKeysForAuthenticatedReq) Rel(link RelName, resp *UsersListG
 }
 
 /*
-UsersListGpgKeysForAuthenticatedResponseBody is a response body for UsersListGpgKeysForAuthenticated
-
-https://developer.github.com/v3/users/gpg_keys/#list-gpg-keys-for-the-authenticated-user
-*/
-type UsersListGpgKeysForAuthenticatedResponseBody []components.GpgKey
-
-/*
 UsersListGpgKeysForAuthenticatedResponse is a response for UsersListGpgKeysForAuthenticated
 
 https://developer.github.com/v3/users/gpg_keys/#list-gpg-keys-for-the-authenticated-user
@@ -3239,7 +3176,7 @@ https://developer.github.com/v3/users/gpg_keys/#list-gpg-keys-for-the-authentica
 type UsersListGpgKeysForAuthenticatedResponse struct {
 	response
 	request *UsersListGpgKeysForAuthenticatedReq
-	Data    UsersListGpgKeysForAuthenticatedResponseBody
+	Data    []components.GpgKey
 }
 
 /*
@@ -3263,7 +3200,7 @@ func UsersListGpgKeysForUser(ctx context.Context, req *UsersListGpgKeysForUserRe
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = UsersListGpgKeysForUserResponseBody{}
+	resp.Data = []components.GpgKey{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3364,13 +3301,6 @@ func (r *UsersListGpgKeysForUserReq) Rel(link RelName, resp *UsersListGpgKeysFor
 }
 
 /*
-UsersListGpgKeysForUserResponseBody is a response body for UsersListGpgKeysForUser
-
-https://developer.github.com/v3/users/gpg_keys/#list-gpg-keys-for-a-user
-*/
-type UsersListGpgKeysForUserResponseBody []components.GpgKey
-
-/*
 UsersListGpgKeysForUserResponse is a response for UsersListGpgKeysForUser
 
 https://developer.github.com/v3/users/gpg_keys/#list-gpg-keys-for-a-user
@@ -3378,7 +3308,7 @@ https://developer.github.com/v3/users/gpg_keys/#list-gpg-keys-for-a-user
 type UsersListGpgKeysForUserResponse struct {
 	response
 	request *UsersListGpgKeysForUserReq
-	Data    UsersListGpgKeysForUserResponseBody
+	Data    []components.GpgKey
 }
 
 /*
@@ -3402,7 +3332,7 @@ func UsersListPublicEmailsForAuthenticated(ctx context.Context, req *UsersListPu
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = UsersListPublicEmailsForAuthenticatedResponseBody{}
+	resp.Data = []components.Email{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3502,13 +3432,6 @@ func (r *UsersListPublicEmailsForAuthenticatedReq) Rel(link RelName, resp *Users
 }
 
 /*
-UsersListPublicEmailsForAuthenticatedResponseBody is a response body for UsersListPublicEmailsForAuthenticated
-
-https://developer.github.com/v3/users/emails/#list-public-email-addresses-for-the-authenticated-user
-*/
-type UsersListPublicEmailsForAuthenticatedResponseBody []components.Email
-
-/*
 UsersListPublicEmailsForAuthenticatedResponse is a response for UsersListPublicEmailsForAuthenticated
 
 https://developer.github.com/v3/users/emails/#list-public-email-addresses-for-the-authenticated-user
@@ -3516,7 +3439,7 @@ https://developer.github.com/v3/users/emails/#list-public-email-addresses-for-th
 type UsersListPublicEmailsForAuthenticatedResponse struct {
 	response
 	request *UsersListPublicEmailsForAuthenticatedReq
-	Data    UsersListPublicEmailsForAuthenticatedResponseBody
+	Data    []components.Email
 }
 
 /*
@@ -3540,7 +3463,7 @@ func UsersListPublicKeysForUser(ctx context.Context, req *UsersListPublicKeysFor
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = UsersListPublicKeysForUserResponseBody{}
+	resp.Data = []components.KeySimple{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3641,13 +3564,6 @@ func (r *UsersListPublicKeysForUserReq) Rel(link RelName, resp *UsersListPublicK
 }
 
 /*
-UsersListPublicKeysForUserResponseBody is a response body for UsersListPublicKeysForUser
-
-https://developer.github.com/v3/users/keys/#list-public-keys-for-a-user
-*/
-type UsersListPublicKeysForUserResponseBody []components.KeySimple
-
-/*
 UsersListPublicKeysForUserResponse is a response for UsersListPublicKeysForUser
 
 https://developer.github.com/v3/users/keys/#list-public-keys-for-a-user
@@ -3655,7 +3571,7 @@ https://developer.github.com/v3/users/keys/#list-public-keys-for-a-user
 type UsersListPublicKeysForUserResponse struct {
 	response
 	request *UsersListPublicKeysForUserReq
-	Data    UsersListPublicKeysForUserResponseBody
+	Data    []components.KeySimple
 }
 
 /*
@@ -3679,7 +3595,7 @@ func UsersListPublicSshKeysForAuthenticated(ctx context.Context, req *UsersListP
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = UsersListPublicSshKeysForAuthenticatedResponseBody{}
+	resp.Data = []components.Key{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3779,13 +3695,6 @@ func (r *UsersListPublicSshKeysForAuthenticatedReq) Rel(link RelName, resp *User
 }
 
 /*
-UsersListPublicSshKeysForAuthenticatedResponseBody is a response body for UsersListPublicSshKeysForAuthenticated
-
-https://developer.github.com/v3/users/keys/#list-public-ssh-keys-for-the-authenticated-user
-*/
-type UsersListPublicSshKeysForAuthenticatedResponseBody []components.Key
-
-/*
 UsersListPublicSshKeysForAuthenticatedResponse is a response for UsersListPublicSshKeysForAuthenticated
 
 https://developer.github.com/v3/users/keys/#list-public-ssh-keys-for-the-authenticated-user
@@ -3793,7 +3702,7 @@ https://developer.github.com/v3/users/keys/#list-public-ssh-keys-for-the-authent
 type UsersListPublicSshKeysForAuthenticatedResponse struct {
 	response
 	request *UsersListPublicSshKeysForAuthenticatedReq
-	Data    UsersListPublicSshKeysForAuthenticatedResponseBody
+	Data    []components.Key
 }
 
 /*
@@ -3817,7 +3726,7 @@ func UsersSetPrimaryEmailVisibilityForAuthenticated(ctx context.Context, req *Us
 	if err != nil {
 		return resp, err
 	}
-	resp.Data = UsersSetPrimaryEmailVisibilityForAuthenticatedResponseBody{}
+	resp.Data = []components.Email{}
 	err = r.decodeBody(&resp.Data)
 	if err != nil {
 		return nil, err
@@ -3923,13 +3832,6 @@ type UsersSetPrimaryEmailVisibilityForAuthenticatedReqBody struct {
 }
 
 /*
-UsersSetPrimaryEmailVisibilityForAuthenticatedResponseBody is a response body for UsersSetPrimaryEmailVisibilityForAuthenticated
-
-https://developer.github.com/v3/users/emails/#set-primary-email-visibility-for-the-authenticated-user
-*/
-type UsersSetPrimaryEmailVisibilityForAuthenticatedResponseBody []components.Email
-
-/*
 UsersSetPrimaryEmailVisibilityForAuthenticatedResponse is a response for UsersSetPrimaryEmailVisibilityForAuthenticated
 
 https://developer.github.com/v3/users/emails/#set-primary-email-visibility-for-the-authenticated-user
@@ -3937,7 +3839,7 @@ https://developer.github.com/v3/users/emails/#set-primary-email-visibility-for-t
 type UsersSetPrimaryEmailVisibilityForAuthenticatedResponse struct {
 	response
 	request *UsersSetPrimaryEmailVisibilityForAuthenticatedReq
-	Data    UsersSetPrimaryEmailVisibilityForAuthenticatedResponseBody
+	Data    []components.Email
 }
 
 /*


### PR DESCRIPTION
Don't build a response body struct when it simply points to a component.  Use the component instead.
