### PR TITLE
update from tags as well as releases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/willabides/octo-go
 go 1.14
 
 require (
+	github.com/Masterminds/semver/v3 v3.1.0
 	github.com/dave/jennifer v1.4.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dnaeon/go-vcr v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver/v3 v3.1.0 h1:Y2lUDsFKVRSYGojLJ1yLxSXdMmMYTYls0rCvoqmMUQk=
+github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/dave/jennifer v1.4.0 h1:tNJFJmLDVTLu+v05mVZ88RINa3vQqnyyWkTKWYz0CwE=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/tools/update-schema/update_test.go
+++ b/tools/update-schema/update_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_higherValidSemver(t *testing.T) {
+	got, err := higherValidSemver("v0.1.0", "v0.2.0")
+	assert.NoError(t, err)
+	assert.Equal(t, "v0.2.0", got)
+	got, err = higherValidSemver("v0.2.0", "v0.2.0")
+	assert.NoError(t, err)
+	assert.Equal(t, "v0.2.0", got)
+	got, err = higherValidSemver("v0.2.0", "v0.1.0")
+	assert.NoError(t, err)
+	assert.Equal(t, "v0.2.0", got)
+	got, err = higherValidSemver("v0.2.0", "hi")
+	assert.NoError(t, err)
+	assert.Equal(t, "v0.2.0", got)
+	got, err = higherValidSemver("hi", "v0.2.0")
+	assert.NoError(t, err)
+	assert.Equal(t, "v0.2.0", got)
+	got, err = higherValidSemver("hi", "hi")
+	assert.Error(t, err)
+	assert.Equal(t, "", got)
+}


### PR DESCRIPTION
v0.0.5 of `github/rest-api-description` doesn't have a release, so no PR was made here for it.

This causes a PR to be created for a tag with a newer semver than the lastest release.